### PR TITLE
fix: unblock billing without Inferno IDs and honor sync queue secret contract

### DIFF
--- a/supabase/functions/_shared/paddlePriceIds.ts
+++ b/supabase/functions/_shared/paddlePriceIds.ts
@@ -72,10 +72,14 @@ export function mapPriceIdToTier(
   return "FREE";
 }
 
-/** True if all three tier list env vars are non-empty (after trim). */
+/**
+ * True when at least one purchasable paid tier is configured.
+ * Inferno is optional in some environments, so billing should not hard-fail
+ * when only Ember/Flame IDs are present.
+ */
 export function paddlePriceIdsConfigured(env: {
   get(key: string): string | undefined;
 }): boolean {
   const { ember, flame, inferno } = getPaddlePriceIdSets(env);
-  return ember.size > 0 && flame.size > 0 && inferno.size > 0;
+  return ember.size + flame.size + inferno.size > 0;
 }

--- a/supabase/functions/process-sync-queue/index.ts
+++ b/supabase/functions/process-sync-queue/index.ts
@@ -39,9 +39,13 @@ function isServiceRoleRequest(req: Request): boolean {
 }
 
 function hasValidCronSecret(req: Request): boolean {
+  const readSecret = (key: string): string | undefined => {
+    const value = Deno.env.get(key)?.trim();
+    return value ? value : undefined;
+  };
   const expectedSecret =
-    Deno.env.get('CRON_SYNC_QUEUE_SECRET') ??
-    Deno.env.get('PROCESS_SYNC_QUEUE_SECRET');
+    readSecret('PROCESS_SYNC_QUEUE_SECRET') ??
+    readSecret('CRON_SYNC_QUEUE_SECRET');
   if (!expectedSecret) return false;
   const provided = req.headers.get('x-cron-secret') ?? '';
   return timingSafeEqualString(expectedSecret, provided);


### PR DESCRIPTION
### Motivation
- The billing config gate treated billing as misconfigured unless all three tier price ID sets (including Inferno) were present, which caused webhooks and subscription updates to hard-fail in Ember/Flame-only environments.
- The scheduled sync processor read `CRON_SYNC_QUEUE_SECRET` before `PROCESS_SYNC_QUEUE_SECRET`, which contradicts the documented env contract and caused rejected requests when only `PROCESS_SYNC_QUEUE_SECRET` was set.

### Description
- Changed `paddlePriceIdsConfigured` in `supabase/functions/_shared/paddlePriceIds.ts` to return true when any paid-tier price ID exists by checking `ember.size + flame.size + inferno.size > 0`, and updated the comment to reflect that Inferno is optional.
- Updated `hasValidCronSecret` in `supabase/functions/process-sync-queue/index.ts` to prefer `PROCESS_SYNC_QUEUE_SECRET` with a fallback to `CRON_SYNC_QUEUE_SECRET`, and added a `readSecret` helper that trims values and treats empty strings as unset to avoid accidental suppression of the fallback.
- These changes maintain backward compatibility while unblocking legitimate production configurations that omit Inferno IDs and honoring the repository's documented env contract.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.
- No other automated tests were run as part of this follow-up; the changes are limited, type-safe, and targeted at auth/config guards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5305fab88832283603d993dcde4d0)