### PR TITLE
feat(portal): expose updatedAt on session pull (Phase 3.3 LWW)

### DIFF
--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -564,6 +564,11 @@ Deno.serve(async (req) => {
           workoutMode: ws.workout_mode,
           routineSessionId: ws.routine_session_id,
           notes: ws.notes ?? null,
+          // Phase 3.3 (audit item #1): server-canonical updatedAt for the
+          // mobile-side LWW pull merge gate. Mobile parses this via
+          // kotlin.time.Instant in PortalPullAdapter and feeds it to
+          // SyncRepository.mergeSessionsLww as the per-session timestamp.
+          updatedAt: ws.updated_at ?? null,
           avgVelocityMps: ws.avg_velocity_mps,
           avgAsymmetryPct: ws.avg_asymmetry_pct,
           velocityLossPct: ws.velocity_loss_pct,


### PR DESCRIPTION
## Summary

One-line addition to \`mobile-sync-pull/index.ts\` session DTO projection: \`updatedAt: ws.updated_at ?? null\`. Required by the mobile companion PR for the LWW pull merge gate.

## Companion PR

\`9thLevelSoftware/Project-Phoenix-MP\` branch \`cursor/dto-drift-phase-3-3\` adds:
- \`PullWorkoutSessionDto.updatedAt\` (nullable for backward compat)
- SQLDelight \`selectSessionUpdatedAt\` + \`mergeSessionLww\` queries
- \`SyncRepository.mergeSessionsLww\` method
- \`SyncManager\` LWW path in \`runPullPage\`

Mobile falls back to legacy INSERT OR IGNORE when \`updatedAt\` is null, so deploying server-side first is safe.

## Test plan
- [x] \`npm run typecheck\` passes
- [x] No behavior change when client doesn't read the field
- [ ] CI green
- [ ] Smoke pull → confirm \`updatedAt\` present in DTO

🤖 Generated with [Claude Code](https://claude.com/claude-code)