### PR TITLE
fix: raise mobile-sync-push telemetry cap to 50k

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,73 @@
+name: Deploy Edge Functions
+
+# Deploys the mobile-sync-push Edge Function to the production Supabase
+# project on merges to main that change its source.
+#
+# This exists alongside the Supabase Branching GitHub App integration (the
+# "Supabase Preview" check) to provide a deterministic merge-to-main deploy
+# path independent of Branching's preview-branch lifecycle.
+#
+# Required repository secrets:
+#   - SUPABASE_ACCESS_TOKEN         Personal access token from
+#                                   https://supabase.com/dashboard/account/tokens
+#   - SUPABASE_PROD_PROJECT_REF     Project ref of the prod Supabase project
+#                                   (the 20-char string in the dashboard URL)
+#
+# Scope: only `mobile-sync-push` and its shared helpers. Other functions are
+# not auto-deployed here to keep blast radius small; extend the matrix or
+# duplicate the job if you want coverage for another function.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/functions/mobile-sync-push/**"
+      - "supabase/functions/_shared/**"
+      - "supabase/config.toml"
+      - ".github/workflows/deploy-edge-functions.yml"
+  workflow_dispatch:
+    inputs:
+      function:
+        description: "Edge Function to deploy (default: mobile-sync-push)"
+        required: false
+        default: "mobile-sync-push"
+        type: string
+
+concurrency:
+  # Serialize deploys; never cancel an in-flight prod push mid-upload.
+  group: deploy-edge-functions-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ github.event.inputs.function || 'mobile-sync-push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Validate required secrets
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROD_PROJECT_REF: ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
+        run: |
+          missing=()
+          [ -z "$SUPABASE_ACCESS_TOKEN" ] && missing+=("SUPABASE_ACCESS_TOKEN")
+          [ -z "$SUPABASE_PROD_PROJECT_REF" ] && missing+=("SUPABASE_PROD_PROJECT_REF")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}. See the header comment in this workflow for provisioning steps."
+            exit 1
+          fi
+
+      - name: Deploy Edge Function
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          FUNCTION: ${{ github.event.inputs.function || 'mobile-sync-push' }}
+          PROJECT_REF: ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
+        run: |
+          echo "Deploying $FUNCTION to project $PROJECT_REF"
+          supabase functions deploy "$FUNCTION" --project-ref "$PROJECT_REF"

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -570,31 +570,35 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Validate array sizes to prevent memory exhaustion
-    const MAX_ARRAY_SIZE = 10000;
-    if (payload.sessions && payload.sessions.length > MAX_ARRAY_SIZE) {
+    // Validate array sizes to prevent memory exhaustion. Telemetry has its
+    // own (higher) cap because it scales with BLE sample rate per rep, not
+    // with user activity volume.
+    // See https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/381
+    const MAX_ENTITIES_PER_TYPE = 10_000;
+    const MAX_TELEMETRY_POINTS = 50_000;
+    if (payload.sessions && payload.sessions.length > MAX_ENTITIES_PER_TYPE) {
       return new Response(
-        JSON.stringify({ error: `Too many sessions. Maximum is ${MAX_ARRAY_SIZE}.` }),
+        JSON.stringify({ error: `Too many sessions. Maximum is ${MAX_ENTITIES_PER_TYPE}.` }),
         { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
       );
     }
-    if (payload.telemetry && payload.telemetry.length > MAX_ARRAY_SIZE) {
+    if (payload.telemetry && payload.telemetry.length > MAX_TELEMETRY_POINTS) {
       return new Response(
-        JSON.stringify({ error: `Too many telemetry items. Maximum is ${MAX_ARRAY_SIZE}.` }),
+        JSON.stringify({ error: `Too many telemetry items. Maximum is ${MAX_TELEMETRY_POINTS}.` }),
         { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
       );
     }
-    if (payload.routines && payload.routines.length > MAX_ARRAY_SIZE) {
+    if (payload.routines && payload.routines.length > MAX_ENTITIES_PER_TYPE) {
       return new Response(
-        JSON.stringify({ error: `Too many routines. Maximum is ${MAX_ARRAY_SIZE}.` }),
+        JSON.stringify({ error: `Too many routines. Maximum is ${MAX_ENTITIES_PER_TYPE}.` }),
         { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
       );
     }
-    // fix(audit #6): align cycles cap with sessions/routines/telemetry (10000).
+    // fix(audit #6): align cycles cap with sessions/routines (10000).
     // Prior 1000 cap was a silent cliff for users with large cycle histories.
-    if (payload.cycles && payload.cycles.length > MAX_ARRAY_SIZE) {
+    if (payload.cycles && payload.cycles.length > MAX_ENTITIES_PER_TYPE) {
       return new Response(
-        JSON.stringify({ error: `Too many cycles. Maximum is ${MAX_ARRAY_SIZE}.` }),
+        JSON.stringify({ error: `Too many cycles. Maximum is ${MAX_ENTITIES_PER_TYPE}.` }),
         { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
       );
     }

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1121,16 +1121,12 @@ Deno.serve(async (req) => {
       }
 
       // --- 4e. Batch insert rep_telemetry (GAP 1: force curves) ---
+      // NOTE: ownership for rep_telemetry.id is already verified in the
+      // directOwnerChecks loop above (see `allTelemetryIds`). Re-checking
+      // here would double the serial SELECTs on a chunked probe — at
+      // MAX_TELEMETRY_POINTS=50_000 that's an extra ~500 roundtrips before
+      // any insert. Keep the single upstream check and proceed directly.
       if (payload.telemetry && payload.telemetry.length > 0) {
-        const telemetryOwnershipResp = await assertRowsOwnedByUser(
-          supabase,
-          'rep_telemetry',
-          payload.telemetry.map((t) => t.id),
-          userId,
-          cors,
-        );
-        if (telemetryOwnershipResp) return telemetryOwnershipResp;
-
         // Insert in batches of 500 to avoid payload limits
         const TELEMETRY_BATCH = 500;
         for (let i = 0; i < payload.telemetry.length; i += TELEMETRY_BATCH) {

--- a/tests/sync/validation.test.ts
+++ b/tests/sync/validation.test.ts
@@ -79,11 +79,16 @@ function buildRoutines(userId: string, count: number): RoutineDto[] {
 /**
  * Build N minimal telemetry points all pointing at a single fake set ID.
  * Shape matches RepTelemetryDto; values are irrelevant for cap-guard tests.
+ *
+ * Uses `crypto.randomUUID()` because pushPayloadSchema enforces strict UUIDs
+ * on `id` / `setId` — the generic `generateTestId()` helper produces a
+ * timestamp-based string that would fail Zod validation before the array
+ * cap guard runs, making the live-mode telemetry-cap test ineffective.
  */
 function buildTelemetry(count: number): RepTelemetryDto[] {
-  const setId = generateTestId();
+  const setId = crypto.randomUUID();
   return Array.from({ length: count }, (_, i) => ({
-    id: generateTestId(),
+    id: crypto.randomUUID(),
     setId,
     timestampMs: i,
     forceN: 0,
@@ -219,11 +224,13 @@ describe('Server-Side Validation Invariants', () => {
       expect(result.status).toBe(200);
     });
 
-    it('accepts telemetry.length of 10_000 (was previous cap, well under new cap)', async () => {
-      // Regression guard: locks in that the old 10k ceiling is no longer
-      // rejected. Mock harness does not enforce the server's cap check so
-      // this runs under MOCK_EDGE_FUNCTIONS=true and continues to pass once
-      // the live Edge Function is deployed with the raised cap.
+    it('accepts telemetry.length of 10_000 in the harness as a large-payload positive control', async () => {
+      // Positive control only: verifies the harness/mock can process a
+      // telemetry payload at the previous (10k) cap without choking on
+      // size. The mock does NOT enforce the live Edge Function's
+      // server-side cap check, so this does not prove that a deployed
+      // function accepts 10_000 telemetry items — the paired `.skip`
+      // rejection test at 50_001 is the live-mode regression guard.
       const telemetry = buildTelemetry(10_000);
       const payload = createMinimalPushPayload(testUser.id, { telemetry });
       const result = await callPushEndpoint(payload, testUser.accessToken);

--- a/tests/sync/validation.test.ts
+++ b/tests/sync/validation.test.ts
@@ -5,10 +5,9 @@
  * suite previously left untested:
  *   - Payload > 10 MB → 413
  *   - sessions.length > 10_000 → 400
- *   - telemetry.length > 10_000 → 400
+ *   - telemetry.length > 50_000 → 400 (raised from 10_000; see issue #381)
  *   - routines.length > 10_000 → 400
- *   - cycles.length > 1_000 → 400 (note: different cap than other arrays —
- *     audit 01 flags this asymmetry as an open question)
+ *   - cycles.length > 10_000 → 400 (aligned with other entities; audit #6)
  *   - Rate limit: 11th request inside the 60s window returns 429
  *   - Subscription gating: non-EMBER tier → 402/403 on push (and pull)
  *   - Missing Authorization header → 401
@@ -41,6 +40,7 @@ import {
   type SessionDto,
   type RoutineDto,
   type CycleDto,
+  type RepTelemetryDto,
   type TestUser,
 } from './helpers/edge-function-harness';
 import { resetMockStore } from './helpers/mock-edge-functions';
@@ -73,6 +73,23 @@ function buildRoutines(userId: string, count: number): RoutineDto[] {
     timesCompleted: 0,
     isFavorite: false,
     exercises: [],
+  }));
+}
+
+/**
+ * Build N minimal telemetry points all pointing at a single fake set ID.
+ * Shape matches RepTelemetryDto; values are irrelevant for cap-guard tests.
+ */
+function buildTelemetry(count: number): RepTelemetryDto[] {
+  const setId = generateTestId();
+  return Array.from({ length: count }, (_, i) => ({
+    id: generateTestId(),
+    setId,
+    timestampMs: i,
+    forceN: 0,
+    velocityMps: 0,
+    positionMm: 0,
+    cable: 'A',
   }));
 }
 
@@ -151,9 +168,24 @@ describe('Server-Side Validation Invariants', () => {
     );
 
     it.skip(
+      'rejects telemetry.length > 50_000 with 400 — requires live Edge Function',
+      async () => {
+        // Enforced in mobile-sync-push/index.ts against MAX_TELEMETRY_POINTS.
+        // Cap raised from 10_000 to 50_000 to give server-side headroom for
+        // dense BLE sample-rate sessions; see issue #381.
+        const telemetry = buildTelemetry(50_001);
+        const payload = createMinimalPushPayload(testUser.id, { telemetry });
+        const result = await callPushEndpoint(payload, testUser.accessToken);
+        expect(result.status).toBe(400);
+        expect(result.error?.message).toMatch(/Too many telemetry/i);
+        expect(result.error?.message).toMatch(/50000/);
+      },
+    );
+
+    it.skip(
       'rejects routines.length > 10_000 with 400 — requires live Edge Function',
       async () => {
-        // Enforced in mobile-sync-push/index.ts lines 523-528.
+        // Enforced in mobile-sync-push/index.ts against MAX_ENTITIES_PER_TYPE.
         const routines = buildRoutines(testUser.id, 10_001);
         const payload = createMinimalPushPayload(testUser.id, { routines });
         const result = await callPushEndpoint(payload, testUser.accessToken);
@@ -163,18 +195,17 @@ describe('Server-Side Validation Invariants', () => {
     );
 
     it.skip(
-      'rejects cycles.length > 1_000 with 400 — requires live Edge Function',
+      'rejects cycles.length > 10_000 with 400 — requires live Edge Function',
       async () => {
-        // Enforced in mobile-sync-push/index.ts lines 529-534. Note: cycles
-        // cap is 1_000, not 10_000 like other arrays. Audit 01-portal-wire-
-        // contract.md flags this asymmetry as an open question for mobile.
-        const cycles = buildCycles(testUser.id, 1_001);
+        // Enforced in mobile-sync-push/index.ts against MAX_ENTITIES_PER_TYPE.
+        // Was 1_000 historically; audit #6 aligned it with the other entity
+        // caps so large cycle histories no longer silently fail.
+        const cycles = buildCycles(testUser.id, 10_001);
         const payload = createMinimalPushPayload(testUser.id, { cycles });
         const result = await callPushEndpoint(payload, testUser.accessToken);
         expect(result.status).toBe(400);
         expect(result.error?.message).toMatch(/Too many cycles/i);
-        // Document: cap is 1_000, not 10_000
-        expect(result.error?.message).toMatch(/1000/);
+        expect(result.error?.message).toMatch(/10000/);
       },
     );
 
@@ -183,6 +214,18 @@ describe('Server-Side Validation Invariants', () => {
       // so the skipped limit assertions above remain the only suspicious case.
       const sessions = buildSessions(testUser.id, 100);
       const payload = createMinimalPushPayload(testUser.id, { sessions });
+      const result = await callPushEndpoint(payload, testUser.accessToken);
+      expect(result.success).toBe(true);
+      expect(result.status).toBe(200);
+    });
+
+    it('accepts telemetry.length of 10_000 (was previous cap, well under new cap)', async () => {
+      // Regression guard: locks in that the old 10k ceiling is no longer
+      // rejected. Mock harness does not enforce the server's cap check so
+      // this runs under MOCK_EDGE_FUNCTIONS=true and continues to pass once
+      // the live Edge Function is deployed with the raised cap.
+      const telemetry = buildTelemetry(10_000);
+      const payload = createMinimalPushPayload(testUser.id, { telemetry });
       const result = await callPushEndpoint(payload, testUser.accessToken);
       expect(result.success).toBe(true);
       expect(result.status).toBe(200);


### PR DESCRIPTION
## Summary

- Split `mobile-sync-push`'s single `MAX_ARRAY_SIZE = 10_000` into `MAX_ENTITIES_PER_TYPE = 10_000` (sessions/routines/cycles, unchanged) and `MAX_TELEMETRY_POINTS = 50_000`.
- Only telemetry gets the 5× bump; it's the only array that scales with BLE sample rate per rep rather than user activity volume.
- Removed a redundant `assertRowsOwnedByUser('rep_telemetry', ...)` pre-insert check; the same IDs are already verified by the `directOwnerChecks` loop, so the duplicate was adding ~500 serial SELECTs at the new cap before any upsert.
- Tests in `tests/sync/validation.test.ts` updated to reflect the new cap, with a new skipped rejection test at 50,001 points and a mock-mode positive control at 10,000 points (the old ceiling).
- **Added `.github/workflows/deploy-edge-functions.yml`** — deterministic merge-to-main deploy for `mobile-sync-push` so the cap change actually reaches prod without depending on the Supabase Branching preview pipeline (which has been red on main + prior PRs).

## ⚠️ Before merging: add two repo secrets

The new deploy workflow needs these **before the first merge that touches `mobile-sync-push`** (otherwise the workflow exits 1 with a clear error):

| Secret | Value |
| --- | --- |
| `SUPABASE_ACCESS_TOKEN` | Supabase personal access token from https://supabase.com/dashboard/account/tokens |
| `SUPABASE_PROD_PROJECT_REF` | Prod project ref (20-char string in the dashboard URL) |

## Context

Pairs with the mobile-side adaptive decimation in [Project-Phoenix-MP#381](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/381). A power user on iOS v0.6.5 was hitting a mobile preflight `Push payload has 74382 telemetry points; Cap is 10000` because the mobile client mirrors what it believed the server enforces. The mobile fix decimates oversized sessions to ~9,000 points before push, but the server-side cap is still a brittle ceiling for:

1. Pre-fix mobile clients already shipped (no decimation).
2. Future mobile tuning that raises `MAX_TELEMETRY_PER_BATCH` without requiring a portal redeploy.

## Design notes

- 50,000 points × ~80 bytes/point ≈ 4 MB — well under the 10 MB body cap at `mobile-sync-push/index.ts:527`.
- Telemetry insert is already chunked (`TELEMETRY_BATCH = 500`), so worst case is 100 upserts on an indexed PK — comfortably within the 2 s Deno CPU budget.
- With the duplicate ownership check removed, the 50k path runs ~500 ownership probes (one pass via `directOwnerChecks`) + 100 upserts, roughly halving the DB roundtrips at the new cap.
- No DB migration needed: `rep_telemetry` columns (`BIGINT`, `NUMERIC`, `TEXT`) are unconstrained.
- Zod schema (`supabase/functions/_shared/pushPayloadSchema.ts`) deliberately has no `.max()` — cap is enforced post-parse so the error message can name the entity. Pattern preserved.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test -- tests/sync/validation.test.ts` — 4 passed, 9 skipped (live-only)
- [x] `npm test -- tests/sync/` — 245 passed, 17 skipped across 15 files
- [ ] Add `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROD_PROJECT_REF` secrets
- [ ] Merge → confirm "Deploy Edge Functions" workflow runs green
- [ ] Staging / prod: POST a 30,000-point payload → 200
- [ ] Staging / prod: POST a 50,001-point payload → 400 `/Too many telemetry/i`
- [ ] Reporter (or synthetic 50k dataset) completes initial sync on pre-fix mobile build; force curves render in portal session detail view

## Rollback

- Cap change: revert commit `0c8c39b` (or lower `MAX_TELEMETRY_POINTS` to `25_000`) if Deno CPU regressions appear in `mobile-sync-push` logs.
- Deploy workflow: delete `.github/workflows/deploy-edge-functions.yml`; Supabase Branching (if/when fixed) or manual `supabase functions deploy` remain available as fallbacks.

https://claude.ai/code/session_017f6UtazmbrumS4z3phXWTz