### PR TITLE
fix: restore reliable community vote count trigger

### DIFF
--- a/supabase/migrations/20260524120000_fix_vote_count_trigger_security.sql
+++ b/supabase/migrations/20260524120000_fix_vote_count_trigger_security.sql
@@ -1,0 +1,43 @@
+-- Ensure community vote counter trigger can update shared content rows
+-- regardless of the voting user's row-level permissions.
+
+CREATE OR REPLACE FUNCTION public.update_vote_count()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.item_type = 'routine' THEN
+      UPDATE public.shared_routines
+      SET vote_count = vote_count + 1
+      WHERE id = NEW.item_id;
+    ELSE
+      UPDATE public.shared_cycles
+      SET vote_count = vote_count + 1
+      WHERE id = NEW.item_id;
+    END IF;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    IF OLD.item_type = 'routine' THEN
+      UPDATE public.shared_routines
+      SET vote_count = GREATEST(0, vote_count - 1)
+      WHERE id = OLD.item_id;
+    ELSE
+      UPDATE public.shared_cycles
+      SET vote_count = GREATEST(0, vote_count - 1)
+      WHERE id = OLD.item_id;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS update_vote_count_on_change ON public.community_votes;
+CREATE TRIGGER update_vote_count_on_change
+  AFTER INSERT OR DELETE ON public.community_votes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_vote_count();

--- a/supabase/migrations/20260524120000_fix_vote_count_trigger_security.sql
+++ b/supabase/migrations/20260524120000_fix_vote_count_trigger_security.sql
@@ -13,7 +13,7 @@ BEGIN
       UPDATE public.shared_routines
       SET vote_count = vote_count + 1
       WHERE id = NEW.item_id;
-    ELSE
+    ELSIF NEW.item_type = 'cycle' THEN
       UPDATE public.shared_cycles
       SET vote_count = vote_count + 1
       WHERE id = NEW.item_id;
@@ -24,12 +24,36 @@ BEGIN
       UPDATE public.shared_routines
       SET vote_count = GREATEST(0, vote_count - 1)
       WHERE id = OLD.item_id;
-    ELSE
+    ELSIF OLD.item_type = 'cycle' THEN
       UPDATE public.shared_cycles
       SET vote_count = GREATEST(0, vote_count - 1)
       WHERE id = OLD.item_id;
     END IF;
     RETURN OLD;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF OLD.item_id IS DISTINCT FROM NEW.item_id
+       OR OLD.item_type IS DISTINCT FROM NEW.item_type THEN
+      IF OLD.item_type = 'routine' THEN
+        UPDATE public.shared_routines
+        SET vote_count = GREATEST(0, vote_count - 1)
+        WHERE id = OLD.item_id;
+      ELSIF OLD.item_type = 'cycle' THEN
+        UPDATE public.shared_cycles
+        SET vote_count = GREATEST(0, vote_count - 1)
+        WHERE id = OLD.item_id;
+      END IF;
+
+      IF NEW.item_type = 'routine' THEN
+        UPDATE public.shared_routines
+        SET vote_count = vote_count + 1
+        WHERE id = NEW.item_id;
+      ELSIF NEW.item_type = 'cycle' THEN
+        UPDATE public.shared_cycles
+        SET vote_count = vote_count + 1
+        WHERE id = NEW.item_id;
+      END IF;
+    END IF;
+    RETURN NEW;
   END IF;
 
   RETURN COALESCE(NEW, OLD);
@@ -38,6 +62,6 @@ $$;
 
 DROP TRIGGER IF EXISTS update_vote_count_on_change ON public.community_votes;
 CREATE TRIGGER update_vote_count_on_change
-  AFTER INSERT OR DELETE ON public.community_votes
+  AFTER INSERT OR DELETE OR UPDATE ON public.community_votes
   FOR EACH ROW
   EXECUTE FUNCTION public.update_vote_count();


### PR DESCRIPTION
### Motivation
- Upvote animations were occurring but displayed counts remained at `0` because the server-side vote counter could not update shared rows under row-level security, so the trigger needs elevated privileges to reliably maintain denormalized `vote_count`.

### Description
- Add idempotent migration `supabase/migrations/20260524120000_fix_vote_count_trigger_security.sql` which creates `public.update_vote_count()` as a `SECURITY DEFINER` function and recreates the `update_vote_count_on_change` trigger to increment/decrement `shared_routines.vote_count` and `shared_cycles.vote_count` on `community_votes` insert/delete.

### Testing
- Ran `npm run test:sync` and the sync test suite completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a126c93ba608322b3866d830fb50010)