### PR TITLE
fix(ui): restore visible text on active underline tab

### DIFF
--- a/src/app/components/ui/tabs.tsx
+++ b/src/app/components/ui/tabs.tsx
@@ -63,7 +63,14 @@ const tabsTriggerVariants = cva(
 				default:
 					"flex-1 h-[calc(100%-1px)] rounded-md border border-transparent px-2 py-1 text-secondary-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground",
 				underline:
-					"flex-1 rounded-none border-b-2 border-transparent px-4 py-3 text-secondary-foreground data-[state=active]:border-primary data-[state=active]:text-white",
+					// Active state: use `text-foreground` (theme's light-on-dark
+					// token, #e0e0e8) rather than `text-white` which in this
+					// codebase was rendering invisible on the dark background
+					// — the Leaderboard tab group was reported with black-on-black
+					// selected text. `font-semibold` on active gives an extra
+					// visual cue so the tab reads as selected even for users who
+					// can't see the thin orange underline.
+					"flex-1 rounded-none border-b-2 border-transparent px-4 py-3 text-muted-foreground data-[state=active]:border-primary data-[state=active]:text-foreground data-[state=active]:font-semibold",
 			},
 		},
 		defaultVariants: {


### PR DESCRIPTION
## Summary

Leaderboard tab group rendered black-on-black when the first tab was selected — only the orange underline bar visible. Fix in \`src/app/components/ui/tabs.tsx\` underline variant.

### Before
- Active: \`text-white\` (Tailwind literal, rendered invisible on this codebase's dark theme — likely Tailwind v4 / purge interaction)
- Inactive: \`text-secondary-foreground\` = same \`#e0e0e8\` as theme foreground → active and inactive indistinguishable except for the 2px underline

### After
- Active: \`text-foreground\` (theme \`#e0e0e8\`, guaranteed visible)
- Active: \`font-semibold\` for second visual cue
- Inactive: \`text-muted-foreground\` (\`#a0a0ac\`) so inactive is clearly dimmer

### Affected call sites
- \`Leaderboard.tsx\` (reported)
- \`Community.tsx\`
- \`Challenges.tsx\`

## Test plan
- [x] \`npm run typecheck\` passes
- [x] \`npx biome check src/app/components/ui/tabs.tsx\` clean
- [ ] Visual: Leaderboard All-Time / Weekly Challenge / My Rankings tabs — selected tab text clearly visible, inactive tabs dimmer, underline on selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)