### PR TITLE
fix(auth): guide users out of in-app browsers before Google OAuth

### DIFF
--- a/src/app/components/LandingPage.tsx
+++ b/src/app/components/LandingPage.tsx
@@ -32,15 +32,21 @@ import {
 	TabsTrigger,
 } from "@/app/components/ui/tabs";
 import { useAuth } from "@/app/hooks/useAuth";
+import {
+	buildAndroidChromeIntentUrl,
+	detectInAppBrowser,
+	getInAppBrowserLabel,
+	type InAppBrowserDetection,
+} from "@/lib/in-app-browser";
 import { TIER_PRICING } from "@/lib/pricing";
 import {
 	buildSocialAuthRedirectUrl,
 	DEFAULT_SOCIAL_AUTH_AVAILABILITY,
-	getSocialAuthAvailability,
 	GOOGLE_OAUTH_SCOPES,
-	supabase,
+	getSocialAuthAvailability,
 	type SocialAuthAvailability,
 	type SocialAuthProvider,
+	supabase,
 } from "@/lib/supabase";
 import { ForceCurveDemo } from "./landing/ForceCurveDemo";
 import { ProductShowcase } from "./landing/ProductShowcase";
@@ -86,6 +92,11 @@ export function LandingPage() {
 	const [scrolled, setScrolled] = useState(false);
 	const [socialAuthAvailability, setSocialAuthAvailability] =
 		useState<SocialAuthAvailability>(DEFAULT_SOCIAL_AUTH_AVAILABILITY);
+	const [inAppBrowser, setInAppBrowser] = useState<InAppBrowserDetection>({
+		isInAppBrowser: false,
+		browser: null,
+		platform: "other",
+	});
 
 	const hasSocialAuthOptions =
 		socialAuthAvailability.google || socialAuthAvailability.apple;
@@ -114,6 +125,10 @@ export function LandingPage() {
 		const handleScroll = () => setScrolled(window.scrollY > 20);
 		window.addEventListener("scroll", handleScroll, { passive: true });
 		return () => window.removeEventListener("scroll", handleScroll);
+	}, []);
+
+	useEffect(() => {
+		setInAppBrowser(detectInAppBrowser());
 	}, []);
 
 	useEffect(() => {
@@ -227,6 +242,17 @@ export function LandingPage() {
 			return;
 		}
 
+		if (inAppBrowser.isInAppBrowser) {
+			const providerLabel = provider === "apple" ? "Apple" : "Google";
+			const hostLabel = inAppBrowser.browser
+				? getInAppBrowserLabel(inAppBrowser.browser)
+				: "this app";
+			const msg = `${providerLabel} blocks sign-in from ${hostLabel}'s in-app browser. Open phoenix-portal.com in your device browser (Chrome/Safari) and try again.`;
+			setAuthAlertMessage(msg);
+			toast.error(msg);
+			return;
+		}
+
 		setAuthLoading(true);
 		setAuthAlertMessage(null);
 		try {
@@ -234,9 +260,7 @@ export function LandingPage() {
 				provider,
 				options: {
 					redirectTo: buildSocialAuthRedirectUrl(provider),
-					...(provider === "google"
-						? { scopes: GOOGLE_OAUTH_SCOPES }
-						: {}),
+					...(provider === "google" ? { scopes: GOOGLE_OAUTH_SCOPES } : {}),
 				},
 			});
 			if (error) {
@@ -572,6 +596,35 @@ export function LandingPage() {
 										</span>
 									</div>
 								</div>
+
+								{inAppBrowser.isInAppBrowser ? (
+									<div
+										role="alert"
+										className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-200"
+									>
+										<p className="font-medium">
+											Google and Apple block sign-in from in-app browsers.
+										</p>
+										<p className="mt-1 text-amber-200/90">
+											{inAppBrowser.platform === "ios"
+												? "Tap the ••• menu above and choose \u201COpen in Safari\u201D, then try again. Or use email and password below."
+												: inAppBrowser.platform === "android"
+													? "Tap the ••• menu above and choose \u201COpen in browser\u201D, then try again."
+													: "Open phoenix-portal.com in Chrome or Safari, then try again."}
+										</p>
+										{inAppBrowser.platform === "android" ? (
+											<a
+												href={
+													buildAndroidChromeIntentUrl() ??
+													"https://phoenix-portal.com"
+												}
+												className="mt-2 inline-flex items-center text-amber-100 underline underline-offset-2 hover:text-white"
+											>
+												Open in Chrome
+											</a>
+										) : null}
+									</div>
+								) : null}
 
 								{/* OAuth buttons — brand-compliant per Google/Apple guidelines */}
 								<div className="flex flex-col gap-3">

--- a/src/app/components/__tests__/LandingPage.test.tsx
+++ b/src/app/components/__tests__/LandingPage.test.tsx
@@ -19,9 +19,8 @@ vi.mock("@/providers/AuthProvider", () => mockAuth);
 const mockSignInWithOAuth = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/supabase", async () => {
-	const actual = await vi.importActual<typeof import("@/lib/supabase")>(
-		"@/lib/supabase",
-	);
+	const actual =
+		await vi.importActual<typeof import("@/lib/supabase")>("@/lib/supabase");
 
 	return {
 		...actual,
@@ -168,7 +167,9 @@ describe("LandingPage", () => {
 		await renderLandingPage({ apple: false, google: true });
 
 		await user.click(screen.getByRole("button", { name: /^sign in$/i }));
-		await user.click(screen.getByRole("button", { name: /sign in with google/i }));
+		await user.click(
+			screen.getByRole("button", { name: /sign in with google/i }),
+		);
 
 		expect(mockSignInWithOAuth).toHaveBeenCalledWith({
 			provider: "google",
@@ -184,7 +185,9 @@ describe("LandingPage", () => {
 		await renderLandingPage({ apple: true, google: false });
 
 		await user.click(screen.getByRole("button", { name: /^sign in$/i }));
-		await user.click(screen.getByRole("button", { name: /sign in with apple/i }));
+		await user.click(
+			screen.getByRole("button", { name: /sign in with apple/i }),
+		);
 
 		expect(mockSignInWithOAuth).toHaveBeenCalledWith({
 			provider: "apple",
@@ -192,5 +195,41 @@ describe("LandingPage", () => {
 				redirectTo: `${window.location.origin}/auth/callback?provider=apple`,
 			},
 		});
+	});
+
+	it("blocks Google OAuth and shows guidance when opened in an in-app browser", async () => {
+		const REDDIT_UA =
+			"Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 Reddit/Version 2024.40.1/Build 1";
+		const originalUA = Object.getOwnPropertyDescriptor(
+			window.navigator,
+			"userAgent",
+		);
+		Object.defineProperty(window.navigator, "userAgent", {
+			value: REDDIT_UA,
+			configurable: true,
+		});
+
+		try {
+			const user = userEvent.setup();
+			await renderLandingPage({ apple: false, google: true });
+
+			await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+			expect(
+				await screen.findByText(/block sign-in from in-app browsers/i),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("link", { name: /open in chrome/i }),
+			).toBeInTheDocument();
+
+			await user.click(
+				screen.getByRole("button", { name: /sign in with google/i }),
+			);
+			expect(mockSignInWithOAuth).not.toHaveBeenCalled();
+		} finally {
+			if (originalUA) {
+				Object.defineProperty(window.navigator, "userAgent", originalUA);
+			}
+		}
 	});
 });

--- a/src/lib/__tests__/in-app-browser.test.ts
+++ b/src/lib/__tests__/in-app-browser.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAndroidChromeIntentUrl,
+	detectInAppBrowser,
+} from "../in-app-browser";
+
+describe("detectInAppBrowser", () => {
+	it.each([
+		[
+			"Reddit Android",
+			"Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 Reddit/Version 2024.40.1/Build 1",
+			"reddit",
+			"android",
+		],
+		[
+			"Reddit iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 Reddit/2024.40.0",
+			"reddit",
+			"ios",
+		],
+		[
+			"Instagram iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 Instagram 300.0.0.0.0 (iPhone14,2; iOS 17_2; en_US)",
+			"instagram",
+			"ios",
+		],
+		[
+			"Facebook Android",
+			"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/440.0.0.0;]",
+			"facebook",
+			"android",
+		],
+		[
+			"Messenger iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 [FBAN/MessengerForiOS;FBAV/440.0.0;FBBV/1;FB_IAB/MESSENGER;]",
+			"messenger",
+			"ios",
+		],
+		[
+			"TikTok Android",
+			"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36 BytedanceWebview/d8a21c6",
+			"tiktok",
+			"android",
+		],
+		[
+			"Twitter/X Android",
+			"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36 TwitterAndroid",
+			"twitter",
+			"android",
+		],
+		[
+			"LinkedIn iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 LinkedInApp/9.30.1",
+			"linkedin",
+			"ios",
+		],
+		[
+			"WeChat Android",
+			"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 MicroMessenger/8.0.42",
+			"wechat",
+			"android",
+		],
+		[
+			"Google App iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 GSA/300.0.553234547",
+			"google-app",
+			"ios",
+		],
+		[
+			"Generic Android WebView",
+			"Mozilla/5.0 (Linux; Android 13; Pixel 7; wv) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36",
+			"webview",
+			"android",
+		],
+	])("detects %s as in-app browser", (_label, ua, expectedBrowser, expectedPlatform) => {
+		const result = detectInAppBrowser(ua);
+		expect(result.isInAppBrowser).toBe(true);
+		expect(result.browser).toBe(expectedBrowser);
+		expect(result.platform).toBe(expectedPlatform);
+	});
+
+	it.each([
+		[
+			"Chrome Android",
+			"Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+			"android",
+		],
+		[
+			"Safari iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1",
+			"ios",
+		],
+		[
+			"Chrome iOS",
+			"Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1",
+			"ios",
+		],
+		[
+			"Firefox desktop",
+			"Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0",
+			"other",
+		],
+		[
+			"Edge desktop",
+			"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+			"other",
+		],
+	])("treats %s as a real browser", (_label, ua, expectedPlatform) => {
+		const result = detectInAppBrowser(ua);
+		expect(result.isInAppBrowser).toBe(false);
+		expect(result.browser).toBeNull();
+		expect(result.platform).toBe(expectedPlatform);
+	});
+});
+
+describe("buildAndroidChromeIntentUrl", () => {
+	it("builds an intent URL that targets Chrome for an https URL", () => {
+		const result = buildAndroidChromeIntentUrl(
+			"https://phoenix-portal.com/dashboard?ref=reddit#top",
+		);
+		expect(result).toBe(
+			"intent://phoenix-portal.com/dashboard?ref=reddit#top#Intent;scheme=https;package=com.android.chrome;end",
+		);
+	});
+
+	it("returns null for unsupported schemes", () => {
+		expect(buildAndroidChromeIntentUrl("javascript:alert(1)")).toBeNull();
+		expect(buildAndroidChromeIntentUrl("")).toBeNull();
+	});
+
+	it("returns null for malformed URLs", () => {
+		expect(buildAndroidChromeIntentUrl("not a url")).toBeNull();
+	});
+});

--- a/src/lib/in-app-browser.ts
+++ b/src/lib/in-app-browser.ts
@@ -1,0 +1,110 @@
+export type InAppBrowser =
+	| "reddit"
+	| "instagram"
+	| "facebook"
+	| "messenger"
+	| "tiktok"
+	| "twitter"
+	| "linkedin"
+	| "snapchat"
+	| "pinterest"
+	| "line"
+	| "wechat"
+	| "discord"
+	| "slack"
+	| "google-app"
+	| "webview";
+
+export type DevicePlatform = "ios" | "android" | "other";
+
+export interface InAppBrowserDetection {
+	isInAppBrowser: boolean;
+	browser: InAppBrowser | null;
+	platform: DevicePlatform;
+}
+
+const PATTERNS: ReadonlyArray<{ regex: RegExp; name: InAppBrowser }> = [
+	{ regex: /\bInstagram\b/i, name: "instagram" },
+	{ regex: /\bMessenger\b|FB_IAB.*MESSENGER/i, name: "messenger" },
+	{ regex: /FBAN|FBAV|FB_IAB/i, name: "facebook" },
+	{ regex: /Reddit/i, name: "reddit" },
+	{ regex: /TikTok|musical_ly|Bytedance/i, name: "tiktok" },
+	{ regex: /Twitter|TwitterAndroid/i, name: "twitter" },
+	{ regex: /LinkedInApp/i, name: "linkedin" },
+	{ regex: /Snapchat/i, name: "snapchat" },
+	{ regex: /Pinterest/i, name: "pinterest" },
+	{ regex: /\bLine\//i, name: "line" },
+	{ regex: /MicroMessenger/i, name: "wechat" },
+	{ regex: /Discord/i, name: "discord" },
+	{ regex: /\bSlack\b/i, name: "slack" },
+	{ regex: /\bGSA\//i, name: "google-app" },
+];
+
+function detectPlatform(userAgent: string): DevicePlatform {
+	if (/Android/i.test(userAgent)) return "android";
+	if (/iPhone|iPad|iPod/i.test(userAgent)) return "ios";
+	return "other";
+}
+
+export function detectInAppBrowser(
+	userAgent: string = typeof navigator !== "undefined"
+		? navigator.userAgent
+		: "",
+): InAppBrowserDetection {
+	const platform = detectPlatform(userAgent);
+
+	for (const { regex, name } of PATTERNS) {
+		if (regex.test(userAgent)) {
+			return { isInAppBrowser: true, browser: name, platform };
+		}
+	}
+
+	// Generic Android WebView token (does not trigger on Chrome/Firefox/Samsung Internet)
+	if (/; wv\)/i.test(userAgent)) {
+		return { isInAppBrowser: true, browser: "webview", platform };
+	}
+
+	return { isInAppBrowser: false, browser: null, platform };
+}
+
+/**
+ * Builds an Android `intent://` URL that forces the link to open in Chrome,
+ * bypassing the host app's embedded WebView. iOS has no equivalent API.
+ */
+export function buildAndroidChromeIntentUrl(
+	url: string = typeof window !== "undefined" ? window.location.href : "",
+): string | null {
+	if (!url) return null;
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+	const scheme = parsed.protocol.replace(":", "");
+	const rest = `${parsed.host}${parsed.pathname}${parsed.search}${parsed.hash}`;
+	return `intent://${rest}#Intent;scheme=${scheme};package=com.android.chrome;end`;
+}
+
+const BROWSER_LABELS: Record<InAppBrowser, string> = {
+	reddit: "Reddit",
+	instagram: "Instagram",
+	facebook: "Facebook",
+	messenger: "Messenger",
+	tiktok: "TikTok",
+	twitter: "X",
+	linkedin: "LinkedIn",
+	snapchat: "Snapchat",
+	pinterest: "Pinterest",
+	line: "LINE",
+	wechat: "WeChat",
+	discord: "Discord",
+	slack: "Slack",
+	"google-app": "the Google app",
+	webview: "this app",
+};
+
+export function getInAppBrowserLabel(browser: InAppBrowser): string {
+	return BROWSER_LABELS[browser];
+}


### PR DESCRIPTION
## Summary
- Google OAuth was throwing `403: disallowed_useragent` for users landing on phoenix-portal.com from in-app browsers (Reddit, Instagram, Facebook, etc.) because Google blocks embedded WebViews under its "Use secure browsers" policy.
- Add `src/lib/in-app-browser.ts` to detect the common social app WebViews (Reddit/IG/FB/Messenger/TikTok/X/LinkedIn/Snap/Pinterest/Line/WeChat/Discord/Slack/Google App) plus the generic Android `wv` token, and to build an Android `intent://` URL that forces Chrome.
- `LandingPage` now short-circuits the OAuth call with a clear toast and renders a warning banner above the Google/Apple buttons with platform-specific "open in browser" instructions (plus an **Open in Chrome** deep link on Android). Email/password remains fully functional as a fallback.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/lib/__tests__/in-app-browser.test.ts` — 19/19 pass (covers Reddit/IG/FB/Messenger/TikTok/X/LinkedIn/WeChat/Google App/generic `wv`, plus Chrome/Safari/Chrome-iOS/Firefox/Edge negatives, plus `buildAndroidChromeIntentUrl` happy + edge cases)
- [x] `npx vitest run src/app/components/__tests__/LandingPage.test.tsx` — 11/11 pass including new "blocks Google OAuth and shows guidance when opened in an in-app browser" case
- [x] `npx vitest run` — full suite 935 passing / 16 pre-existing skipped / 0 failing
- [ ] Manual smoke on a device: open a `phoenix-portal.com` link from Reddit/Instagram/Facebook and confirm the banner appears and the Android **Open in Chrome** link escapes the WebView.