### PR TITLE
Avoid upserting `id` for cycle_days to prevent PK conflicts

### DIFF
--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1607,19 +1607,22 @@ Deno.serve(async (req) => {
       const dayRows = payload.cycles
         .filter((c) => childAllowed(acceptedCycleIds, c.id))
         .flatMap((c) =>
-        c.days.map((d) => ({
-          id: d.id,
-          cycle_id: d.cycleId,
-          day_number: d.dayNumber,
-          day_type: d.dayType ?? 'workout',
-          routine_id: d.routineId,
-          weight_adjustment: d.weightAdjustment ?? 0,
-          rep_modifier: d.repModifier ?? 0,
-          rest_override: d.restOverride,
-          rest_type: d.restType,
-          notes: d.notes,
-        }))
-      );
+          c.days.map((d) => ({
+            // Do not upsert id when conflict target is (cycle_id, day_number).
+            // If a client reuses an id across different day rows, Postgres can
+            // still raise duplicate key on cycle_days_pkey before conflict
+            // resolution for the composite unique key.
+            cycle_id: d.cycleId,
+            day_number: d.dayNumber,
+            day_type: d.dayType ?? 'workout',
+            routine_id: d.routineId,
+            weight_adjustment: d.weightAdjustment ?? 0,
+            rep_modifier: d.repModifier ?? 0,
+            rest_override: d.restOverride,
+            rest_type: d.restType,
+            notes: d.notes,
+          })),
+        );
 
       if (dayRows.length > 0) {
         const { error: dayErr } = await supabase

--- a/tests/sync/round-trip/entity-roundtrip.test.ts
+++ b/tests/sync/round-trip/entity-roundtrip.test.ts
@@ -486,6 +486,83 @@ describe('Entity Round-Trip Tests', () => {
       expect(pulledCycle.days).toHaveLength(3);
     });
 
+    it('should handle cycle day DTOs that reuse the same id across different day numbers', async () => {
+      // Arrange: two day DTOs intentionally reuse the same id
+      const cycleId = generateTestId();
+      const sharedDayId = generateTestId();
+      const firstRoutineId = generateTestId();
+      const secondRoutineId = generateTestId();
+
+      const cycle: CycleDto = {
+        id: cycleId,
+        userId: testUser.id,
+        name: 'Duplicate Day ID Cycle',
+        description: 'Regression test for cycle_days upsert conflict target',
+        durationWeeks: 4,
+        workoutDays: 2,
+        restDays: 0,
+        currentWeek: 1,
+        status: 'active',
+        startedAt: null,
+        lastUsedAt: null,
+        progressionSettings: null,
+        deloadSettings: null,
+        days: [
+          {
+            id: sharedDayId,
+            cycleId,
+            dayNumber: 1,
+            dayType: 'workout',
+            routineId: firstRoutineId,
+            weightAdjustment: 5,
+            repModifier: 1,
+            restOverride: null,
+            restType: null,
+            notes: 'Day 1 update',
+          },
+          {
+            id: sharedDayId,
+            cycleId,
+            dayNumber: 2,
+            dayType: 'workout',
+            routineId: secondRoutineId,
+            weightAdjustment: -5,
+            repModifier: -1,
+            restOverride: null,
+            restType: null,
+            notes: 'Day 2 update',
+          },
+        ],
+      };
+
+      const payload = createMinimalPushPayload(testUser.id, { cycles: [cycle] });
+
+      // Act: should not fail with duplicate-key errors from cycle_days_pkey
+      const pushResult = await callPushEndpoint(payload, testUser.accessToken);
+      expect(pushResult.success).toBe(true);
+      const pullResult = await callPullEndpoint(0, testUser.accessToken);
+
+      // Assert: both day rows are preserved by (cycleId, dayNumber)
+      expect(pullResult.success).toBe(true);
+      const pulledCycle = pullResult.data!.cycles.find(c => c.id === cycleId);
+      expect(pulledCycle).toBeDefined();
+      expect(pulledCycle!.days).toHaveLength(2);
+      expect(pulledCycle!.days).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            dayNumber: 1,
+            routineId: firstRoutineId,
+            notes: 'Day 1 update',
+          }),
+          expect.objectContaining({
+            dayNumber: 2,
+            routineId: secondRoutineId,
+            notes: 'Day 2 update',
+          }),
+        ]),
+      );
+    });
+
     it('should preserve deload day configuration', async () => {
       // Arrange: Cycle with deload week
       const cycleId = generateTestId();


### PR DESCRIPTION
### Motivation
- Prevent Postgres duplicate-key errors when clients reuse the same `id` across different day rows by relying on the composite unique key `(cycle_id, day_number)` for conflict resolution.

### Description
- Remove the `id` field from the `cycle_days` upsert payload and add a clarifying comment so upserts use `onConflict: 'cycle_id,day_number'` without triggering the `cycle_days` primary key before conflict resolution.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126764a0608322a7f6bb3ec6a66dc1)