### PR TITLE
docs: raise Symphony Codex read timeout

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -42,7 +42,7 @@ codex:
     type: workspaceWrite
     networkAccess: true
   turn_timeout_ms: 3600000
-  read_timeout_ms: 5000
+  read_timeout_ms: 60000
   stall_timeout_ms: 300000
 ---
 You are working on a Linear issue for Phoenix Portal.


### PR DESCRIPTION
## Summary
- raise `codex.read_timeout_ms` from `5000` to `60000` in `WORKFLOW.md`
- preserve the smoke scope as a workflow/config-only change
- record that this addresses the previously observed Symphony `:response_timeout`

## Validation
- `npm run lint`
- `npm run verify`
- `npm run verify:full`

Linear: https://linear.app/9th-level-software/issue/9TH-12/run-first-symphony-smoke-issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to extend operational timeout thresholds, allowing for longer processing windows during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->