### PR TITLE
Add full community routine and cycle viewability with import saves

### DIFF
--- a/src/app/components/Community.tsx
+++ b/src/app/components/Community.tsx
@@ -33,7 +33,6 @@ import type { CommunityFeedItem } from "@/schemas/community";
 import { useCommunityStore } from "@/stores/useCommunityStore";
 
 const SORT_OPTIONS = [
-	{ value: "hot", label: "Hot" },
 	{ value: "top", label: "Top" },
 	{ value: "new", label: "New" },
 ] as const;

--- a/src/app/components/community/CommunityContentPreview.tsx
+++ b/src/app/components/community/CommunityContentPreview.tsx
@@ -22,9 +22,7 @@ function asPrimitiveArray(value: unknown): Array<string | number | boolean> {
 
 function formatStoredDurationMinutes(duration: number | null | undefined) {
 	if (!duration) return "0 min";
-	return duration > 300
-		? `${Math.round(duration / 60)} min`
-		: `${Math.round(duration)} min`;
+	return `${Math.round(duration / 60)} min`;
 }
 
 function formatLoad(exercise: RoutineExerciseSnapshot) {
@@ -177,6 +175,22 @@ export function RoutineSnapshotPreview({
 		});
 		return items;
 	}, []);
+	let exerciseNumber = 0;
+	const indexedGroups = grouped.map((item) => {
+		if (item.type === "exercise") {
+			const indexedItem = { ...item, index: exerciseNumber };
+			exerciseNumber += 1;
+			return indexedItem;
+		}
+
+		const indexedExercises = item.exercises.map((exercise) => {
+			const indexedExercise = { exercise, index: exerciseNumber };
+			exerciseNumber += 1;
+			return indexedExercise;
+		});
+
+		return { ...item, exercises: indexedExercises };
+	});
 
 	return (
 		<section className="space-y-3">
@@ -185,12 +199,12 @@ export function RoutineSnapshotPreview({
 				<h4 className="text-sm font-semibold text-white">{title}</h4>
 			</div>
 			<div className="space-y-3">
-				{grouped.map((item, itemIndex) =>
+				{indexedGroups.map((item) =>
 					item.type === "exercise" ? (
 						<RoutineExerciseCard
 							key={`${item.exercise.name}-${item.exercise.order_index}`}
 							exercise={item.exercise}
-							index={itemIndex}
+							index={item.index}
 						/>
 					) : (
 						<div
@@ -213,11 +227,11 @@ export function RoutineSnapshotPreview({
 								</span>
 							</div>
 							<div className="space-y-2">
-								{item.exercises.map((exercise, exerciseIndex) => (
+								{item.exercises.map(({ exercise, index }) => (
 									<RoutineExerciseCard
 										key={`${exercise.name}-${exercise.order_index}`}
 										exercise={exercise}
-										index={exerciseIndex}
+										index={index}
 									/>
 								))}
 							</div>
@@ -317,7 +331,7 @@ export function CycleSnapshotPreview({
 						Duration
 					</div>
 					<p className="text-lg font-semibold text-white">
-						{snapshot.duration_weeks} days
+						{snapshot.duration_weeks} weeks
 					</p>
 				</div>
 				<div className="rounded-lg border border-secondary bg-surface-2 p-3">

--- a/src/app/components/community/CommunityContentPreview.tsx
+++ b/src/app/components/community/CommunityContentPreview.tsx
@@ -1,0 +1,415 @@
+import { Calendar, Clock, Dumbbell, Repeat } from "lucide-react";
+import { Badge } from "@/app/components/ui/badge";
+import { formatWeight } from "@/lib/units";
+import type {
+	CycleSnapshot,
+	EmbeddedRoutineSnapshot,
+	RoutineExerciseSnapshot,
+} from "@/schemas/community";
+import { WEIGHT_MULTIPLIER } from "@/schemas/transforms";
+
+function orderedExercises(exercises: RoutineExerciseSnapshot[]) {
+	return [...exercises].sort((a, b) => a.order_index - b.order_index);
+}
+
+function asPrimitiveArray(value: unknown): Array<string | number | boolean> {
+	return Array.isArray(value)
+		? value.filter((item): item is string | number | boolean =>
+				["string", "number", "boolean"].includes(typeof item),
+			)
+		: [];
+}
+
+function formatStoredDurationMinutes(duration: number | null | undefined) {
+	if (!duration) return "0 min";
+	return duration > 300
+		? `${Math.round(duration / 60)} min`
+		: `${Math.round(duration)} min`;
+}
+
+function formatLoad(exercise: RoutineExerciseSnapshot) {
+	if (exercise.is_bodyweight) return "Bodyweight";
+	return formatWeight((exercise.weight ?? 0) * WEIGHT_MULTIPLIER, "kg");
+}
+
+function formatPrescription(exercise: RoutineExerciseSnapshot) {
+	const load = formatLoad(exercise);
+	if (exercise.duration_seconds) {
+		return `${exercise.sets} sets / ${exercise.duration_seconds}s / ${load}`;
+	}
+	if (exercise.is_amrap) {
+		return `${exercise.sets} sets / AMRAP / ${load}`;
+	}
+	return `${exercise.sets} sets / ${exercise.reps} reps / ${load}`;
+}
+
+function exerciseBadges(exercise: RoutineExerciseSnapshot) {
+	return [
+		exercise.mode,
+		exercise.is_amrap ? "AMRAP" : null,
+		exercise.is_bodyweight ? "Bodyweight" : null,
+		exercise.eccentric_load ? `Eccentric ${exercise.eccentric_load}` : null,
+		exercise.echo_level ? `Echo ${exercise.echo_level}` : null,
+		exercise.rep_count_timing ? `Timing ${exercise.rep_count_timing}` : null,
+		exercise.stop_at_position ? `Stop ${exercise.stop_at_position}` : null,
+		exercise.stall_detection === false ? "Stall off" : null,
+	].filter(Boolean) as string[];
+}
+
+function perSetRows(exercise: RoutineExerciseSnapshot) {
+	const weights = asPrimitiveArray(exercise.per_set_weights).map((value) =>
+		typeof value === "number"
+			? formatWeight(value * WEIGHT_MULTIPLIER, "kg")
+			: String(value),
+	);
+	const reps = asPrimitiveArray(exercise.per_set_reps).map(String);
+	const rest = asPrimitiveArray(exercise.per_set_rest).map((value) =>
+		typeof value === "number" ? `${value}s` : String(value),
+	);
+	const echoLevels = asPrimitiveArray(exercise.per_set_echo_levels).map(String);
+
+	return [
+		weights.length ? `Weights: ${weights.join(", ")}` : null,
+		reps.length ? `Reps: ${reps.join(", ")}` : null,
+		rest.length ? `Rest: ${rest.join(", ")}` : null,
+		echoLevels.length ? `Echo: ${echoLevels.join(", ")}` : null,
+	].filter(Boolean) as string[];
+}
+
+function RoutineExerciseCard({
+	exercise,
+	index,
+}: {
+	exercise: RoutineExerciseSnapshot;
+	index: number;
+}) {
+	const perSet = perSetRows(exercise);
+
+	return (
+		<div className="rounded-lg border border-secondary bg-surface-2 p-3">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div className="min-w-0">
+					<div className="mb-1 flex flex-wrap items-center gap-2">
+						<span className="text-xs text-muted-foreground">
+							{String(index + 1).padStart(2, "0")}
+						</span>
+						<h5 className="text-sm font-semibold text-white">
+							{exercise.name}
+						</h5>
+						<Badge className="border-0 bg-secondary text-secondary-foreground">
+							{exercise.muscle_group}
+						</Badge>
+					</div>
+					<p className="text-sm text-secondary-foreground">
+						{formatPrescription(exercise)}
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Rest: {exercise.rest_seconds}s between sets
+					</p>
+					{perSet.length > 0 && (
+						<div className="mt-2 space-y-1 text-xs text-muted-foreground">
+							{perSet.map((row) => (
+								<p key={row}>{row}</p>
+							))}
+						</div>
+					)}
+				</div>
+				<div className="flex flex-wrap gap-1.5 sm:max-w-[240px] sm:justify-end">
+					{exerciseBadges(exercise).map((badge) => (
+						<Badge
+							key={badge}
+							variant="outline"
+							className="border-secondary text-muted-foreground"
+						>
+							{badge}
+						</Badge>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function RoutineSnapshotPreview({
+	exercises,
+	title = "Routine Details",
+}: {
+	exercises: RoutineExerciseSnapshot[] | null | undefined;
+	title?: string;
+}) {
+	if (!exercises || exercises.length === 0) {
+		return (
+			<div className="rounded-lg border border-dashed border-secondary p-4 text-sm text-muted-foreground">
+				Full routine details are unavailable for this older share.
+			</div>
+		);
+	}
+
+	const grouped = orderedExercises(exercises).reduce<
+		Array<
+			| { type: "exercise"; exercise: RoutineExerciseSnapshot }
+			| {
+					type: "superset";
+					id: string;
+					color: string | null | undefined;
+					exercises: RoutineExerciseSnapshot[];
+			  }
+		>
+	>((items, exercise) => {
+		if (!exercise.superset_id) {
+			items.push({ type: "exercise", exercise });
+			return items;
+		}
+		if (
+			items.some(
+				(item) => item.type === "superset" && item.id === exercise.superset_id,
+			)
+		) {
+			return items;
+		}
+		items.push({
+			type: "superset",
+			id: exercise.superset_id,
+			color: exercise.superset_color,
+			exercises: exercises
+				.filter((entry) => entry.superset_id === exercise.superset_id)
+				.sort((a, b) => (a.superset_order ?? 0) - (b.superset_order ?? 0)),
+		});
+		return items;
+	}, []);
+
+	return (
+		<section className="space-y-3">
+			<div className="flex items-center gap-2">
+				<Dumbbell className="h-4 w-4 text-primary" />
+				<h4 className="text-sm font-semibold text-white">{title}</h4>
+			</div>
+			<div className="space-y-3">
+				{grouped.map((item, itemIndex) =>
+					item.type === "exercise" ? (
+						<RoutineExerciseCard
+							key={`${item.exercise.name}-${item.exercise.order_index}`}
+							exercise={item.exercise}
+							index={itemIndex}
+						/>
+					) : (
+						<div
+							key={item.id}
+							className="rounded-lg border border-secondary bg-background/30 p-3"
+							style={{
+								borderLeftColor: item.color ?? undefined,
+								borderLeftWidth: 4,
+							}}
+						>
+							<div className="mb-3 flex items-center gap-2">
+								<Badge
+									variant="outline"
+									className="border-primary/40 text-primary"
+								>
+									Superset
+								</Badge>
+								<span className="text-xs text-muted-foreground">
+									{item.exercises.length} exercises
+								</span>
+							</div>
+							<div className="space-y-2">
+								{item.exercises.map((exercise, exerciseIndex) => (
+									<RoutineExerciseCard
+										key={`${exercise.name}-${exercise.order_index}`}
+										exercise={exercise}
+										index={exerciseIndex}
+									/>
+								))}
+							</div>
+						</div>
+					),
+				)}
+			</div>
+		</section>
+	);
+}
+
+function SettingList({ title, value }: { title: string; value: unknown }) {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const entries = Object.entries(value as Record<string, unknown>).filter(
+		([, entryValue]) => entryValue !== null && entryValue !== undefined,
+	);
+	if (entries.length === 0) return null;
+
+	return (
+		<div className="rounded-lg border border-secondary bg-surface-2 p-3">
+			<h5 className="mb-2 text-sm font-semibold text-white">{title}</h5>
+			<div className="grid gap-2 sm:grid-cols-2">
+				{entries.map(([key, entryValue]) => (
+					<div key={key} className="text-xs">
+						<span className="capitalize text-muted-foreground">
+							{key.replace(/_/g, " ")}:
+						</span>{" "}
+						<span className="text-secondary-foreground">
+							{String(entryValue)}
+						</span>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function CycleRoutineDetails({
+	routine,
+}: {
+	routine: EmbeddedRoutineSnapshot | null | undefined;
+}) {
+	if (!routine) {
+		return (
+			<p className="mt-2 text-xs text-muted-foreground">
+				The routine assigned to this day is unavailable in the shared snapshot.
+			</p>
+		);
+	}
+
+	return (
+		<details className="mt-3 rounded-lg border border-secondary bg-background/40 p-3">
+			<summary className="cursor-pointer text-sm font-medium text-white">
+				View {routine.name}
+			</summary>
+			<div className="mt-3">
+				<RoutineSnapshotPreview
+					exercises={routine.exercises}
+					title={`${routine.name} Exercises`}
+				/>
+			</div>
+		</details>
+	);
+}
+
+export function CycleSnapshotPreview({
+	snapshot,
+}: {
+	snapshot: CycleSnapshot | null | undefined;
+}) {
+	if (!snapshot) {
+		return (
+			<div className="rounded-lg border border-dashed border-secondary p-4 text-sm text-muted-foreground">
+				Full cycle details are unavailable for this older share.
+			</div>
+		);
+	}
+
+	const days = [...snapshot.days].sort((a, b) => a.day_number - b.day_number);
+	const workoutDays =
+		snapshot.workout_days ??
+		days.filter((day) => day.day_type === "workout").length;
+	const restDays =
+		snapshot.rest_days ?? days.filter((day) => day.day_type === "rest").length;
+
+	return (
+		<section className="space-y-3">
+			<div className="flex items-center gap-2">
+				<Calendar className="h-4 w-4 text-primary" />
+				<h4 className="text-sm font-semibold text-white">Cycle Details</h4>
+			</div>
+
+			<div className="grid gap-2 sm:grid-cols-3">
+				<div className="rounded-lg border border-secondary bg-surface-2 p-3">
+					<div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+						<Calendar className="h-3.5 w-3.5" />
+						Duration
+					</div>
+					<p className="text-lg font-semibold text-white">
+						{snapshot.duration_weeks} days
+					</p>
+				</div>
+				<div className="rounded-lg border border-secondary bg-surface-2 p-3">
+					<div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+						<Dumbbell className="h-3.5 w-3.5" />
+						Workouts
+					</div>
+					<p className="text-lg font-semibold text-white">{workoutDays}</p>
+				</div>
+				<div className="rounded-lg border border-secondary bg-surface-2 p-3">
+					<div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+						<Clock className="h-3.5 w-3.5" />
+						Rest Days
+					</div>
+					<p className="text-lg font-semibold text-white">{restDays}</p>
+				</div>
+			</div>
+
+			<SettingList title="Progression" value={snapshot.progression_settings} />
+			<SettingList title="Deload" value={snapshot.deload_settings} />
+
+			<div className="space-y-2">
+				<div className="flex items-center gap-2">
+					<Repeat className="h-4 w-4 text-primary" />
+					<h5 className="text-sm font-semibold text-white">Schedule</h5>
+				</div>
+				{days.map((day) => {
+					const routine = day.routine;
+					const isWorkout = day.day_type === "workout";
+
+					return (
+						<div
+							key={day.day_number}
+							className="rounded-lg border border-secondary bg-surface-2 p-3"
+						>
+							<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+								<div>
+									<div className="mb-1 flex flex-wrap items-center gap-2">
+										<Badge
+											variant={isWorkout ? "default" : "outline"}
+											className={
+												isWorkout
+													? "border-0 bg-primary text-white"
+													: "border-secondary text-muted-foreground"
+											}
+										>
+											Day {day.day_number}
+										</Badge>
+										<h6 className="text-sm font-semibold text-white">
+											{isWorkout ? (routine?.name ?? "Workout") : "Rest Day"}
+										</h6>
+									</div>
+									{isWorkout && routine && (
+										<p className="text-xs text-muted-foreground">
+											{routine.exercise_count} exercises /{" "}
+											{formatStoredDurationMinutes(routine.estimated_duration)}
+										</p>
+									)}
+									{!isWorkout && (
+										<p className="text-xs capitalize text-muted-foreground">
+											{day.rest_type ?? "complete"} rest
+										</p>
+									)}
+								</div>
+								<div className="text-xs text-muted-foreground sm:text-right">
+									{day.weight_adjustment !== 0 && (
+										<p>
+											Weight {day.weight_adjustment > 0 ? "+" : ""}
+											{day.weight_adjustment}%
+										</p>
+									)}
+									{day.rep_modifier !== 0 && (
+										<p>
+											Reps {day.rep_modifier > 0 ? "+" : ""}
+											{day.rep_modifier}
+										</p>
+									)}
+									{day.rest_override != null && (
+										<p>Rest {day.rest_override}s</p>
+									)}
+								</div>
+							</div>
+							{day.notes && (
+								<p className="mt-2 text-xs text-secondary-foreground">
+									{day.notes}
+								</p>
+							)}
+							{isWorkout && <CycleRoutineDetails routine={routine} />}
+						</div>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/src/app/components/community/CommunityDetailDrawer.tsx
+++ b/src/app/components/community/CommunityDetailDrawer.tsx
@@ -9,6 +9,7 @@ import {
 	Link2,
 } from "lucide-react";
 import { useMemo } from "react";
+import { Link } from "react-router";
 import { FeatureHint } from "@/app/components/FeatureHint";
 import { Badge } from "@/app/components/ui/badge";
 import { Button } from "@/app/components/ui/button";
@@ -31,9 +32,21 @@ import { useIsMobile } from "@/app/hooks/useIsMobile";
 import { PHOENIX } from "@/lib/colors";
 import { useSaveItem, useVote } from "@/mutations/community";
 import { useAuth } from "@/providers/AuthProvider";
-import { savedItemsOptions } from "@/queries/community";
-import type { CommunityFeedItem, SharedRoutine } from "@/schemas/community";
+import {
+	communityItemDetailOptions,
+	savedItemsOptions,
+} from "@/queries/community";
+import type {
+	CommunityFeedItem,
+	CommunityItemDetail,
+	SharedRoutine,
+	SharedRoutineDetail,
+} from "@/schemas/community";
 import { CommentThread } from "./CommentThread";
+import {
+	CycleSnapshotPreview,
+	RoutineSnapshotPreview,
+} from "./CommunityContentPreview";
 import { ContentActionMenu } from "./ContentActionMenu";
 
 interface CommunityDetailDrawerProps {
@@ -42,18 +55,33 @@ interface CommunityDetailDrawerProps {
 	onClose: () => void;
 }
 
-function isRoutine(item: CommunityFeedItem): item is SharedRoutine {
+function isRoutine(
+	item: CommunityFeedItem | CommunityItemDetail,
+): item is SharedRoutine | SharedRoutineDetail {
 	return "exercise_count" in item;
 }
 
-function DetailContent({ item }: { item: CommunityFeedItem }) {
+function DetailContent({
+	item,
+	detail,
+	detailLoading,
+	detailError,
+}: {
+	item: CommunityFeedItem;
+	detail: CommunityItemDetail | undefined;
+	detailLoading: boolean;
+	detailError: boolean;
+}) {
 	const { user } = useAuth();
-	const isDeletedUser = item.user_id === null;
+	const displayItem = detail ?? item;
+	const isDeletedUser = displayItem.user_id === null;
 	const authorName = isDeletedUser
 		? "[Deleted User]"
-		: (item.profiles?.display_name ?? "Unknown");
-	const sharedAgo = formatDistanceToNow(item.shared_at, { addSuffix: true });
-	const itemType = isRoutine(item) ? "routine" : "cycle";
+		: (displayItem.profiles?.display_name ?? "Unknown");
+	const sharedAgo = formatDistanceToNow(displayItem.shared_at, {
+		addSuffix: true,
+	});
+	const itemType = isRoutine(displayItem) ? "routine" : "cycle";
 
 	const voteMutation = useVote();
 	const saveMutation = useSaveItem();
@@ -63,10 +91,27 @@ function DetailContent({ item }: { item: CommunityFeedItem }) {
 		enabled: !!user?.id,
 	});
 
-	const isSaved = useMemo(
-		() => savedItems?.some((s) => s.shared_item_id === item.id) ?? false,
-		[savedItems, item.id],
+	const savedItem = useMemo(
+		() =>
+			savedItems?.find(
+				(s) => s.shared_item_id === displayItem.id && s.item_type === itemType,
+			) ?? null,
+		[savedItems, displayItem.id, itemType],
 	);
+	const importedId =
+		itemType === "routine"
+			? savedItem?.imported_routine_id
+			: savedItem?.imported_cycle_id;
+	const isImported = Boolean(importedId);
+	const importedHref =
+		itemType === "routine"
+			? `/routines/${importedId}/view`
+			: `/cycles/${importedId}`;
+	const hasImportableSnapshot = isRoutine(displayItem)
+		? "exercises_snapshot" in displayItem &&
+			Array.isArray(displayItem.exercises_snapshot) &&
+			displayItem.exercises_snapshot.length > 0
+		: "cycle_snapshot" in displayItem && Boolean(displayItem.cycle_snapshot);
 
 	return (
 		<div className="space-y-4">
@@ -83,21 +128,23 @@ function DetailContent({ item }: { item: CommunityFeedItem }) {
 				</div>
 				{user && (
 					<ContentActionMenu
-						contentId={item.id}
+						contentId={displayItem.id}
 						contentType={itemType}
-						authorId={item.user_id}
+						authorId={displayItem.user_id}
 						currentUserId={user.id}
 					/>
 				)}
 			</div>
 
 			{/* Description */}
-			<p className="text-sm text-secondary-foreground">{item.description}</p>
+			<p className="text-sm text-secondary-foreground">
+				{displayItem.description}
+			</p>
 
 			{/* Tags */}
-			{item.tags.length > 0 && (
+			{displayItem.tags.length > 0 && (
 				<div className="flex flex-wrap gap-1.5">
-					{item.tags.map((tag) => (
+					{displayItem.tags.map((tag) => (
 						<Badge
 							key={tag}
 							className="bg-secondary text-secondary-foreground border-0 text-xs"
@@ -110,91 +157,107 @@ function DetailContent({ item }: { item: CommunityFeedItem }) {
 
 			{/* Stats */}
 			<div className="flex items-center gap-4 text-sm text-muted-foreground">
-				{isRoutine(item) ? (
+				{isRoutine(displayItem) ? (
 					<>
 						<div className="flex items-center gap-1">
 							<Dumbbell className="w-4 h-4" />
-							<span>{item.exercise_count} exercises</span>
+							<span>{displayItem.exercise_count} exercises</span>
 						</div>
 						<div className="flex items-center gap-1">
 							<Clock className="w-4 h-4" />
-							<span>{item.estimated_duration} min</span>
+							<span>{displayItem.estimated_duration} min</span>
 						</div>
 					</>
 				) : (
 					<div className="flex items-center gap-1">
 						<Calendar className="w-4 h-4" />
-						<span>{item.duration_weeks} weeks</span>
+						<span>{displayItem.duration_weeks} days</span>
 					</div>
 				)}
 			</div>
 
-			{/* Exercise list preview for routines */}
-			{isRoutine(item) && item.exercises_snapshot && (
-				<div>
-					<h4 className="text-sm font-semibold text-white mb-2">Exercises</h4>
-					<div className="space-y-1.5">
-						{(Array.isArray(item.exercises_snapshot)
-							? (item.exercises_snapshot as Array<{ name?: string }>)
-							: []
-						)
-							.slice(0, 6)
-							.map((ex, i) => (
-								<div
-									// biome-ignore lint/suspicious/noArrayIndexKey: snapshot array with no unique IDs, never reorders
-									key={i}
-									className="flex items-center gap-2 p-2 bg-surface-2 rounded-md text-sm"
-								>
-									<span className="text-muted-foreground w-5 text-right">
-										{i + 1}
-									</span>
-									<span className="text-white">
-										{typeof ex === "object" && ex?.name
-											? ex.name
-											: `Exercise ${i + 1}`}
-									</span>
-								</div>
-							))}
-					</div>
+			{detailLoading ? (
+				<div className="rounded-lg border border-secondary bg-surface-2 p-4 text-sm text-muted-foreground">
+					Loading full details...
 				</div>
+			) : detailError ? (
+				<div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+					Full details could not be loaded.
+				</div>
+			) : isRoutine(displayItem) ? (
+				<RoutineSnapshotPreview
+					exercises={
+						"exercises_snapshot" in displayItem
+							? displayItem.exercises_snapshot
+							: null
+					}
+				/>
+			) : (
+				<CycleSnapshotPreview
+					snapshot={
+						"cycle_snapshot" in displayItem ? displayItem.cycle_snapshot : null
+					}
+				/>
 			)}
 
 			{/* Vote + Save actions */}
 			<div className="flex items-center gap-3 pt-2">
 				<Button
 					variant="outline"
-					onClick={() => voteMutation.mutate({ itemId: item.id, itemType })}
+					onClick={() =>
+						voteMutation.mutate({ itemId: displayItem.id, itemType })
+					}
 					disabled={voteMutation.isPending}
 					className="flex-1 border-secondary text-muted-foreground hover:border-primary hover:text-white"
 				>
 					<ArrowBigUp className="w-5 h-5 mr-1.5" />
-					{item.vote_count}
+					{displayItem.vote_count}
 				</Button>
-				<Button
-					variant="outline"
-					onClick={() =>
-						saveMutation.mutate({ sharedItemId: item.id, itemType })
-					}
-					disabled={saveMutation.isPending}
-					className={`flex-1 border-secondary transition-colors ${
-						isSaved
-							? "text-primary border-primary/50"
-							: "text-muted-foreground hover:border-primary hover:text-white"
-					}`}
-				>
-					<Bookmark
-						className="w-4 h-4 mr-1.5"
-						fill={isSaved ? PHOENIX.ember : "none"}
-					/>
-					{isSaved ? "Saved" : "Save"}
-				</Button>
+				{isImported && importedId ? (
+					<Button
+						asChild
+						variant="outline"
+						className="flex-1 border-primary/50 text-primary transition-colors"
+					>
+						<Link to={importedHref}>
+							<Bookmark className="w-4 h-4 mr-1.5" fill={PHOENIX.ember} />
+							{itemType === "routine"
+								? "Saved to My Routines"
+								: "Saved to My Cycles"}
+						</Link>
+					</Button>
+				) : (
+					<Button
+						variant="outline"
+						onClick={() =>
+							saveMutation.mutate({ sharedItemId: displayItem.id, itemType })
+						}
+						disabled={
+							saveMutation.isPending ||
+							detailLoading ||
+							detailError ||
+							!hasImportableSnapshot
+						}
+						className="flex-1 border-secondary text-muted-foreground transition-colors hover:border-primary hover:text-white"
+					>
+						<Bookmark className="w-4 h-4 mr-1.5" />
+						{saveMutation.isPending
+							? "Saving..."
+							: itemType === "routine"
+								? "Save to My Routines"
+								: "Save to My Cycles"}
+					</Button>
+				)}
 			</div>
 
 			{/* Linked reference indicator */}
-			{isSaved && (
+			{isImported && (
 				<div className="flex items-center gap-1.5 text-xs text-muted-foreground pt-1">
 					<Link2 className="w-3 h-3" />
-					<span>Linked to original</span>
+					<span>
+						Imported as an editable copy. Community comments stay linked to the
+						original share.
+					</span>
 				</div>
 			)}
 		</div>
@@ -207,6 +270,11 @@ export function CommunityDetailDrawer({
 	onClose,
 }: CommunityDetailDrawerProps) {
 	const isMobile = useIsMobile();
+	const itemType = item && isRoutine(item) ? "routine" : "cycle";
+	const detailQuery = useQuery({
+		...communityItemDetailOptions(itemType, item?.id ?? ""),
+		enabled: open && !!item,
+	});
 
 	if (!item) return null;
 
@@ -223,7 +291,12 @@ export function CommunityDetailDrawer({
 						</DrawerDescription>
 					</DrawerHeader>
 					<div className="px-4 pb-4 overflow-y-auto">
-						<DetailContent item={item} />
+						<DetailContent
+							item={item}
+							detail={detailQuery.data}
+							detailLoading={detailQuery.isLoading}
+							detailError={detailQuery.isError}
+						/>
 						<div className="mt-4 pt-4 border-t border-secondary">
 							<CommentThread
 								itemId={item.id}
@@ -246,7 +319,12 @@ export function CommunityDetailDrawer({
 						{item.difficulty} {isRoutine(item) ? "Routine" : "Cycle"}
 					</DialogDescription>
 				</DialogHeader>
-				<DetailContent item={item} />
+				<DetailContent
+					item={item}
+					detail={detailQuery.data}
+					detailLoading={detailQuery.isLoading}
+					detailError={detailQuery.isError}
+				/>
 				<FeatureHint
 					hintId="community-comments"
 					content="Join the discussion -- share feedback on routines and training cycles"

--- a/src/app/components/community/CommunityDetailDrawer.tsx
+++ b/src/app/components/community/CommunityDetailDrawer.tsx
@@ -171,7 +171,7 @@ function DetailContent({
 				) : (
 					<div className="flex items-center gap-1">
 						<Calendar className="w-4 h-4" />
-						<span>{displayItem.duration_weeks} days</span>
+						<span>{displayItem.duration_weeks} weeks</span>
 					</div>
 				)}
 			</div>

--- a/src/app/components/community/CommunityFeedCard.tsx
+++ b/src/app/components/community/CommunityFeedCard.tsx
@@ -127,12 +127,7 @@ export function CommunityFeedCard({
 							</div>
 							<div className="flex items-center gap-1">
 								<Clock className="w-3.5 h-3.5" />
-								<span>
-									{item.estimated_duration > 300
-										? Math.round(item.estimated_duration / 60)
-										: item.estimated_duration}{" "}
-									min
-								</span>
+								<span>{item.estimated_duration} min</span>
 							</div>
 						</>
 					) : (

--- a/src/app/components/community/ShareContentDialog.tsx
+++ b/src/app/components/community/ShareContentDialog.tsx
@@ -224,7 +224,7 @@ export function ShareContentDialog({
 								<p className="text-xs text-muted-foreground">
 									{selectedSource.exercise_count ?? 0} exercises
 									{selectedSource.estimated_duration
-										? ` / ~${selectedSource.estimated_duration > 300 ? Math.round(selectedSource.estimated_duration / 60) : selectedSource.estimated_duration} min`
+										? ` / ~${selectedSource.estimated_duration} min`
 										: ""}
 								</p>
 							)}

--- a/src/app/components/community/ShareContentDialog.tsx
+++ b/src/app/components/community/ShareContentDialog.tsx
@@ -42,7 +42,6 @@ interface SourceItem {
 	name: string;
 	exercise_count?: number;
 	estimated_duration?: number;
-	exercises_snapshot?: unknown;
 	duration_weeks?: number;
 }
 
@@ -129,14 +128,6 @@ export function ShareContentDialog({
 				description,
 				tags,
 				difficulty: difficulty as "Beginner" | "Intermediate" | "Advanced",
-				exerciseCount: selectedSource?.exercise_count,
-				estimatedDuration: selectedSource?.estimated_duration,
-				exercisesSnapshot:
-					contentType === "routine"
-						? selectedSource?.exercises_snapshot
-						: undefined,
-				durationWeeks:
-					contentType === "cycle" ? selectedSource?.duration_weeks : undefined,
 			},
 			{
 				onSuccess: () => {

--- a/src/app/components/community/__tests__/CommunityContentPreview.test.tsx
+++ b/src/app/components/community/__tests__/CommunityContentPreview.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	CycleSnapshotPreview,
+	RoutineSnapshotPreview,
+} from "../CommunityContentPreview";
+
+describe("CommunityContentPreview", () => {
+	it("renders full routine exercise details from a snapshot", () => {
+		render(
+			<RoutineSnapshotPreview
+				exercises={[
+					{
+						name: "Bench Press",
+						muscle_group: "Chest",
+						sets: 3,
+						reps: 8,
+						weight: 40,
+						rest_seconds: 90,
+						duration_seconds: null,
+						mode: "OLD_SCHOOL",
+						order_index: 0,
+						per_set_weights: [40, 42.5, 45],
+						per_set_reps: [8, 8, 6],
+						per_set_rest: [90, 90, 120],
+						is_amrap: false,
+						is_bodyweight: false,
+						stall_detection: true,
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Bench Press")).toBeInTheDocument();
+		expect(screen.getByText(/3 sets \/ 8 reps/i)).toBeInTheDocument();
+		expect(screen.getByText(/Weights:/i)).toBeInTheDocument();
+		expect(screen.getByText(/Rest: 90s between sets/i)).toBeInTheDocument();
+	});
+
+	it("renders cycle days, overrides, and embedded routine details", () => {
+		render(
+			<CycleSnapshotPreview
+				snapshot={{
+					duration_weeks: 7,
+					workout_days: 1,
+					rest_days: 1,
+					progression_settings: { type: "percentage", amount: 5 },
+					deload_settings: null,
+					days: [
+						{
+							day_number: 1,
+							day_type: "workout",
+							routine_id: "routine-1",
+							weight_adjustment: 5,
+							rep_modifier: 1,
+							rest_override: 120,
+							notes: "Push emphasis",
+							rest_type: null,
+							routine: {
+								source_routine_id: "routine-1",
+								name: "Push Routine",
+								description: "Upper body",
+								exercise_count: 1,
+								estimated_duration: 2700,
+								tags: ["Chest"],
+								exercises: [
+									{
+										name: "Bench Press",
+										muscle_group: "Chest",
+										sets: 3,
+										reps: 8,
+										weight: 40,
+										rest_seconds: 90,
+										mode: "OLD_SCHOOL",
+										order_index: 0,
+									},
+								],
+							},
+						},
+						{
+							day_number: 2,
+							day_type: "rest",
+							routine_id: null,
+							weight_adjustment: 0,
+							rep_modifier: 0,
+							rest_override: null,
+							notes: null,
+							rest_type: "complete",
+						},
+					],
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Cycle Details")).toBeInTheDocument();
+		expect(screen.getByText("Push Routine")).toBeInTheDocument();
+		expect(screen.getByText("Push emphasis")).toBeInTheDocument();
+		expect(screen.getByText("View Push Routine")).toBeInTheDocument();
+		expect(screen.getByText("Rest Day")).toBeInTheDocument();
+	});
+});

--- a/src/app/components/community/__tests__/CommunityContentPreview.test.tsx
+++ b/src/app/components/community/__tests__/CommunityContentPreview.test.tsx
@@ -37,6 +37,64 @@ describe("CommunityContentPreview", () => {
 		expect(screen.getByText(/Rest: 90s between sets/i)).toBeInTheDocument();
 	});
 
+	it("keeps exercise numbering sequential when supersets are rendered", () => {
+		render(
+			<RoutineSnapshotPreview
+				exercises={[
+					{
+						name: "Back Squat",
+						muscle_group: "Legs",
+						sets: 3,
+						reps: 5,
+						weight: 80,
+						rest_seconds: 120,
+						mode: "OLD_SCHOOL",
+						order_index: 0,
+					},
+					{
+						name: "Pull Up",
+						muscle_group: "Back",
+						sets: 3,
+						reps: 8,
+						weight: 0,
+						rest_seconds: 90,
+						mode: "OLD_SCHOOL",
+						order_index: 1,
+						superset_id: "superset-a",
+						superset_order: 0,
+					},
+					{
+						name: "Push Up",
+						muscle_group: "Chest",
+						sets: 3,
+						reps: 12,
+						weight: 0,
+						rest_seconds: 90,
+						mode: "OLD_SCHOOL",
+						order_index: 2,
+						superset_id: "superset-a",
+						superset_order: 1,
+					},
+					{
+						name: "Plank",
+						muscle_group: "Core",
+						sets: 3,
+						reps: 1,
+						weight: 0,
+						rest_seconds: 60,
+						duration_seconds: 45,
+						mode: "OLD_SCHOOL",
+						order_index: 3,
+					},
+				]}
+			/>,
+		);
+
+		expect(
+			screen.getAllByText(/^\d\d$/).map((node) => node.textContent),
+		).toEqual(["01", "02", "03", "04"]);
+	});
+
 	it("renders cycle days, overrides, and embedded routine details", () => {
 		render(
 			<CycleSnapshotPreview
@@ -61,7 +119,7 @@ describe("CommunityContentPreview", () => {
 								name: "Push Routine",
 								description: "Upper body",
 								exercise_count: 1,
-								estimated_duration: 2700,
+								estimated_duration: 150,
 								tags: ["Chest"],
 								exercises: [
 									{
@@ -93,7 +151,9 @@ describe("CommunityContentPreview", () => {
 		);
 
 		expect(screen.getByText("Cycle Details")).toBeInTheDocument();
+		expect(screen.getByText("7 weeks")).toBeInTheDocument();
 		expect(screen.getByText("Push Routine")).toBeInTheDocument();
+		expect(screen.getByText(/1 exercises \/ 3 min/i)).toBeInTheDocument();
 		expect(screen.getByText("Push emphasis")).toBeInTheDocument();
 		expect(screen.getByText("View Push Routine")).toBeInTheDocument();
 		expect(screen.getByText("Rest Day")).toBeInTheDocument();

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1273,6 +1273,8 @@ export type Database = {
 			saved_community_items: {
 				Row: {
 					id: string;
+					imported_cycle_id: string | null;
+					imported_routine_id: string | null;
 					item_type: string;
 					saved_at: string;
 					shared_item_id: string;
@@ -1280,6 +1282,8 @@ export type Database = {
 				};
 				Insert: {
 					id?: string;
+					imported_cycle_id?: string | null;
+					imported_routine_id?: string | null;
 					item_type: string;
 					saved_at?: string;
 					shared_item_id: string;
@@ -1287,6 +1291,8 @@ export type Database = {
 				};
 				Update: {
 					id?: string;
+					imported_cycle_id?: string | null;
+					imported_routine_id?: string | null;
 					item_type?: string;
 					saved_at?: string;
 					shared_item_id?: string;
@@ -1412,6 +1418,7 @@ export type Database = {
 			shared_cycles: {
 				Row: {
 					comment_count: number;
+					cycle_snapshot: Json | null;
 					cycle_id: string;
 					description: string;
 					difficulty: string;
@@ -1428,6 +1435,7 @@ export type Database = {
 				};
 				Insert: {
 					comment_count?: number;
+					cycle_snapshot?: Json | null;
 					cycle_id: string;
 					description?: string;
 					difficulty?: string;
@@ -1444,6 +1452,7 @@ export type Database = {
 				};
 				Update: {
 					comment_count?: number;
+					cycle_snapshot?: Json | null;
 					cycle_id?: string;
 					description?: string;
 					difficulty?: string;
@@ -2496,6 +2505,20 @@ export type Database = {
 			get_workout_streak: {
 				Args: { p_profile_id?: string; p_user_id: string };
 				Returns: number;
+			};
+			import_shared_cycle: {
+				Args: {
+					p_local_profile_id?: string | null;
+					p_shared_cycle_id: string;
+				};
+				Returns: string;
+			};
+			import_shared_routine: {
+				Args: {
+					p_local_profile_id?: string | null;
+					p_shared_routine_id: string;
+				};
+				Returns: string;
 			};
 			refresh_community_benchmarks: { Args: never; Returns: undefined };
 			refresh_hot_scores: { Args: never; Returns: undefined };

--- a/src/mutations/__tests__/community.test.tsx
+++ b/src/mutations/__tests__/community.test.tsx
@@ -217,6 +217,49 @@ describe("useShareContent", () => {
 		});
 	});
 
+	it("converts short raw routine durations from seconds to shared minutes", async () => {
+		const { useShareContent } = await import("../community");
+
+		const single = vi.fn().mockResolvedValue({
+			data: {
+				id: "routine-1",
+				user_id: "test-user-id",
+				name: "Short Routine",
+				description: "Source description",
+				exercise_count: 1,
+				estimated_duration: 150,
+				tags: [],
+				routine_exercises: [],
+			},
+			error: null,
+		});
+		const order = vi.fn(() => ({ single }));
+		const eqUserId = vi.fn(() => ({ order }));
+		const eqRoutineId = vi.fn(() => ({ eq: eqUserId }));
+		mockChain.select.mockReturnValue({ eq: eqRoutineId });
+		mockChain.insert.mockResolvedValue({ error: null });
+
+		const { wrapper } = createWrapper();
+		const { result } = renderHook(() => useShareContent(), { wrapper });
+
+		result.current.mutate({
+			type: "routine",
+			sourceId: "routine-1",
+			name: "Short Routine",
+			description: "Shared routine",
+			tags: [],
+			difficulty: "Beginner",
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(mockChain.insert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				estimated_duration: 3,
+			}),
+		);
+	});
+
 	it("inserts into shared_cycles for cycle type", async () => {
 		const { useShareContent } = await import("../community");
 

--- a/src/mutations/__tests__/community.test.tsx
+++ b/src/mutations/__tests__/community.test.tsx
@@ -16,9 +16,10 @@ const mockChain = {
 };
 
 const from = vi.fn(() => mockChain);
+const rpc = vi.fn();
 
 vi.mock("@/lib/supabase", () => ({
-	supabase: { from },
+	supabase: { from, rpc },
 }));
 
 vi.mock("@/providers/AuthProvider", () => ({
@@ -137,6 +138,52 @@ describe("useShareContent", () => {
 	it("inserts into shared_routines for routine type and invalidates feed", async () => {
 		const { useShareContent } = await import("../community");
 
+		const single = vi.fn().mockResolvedValue({
+			data: {
+				id: "routine-1",
+				user_id: "test-user-id",
+				name: "Source Routine",
+				description: "Source description",
+				exercise_count: 1,
+				estimated_duration: 2700,
+				tags: ["Chest"],
+				routine_exercises: [
+					{
+						name: "Bench Press",
+						muscle_group: "Chest",
+						exercise_id: null,
+						sets: 3,
+						reps: 8,
+						weight: 40,
+						rest_seconds: 90,
+						duration_seconds: null,
+						mode: "OLD_SCHOOL",
+						order_index: 0,
+						superset_id: null,
+						superset_color: null,
+						superset_order: null,
+						per_set_weights: null,
+						per_set_rest: null,
+						per_set_reps: null,
+						per_set_echo_levels: null,
+						is_amrap: false,
+						is_bodyweight: false,
+						pr_percentage: null,
+						rep_count_timing: null,
+						stop_at_position: null,
+						stall_detection: true,
+						eccentric_load: null,
+						echo_level: null,
+						warmup_sets: null,
+					},
+				],
+			},
+			error: null,
+		});
+		const order = vi.fn(() => ({ single }));
+		const eqUserId = vi.fn(() => ({ order }));
+		const eqRoutineId = vi.fn(() => ({ eq: eqUserId }));
+		mockChain.select.mockReturnValue({ eq: eqRoutineId });
 		mockChain.insert.mockResolvedValue({ error: null });
 
 		const { queryClient, wrapper } = createWrapper();
@@ -151,13 +198,20 @@ describe("useShareContent", () => {
 			description: "Shared routine",
 			tags: ["Chest"],
 			difficulty: "Intermediate",
-			exerciseCount: 5,
-			estimatedDuration: 45,
 		});
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		expect(from).toHaveBeenCalledWith("shared_routines");
+		expect(mockChain.insert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				exercise_count: 1,
+				estimated_duration: 45,
+				exercises_snapshot: [
+					expect.objectContaining({ name: "Bench Press", weight: 40 }),
+				],
+			}),
+		);
 		expect(invalidateSpy).toHaveBeenCalledWith({
 			queryKey: queryKeys.community.all,
 		});
@@ -166,6 +220,65 @@ describe("useShareContent", () => {
 	it("inserts into shared_cycles for cycle type", async () => {
 		const { useShareContent } = await import("../community");
 
+		const cycleSingle = vi.fn().mockResolvedValue({
+			data: {
+				id: "cycle-1",
+				user_id: "test-user-id",
+				name: "Source Cycle",
+				description: "Cycle source",
+				duration_weeks: 7,
+				workout_days: 1,
+				rest_days: 1,
+				progression_settings: { type: "percentage" },
+				deload_settings: null,
+				cycle_days: [
+					{
+						day_number: 1,
+						day_type: "workout",
+						routine_id: "routine-1",
+						weight_adjustment: 5,
+						rep_modifier: 0,
+						rest_override: null,
+						notes: "Push day",
+						rest_type: null,
+					},
+					{
+						day_number: 2,
+						day_type: "rest",
+						routine_id: null,
+						weight_adjustment: 0,
+						rep_modifier: 0,
+						rest_override: null,
+						notes: null,
+						rest_type: "complete",
+					},
+				],
+			},
+			error: null,
+		});
+		const cycleOrder = vi.fn(() => ({ single: cycleSingle }));
+		const cycleEqUserId = vi.fn(() => ({ order: cycleOrder }));
+		const cycleEqId = vi.fn(() => ({ eq: cycleEqUserId }));
+		const routinesOrder = vi.fn().mockResolvedValue({
+			data: [
+				{
+					id: "routine-1",
+					user_id: "test-user-id",
+					name: "Push Routine",
+					description: "Push",
+					exercise_count: 1,
+					estimated_duration: 2700,
+					tags: ["Chest"],
+					routine_exercises: [],
+				},
+			],
+			error: null,
+		});
+		const routinesIn = vi.fn(() => ({ order: routinesOrder }));
+		const routinesEqUserId = vi.fn(() => ({ in: routinesIn }));
+		mockChain.select
+			.mockReturnValueOnce({ eq: cycleEqId })
+			.mockReturnValueOnce({ eq: routinesEqUserId });
 		mockChain.insert.mockResolvedValue({ error: null });
 
 		const { wrapper } = createWrapper();
@@ -178,17 +291,47 @@ describe("useShareContent", () => {
 			description: "Shared cycle",
 			tags: ["Strength"],
 			difficulty: "Advanced",
-			durationWeeks: 6,
 		});
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
 		expect(from).toHaveBeenCalledWith("shared_cycles");
+		expect(mockChain.insert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				duration_weeks: 7,
+				cycle_snapshot: expect.objectContaining({
+					duration_weeks: 7,
+					days: expect.arrayContaining([
+						expect.objectContaining({
+							day_number: 1,
+							routine: expect.objectContaining({ name: "Push Routine" }),
+						}),
+					]),
+				}),
+			}),
+		);
 	});
 
 	it("shows user-friendly error on share failure", async () => {
 		const { useShareContent } = await import("../community");
 
+		const single = vi.fn().mockResolvedValue({
+			data: {
+				id: "routine-1",
+				user_id: "test-user-id",
+				name: "Source Routine",
+				description: "",
+				exercise_count: 0,
+				estimated_duration: 0,
+				tags: [],
+				routine_exercises: [],
+			},
+			error: null,
+		});
+		const order = vi.fn(() => ({ single }));
+		const eqUserId = vi.fn(() => ({ order }));
+		const eqRoutineId = vi.fn(() => ({ eq: eqUserId }));
+		mockChain.select.mockReturnValue({ eq: eqRoutineId });
 		mockChain.insert.mockResolvedValue({
 			error: { message: "already shared this routine", code: "23505" },
 		});
@@ -488,16 +631,10 @@ describe("useSaveItem", () => {
 		vi.clearAllMocks();
 	});
 
-	it("saves an item when not already saved and invalidates saves cache", async () => {
+	it("imports a routine into the personal library and invalidates affected caches", async () => {
 		const { useSaveItem } = await import("../community");
 
-		// select chain: not saved yet
-		const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
-		const eqItemType = vi.fn(() => ({ maybeSingle }));
-		const eqSharedItemId = vi.fn(() => ({ eq: eqItemType }));
-		const eqUserId = vi.fn(() => ({ eq: eqSharedItemId }));
-		mockChain.select.mockReturnValue({ eq: eqUserId });
-		mockChain.insert.mockResolvedValue({ error: null });
+		rpc.mockResolvedValue({ data: "imported-routine-1", error: null });
 
 		const { queryClient, wrapper } = createWrapper();
 		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
@@ -508,36 +645,49 @@ describe("useSaveItem", () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(from).toHaveBeenCalledWith("saved_community_items");
-		expect(result.current.data).toEqual({ action: "saved" });
+		expect(rpc).toHaveBeenCalledWith("import_shared_routine", {
+			p_shared_routine_id: "shared-1",
+			p_local_profile_id: null,
+		});
+		expect(result.current.data).toEqual({
+			action: "imported",
+			importedId: "imported-routine-1",
+			itemType: "routine",
+		});
 		expect(invalidateSpy).toHaveBeenCalledWith({
 			queryKey: queryKeys.community.saves("test-user-id"),
 		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.community.all,
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.routines.all,
+		});
+		expect(invalidateSpy).toHaveBeenCalledWith({
+			queryKey: queryKeys.cycles.all,
+		});
 	});
 
-	it("unsaves an item when already saved", async () => {
+	it("imports a cycle through the cycle import RPC", async () => {
 		const { useSaveItem } = await import("../community");
 
-		// select chain: already saved
-		const maybeSingle = vi.fn().mockResolvedValue({
-			data: { id: "save-1" },
-			error: null,
-		});
-		const eqItemType = vi.fn(() => ({ maybeSingle }));
-		const eqSharedItemId = vi.fn(() => ({ eq: eqItemType }));
-		const eqUserId = vi.fn(() => ({ eq: eqSharedItemId }));
-		mockChain.select.mockReturnValue({ eq: eqUserId });
-		mockChain.delete.mockImplementation(() => ({
-			eq: vi.fn(() => Promise.resolve({ error: null })),
-		}));
+		rpc.mockResolvedValue({ data: "imported-cycle-1", error: null });
 
 		const { wrapper } = createWrapper();
 		const { result } = renderHook(() => useSaveItem(), { wrapper });
 
-		result.current.mutate({ sharedItemId: "shared-1", itemType: "routine" });
+		result.current.mutate({ sharedItemId: "shared-2", itemType: "cycle" });
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(result.current.data).toEqual({ action: "unsaved" });
+		expect(rpc).toHaveBeenCalledWith("import_shared_cycle", {
+			p_shared_cycle_id: "shared-2",
+			p_local_profile_id: null,
+		});
+		expect(result.current.data).toEqual({
+			action: "imported",
+			importedId: "imported-cycle-1",
+			itemType: "cycle",
+		});
 	});
 });

--- a/src/mutations/community.ts
+++ b/src/mutations/community.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import type { Database, Json } from "@/lib/database.types";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/providers/AuthProvider";
 import { queryKeys } from "@/queries/keys";
+import { useProfileFilterStore } from "@/stores/useProfileFilterStore";
 
 // ---------- useVote (confirmed pattern) ----------
 
@@ -71,10 +73,136 @@ interface ShareContentArgs {
 	description: string;
 	tags: string[];
 	difficulty: "Beginner" | "Intermediate" | "Advanced";
-	exerciseCount?: number;
-	estimatedDuration?: number;
-	exercisesSnapshot?: unknown;
-	durationWeeks?: number;
+}
+
+type RoutineRow = Database["public"]["Tables"]["routines"]["Row"];
+type RoutineExerciseRow =
+	Database["public"]["Tables"]["routine_exercises"]["Row"];
+type TrainingCycleRow = Database["public"]["Tables"]["training_cycles"]["Row"];
+type CycleDayRow = Database["public"]["Tables"]["cycle_days"]["Row"];
+
+type RoutineWithExercises = RoutineRow & {
+	routine_exercises?: RoutineExerciseRow[];
+};
+
+type CycleWithDays = TrainingCycleRow & {
+	cycle_days?: CycleDayRow[];
+};
+
+function toSharedDurationMinutes(duration: number | null | undefined): number {
+	if (!duration) return 0;
+	return duration > 300 ? Math.round(duration / 60) : Math.round(duration);
+}
+
+function routineExerciseSnapshot(exercise: RoutineExerciseRow) {
+	return {
+		name: exercise.name,
+		muscle_group: exercise.muscle_group,
+		exercise_id: exercise.exercise_id,
+		sets: exercise.sets,
+		reps: exercise.reps,
+		weight: exercise.weight,
+		rest_seconds: exercise.rest_seconds,
+		duration_seconds: exercise.duration_seconds,
+		mode: exercise.mode,
+		order_index: exercise.order_index,
+		superset_id: exercise.superset_id,
+		superset_color: exercise.superset_color,
+		superset_order: exercise.superset_order,
+		per_set_weights: exercise.per_set_weights,
+		per_set_rest: exercise.per_set_rest,
+		per_set_reps: exercise.per_set_reps,
+		per_set_echo_levels: exercise.per_set_echo_levels,
+		is_amrap: exercise.is_amrap,
+		is_bodyweight: exercise.is_bodyweight,
+		pr_percentage: exercise.pr_percentage,
+		rep_count_timing: exercise.rep_count_timing,
+		stop_at_position: exercise.stop_at_position,
+		stall_detection: exercise.stall_detection,
+		eccentric_load: exercise.eccentric_load,
+		echo_level: exercise.echo_level,
+		warmup_sets: exercise.warmup_sets,
+	};
+}
+
+function routineSnapshot(routine: RoutineWithExercises) {
+	const exercises = [...(routine.routine_exercises ?? [])]
+		.sort((a, b) => a.order_index - b.order_index)
+		.map(routineExerciseSnapshot);
+
+	return {
+		source_routine_id: routine.id,
+		name: routine.name,
+		description: routine.description,
+		exercise_count: routine.exercise_count,
+		estimated_duration: routine.estimated_duration,
+		tags: routine.tags ?? [],
+		exercises,
+	};
+}
+
+async function fetchRoutineWithExercises(
+	routineId: string,
+	userId: string,
+): Promise<RoutineWithExercises> {
+	const { data, error } = await supabase
+		.from("routines")
+		.select("*, routine_exercises(*)")
+		.eq("id", routineId)
+		.eq("user_id", userId)
+		.order("order_index", {
+			referencedTable: "routine_exercises",
+			ascending: true,
+		})
+		.single();
+
+	if (error) throw error;
+	return data as RoutineWithExercises;
+}
+
+async function fetchCycleWithDays(
+	cycleId: string,
+	userId: string,
+): Promise<CycleWithDays> {
+	const { data, error } = await supabase
+		.from("training_cycles")
+		.select("*, cycle_days(*)")
+		.eq("id", cycleId)
+		.eq("user_id", userId)
+		.order("day_number", {
+			referencedTable: "cycle_days",
+			ascending: true,
+		})
+		.single();
+
+	if (error) throw error;
+	return data as CycleWithDays;
+}
+
+async function fetchRoutinesById(
+	routineIds: string[],
+	userId: string,
+): Promise<Map<string, RoutineWithExercises>> {
+	if (routineIds.length === 0) return new Map();
+
+	const { data, error } = await supabase
+		.from("routines")
+		.select("*, routine_exercises(*)")
+		.eq("user_id", userId)
+		.in("id", routineIds)
+		.order("order_index", {
+			referencedTable: "routine_exercises",
+			ascending: true,
+		});
+
+	if (error) throw error;
+
+	return new Map(
+		((data ?? []) as RoutineWithExercises[]).map((routine) => [
+			routine.id,
+			routine,
+		]),
+	);
 }
 
 export function useShareContent() {
@@ -86,6 +214,11 @@ export function useShareContent() {
 			if (!user) throw new Error("Must be logged in to share");
 
 			if (args.type === "routine") {
+				const routine = await fetchRoutineWithExercises(args.sourceId, user.id);
+				const exercisesSnapshot = (routine.routine_exercises ?? [])
+					.sort((a, b) => a.order_index - b.order_index)
+					.map(routineExerciseSnapshot);
+
 				const { error } = await supabase.from("shared_routines").insert({
 					user_id: user.id,
 					routine_id: args.sourceId,
@@ -93,12 +226,52 @@ export function useShareContent() {
 					description: args.description,
 					tags: args.tags,
 					difficulty: args.difficulty,
-					exercise_count: args.exerciseCount ?? 0,
-					estimated_duration: args.estimatedDuration ?? 0,
-					exercises_snapshot: args.exercisesSnapshot ?? null,
+					exercise_count: routine.exercise_count ?? exercisesSnapshot.length,
+					estimated_duration: toSharedDurationMinutes(
+						routine.estimated_duration,
+					),
+					exercises_snapshot: exercisesSnapshot as Json,
 				});
 				if (error) throw error;
 			} else {
+				const cycle = await fetchCycleWithDays(args.sourceId, user.id);
+				const days = [...(cycle.cycle_days ?? [])].sort(
+					(a, b) => a.day_number - b.day_number,
+				);
+				const routineIds = [
+					...new Set(
+						days
+							.map((day) => day.routine_id)
+							.filter((id): id is string => id !== null),
+					),
+				];
+				const routineMap = await fetchRoutinesById(routineIds, user.id);
+				const cycleSnapshot = {
+					duration_weeks: cycle.duration_weeks,
+					workout_days: cycle.workout_days,
+					rest_days: cycle.rest_days,
+					progression_settings: cycle.progression_settings,
+					deload_settings: cycle.deload_settings,
+					days: days.map((day) => {
+						const embeddedRoutine = day.routine_id
+							? routineMap.get(day.routine_id)
+							: undefined;
+						return {
+							day_number: day.day_number,
+							day_type: day.day_type,
+							routine_id: day.routine_id,
+							weight_adjustment: day.weight_adjustment,
+							rep_modifier: day.rep_modifier,
+							rest_override: day.rest_override,
+							notes: day.notes,
+							rest_type: day.rest_type,
+							routine: embeddedRoutine
+								? routineSnapshot(embeddedRoutine)
+								: null,
+						};
+					}),
+				};
+
 				const { error } = await supabase.from("shared_cycles").insert({
 					user_id: user.id,
 					cycle_id: args.sourceId,
@@ -106,7 +279,8 @@ export function useShareContent() {
 					description: args.description,
 					tags: args.tags,
 					difficulty: args.difficulty,
-					duration_weeks: args.durationWeeks ?? 0,
+					duration_weeks: cycle.duration_weeks,
+					cycle_snapshot: cycleSnapshot as Json,
 				});
 				if (error) throw error;
 			}
@@ -381,43 +555,45 @@ export function useSaveItem() {
 		mutationFn: async ({ sharedItemId, itemType }: SaveItemArgs) => {
 			if (!user) throw new Error("Must be logged in to save");
 
-			// Check if already saved
-			const { data: existing, error: checkError } = await supabase
-				.from("saved_community_items")
-				.select("id")
-				.eq("user_id", user.id)
-				.eq("shared_item_id", sharedItemId)
-				.eq("item_type", itemType)
-				.maybeSingle();
+			const activeProfileId = useProfileFilterStore.getState().activeProfileId;
+			const { data, error } =
+				itemType === "routine"
+					? await supabase.rpc("import_shared_routine", {
+							p_shared_routine_id: sharedItemId,
+							p_local_profile_id: activeProfileId,
+						})
+					: await supabase.rpc("import_shared_cycle", {
+							p_shared_cycle_id: sharedItemId,
+							p_local_profile_id: activeProfileId,
+						});
 
-			if (checkError) throw checkError;
-
-			if (existing) {
-				// Remove save (linked reference)
-				const { error } = await supabase
-					.from("saved_community_items")
-					.delete()
-					.eq("id", existing.id);
-				if (error) throw error;
-				return { action: "unsaved" as const };
-			} else {
-				// Create linked reference (FK to shared_routines/shared_cycles, NOT a data copy)
-				const { error } = await supabase.from("saved_community_items").insert({
-					user_id: user.id,
-					shared_item_id: sharedItemId,
-					item_type: itemType,
-				});
-				if (error) throw error;
-				return { action: "saved" as const };
-			}
+			if (error) throw error;
+			return {
+				action: "imported" as const,
+				importedId: data as string,
+				itemType,
+			};
 		},
 
-		onSuccess: () => {
+		onSuccess: (data) => {
+			toast.success(
+				data.itemType === "routine"
+					? "Routine saved to My Routines"
+					: "Cycle saved to My Cycles",
+			);
 			if (user) {
 				queryClient.invalidateQueries({
 					queryKey: queryKeys.community.saves(user.id),
 				});
 			}
+			queryClient.invalidateQueries({ queryKey: queryKeys.community.all });
+			queryClient.invalidateQueries({ queryKey: queryKeys.routines.all });
+			queryClient.invalidateQueries({ queryKey: queryKeys.cycles.all });
+		},
+
+		onError: (error: Error) => {
+			console.error("[useSaveItem] failed:", error);
+			toast.error("Failed to save content. Please try again.");
 		},
 	});
 }

--- a/src/mutations/community.ts
+++ b/src/mutations/community.ts
@@ -91,7 +91,7 @@ type CycleWithDays = TrainingCycleRow & {
 
 function toSharedDurationMinutes(duration: number | null | undefined): number {
 	if (!duration) return 0;
-	return duration > 300 ? Math.round(duration / 60) : Math.round(duration);
+	return Math.round(duration / 60);
 }
 
 function routineExerciseSnapshot(exercise: RoutineExerciseRow) {

--- a/src/queries/__tests__/community.test.ts
+++ b/src/queries/__tests__/community.test.ts
@@ -75,7 +75,9 @@ describe("communityFeedOptions", () => {
 		const result = await options.queryFn?.({ pageParam: 0 } as never);
 
 		expect(from).toHaveBeenCalledWith("shared_routines");
-		expect(feedQuery.select).toHaveBeenCalledWith("*");
+		expect(feedQuery.select).toHaveBeenCalledWith(
+			expect.not.stringContaining("exercises_snapshot"),
+		);
 		expect(feedQuery.range).toHaveBeenCalledWith(0, 19);
 		expect(from).toHaveBeenCalledWith("public_profiles");
 		expect(profilesQuery.select).toHaveBeenCalledWith(

--- a/src/queries/community.ts
+++ b/src/queries/community.ts
@@ -5,12 +5,20 @@ import {
 	communityVoteSchema,
 	creatorStatsSchema,
 	savedItemSchema,
+	sharedCycleDetailSchema,
 	sharedCycleSchema,
+	sharedRoutineDetailSchema,
 	sharedRoutineSchema,
 } from "@/schemas/community";
 import { queryKeys } from "./keys";
 
 const PAGE_SIZE = 20;
+const ROUTINE_SUMMARY_SELECT =
+	"id,user_id,routine_id,name,description,exercise_count,estimated_duration,tags,difficulty,vote_count,save_count,hot_score,comment_count,shared_at,updated_at";
+const CYCLE_SUMMARY_SELECT =
+	"id,user_id,cycle_id,name,description,duration_weeks,tags,difficulty,vote_count,save_count,hot_score,comment_count,shared_at,updated_at";
+const ROUTINE_DETAIL_SELECT = `${ROUTINE_SUMMARY_SELECT},exercises_snapshot`;
+const CYCLE_DETAIL_SELECT = `${CYCLE_SUMMARY_SELECT},cycle_snapshot`;
 
 type FeedTab = "routines" | "cycles";
 type FeedSort = "hot" | "top" | "new";
@@ -26,8 +34,51 @@ interface FeedParams {
 	userId?: string;
 }
 
+type ProfileSummary = {
+	display_name: string | null;
+	avatar_url: string | null;
+};
+
+async function hydrateProfiles<T extends { user_id: string | null }>(
+	rows: T[],
+): Promise<Array<T & { profiles: ProfileSummary | null }>> {
+	const userIds = [
+		...new Set(
+			rows.map((row) => row.user_id).filter((id): id is string => id !== null),
+		),
+	];
+
+	const profileMap: Record<string, ProfileSummary> = {};
+
+	if (userIds.length > 0) {
+		const { data: profiles } = await supabase
+			.from("public_profiles")
+			.select("id, display_name, avatar_url")
+			.in("id", userIds);
+
+		if (profiles) {
+			for (const p of profiles as Array<
+				ProfileSummary & { id: string | null }
+			>) {
+				if (!p.id) continue;
+				profileMap[p.id] = {
+					display_name: p.display_name,
+					avatar_url: p.avatar_url,
+				};
+			}
+		}
+	}
+
+	return rows.map((row) => ({
+		...row,
+		profiles: row.user_id ? (profileMap[row.user_id] ?? null) : null,
+	}));
+}
+
 export function communityFeedOptions(params: FeedParams) {
 	const table = params.tab === "routines" ? "shared_routines" : "shared_cycles";
+	const select =
+		params.tab === "routines" ? ROUTINE_SUMMARY_SELECT : CYCLE_SUMMARY_SELECT;
 	const schema =
 		params.tab === "routines"
 			? z.array(sharedRoutineSchema)
@@ -45,15 +96,15 @@ export function communityFeedOptions(params: FeedParams) {
 			// shared_routines/shared_cycles.user_id -> auth.users(id), not profiles(id)
 			// PostgREST cannot resolve the profiles join directly, so we do a
 			// two-step fetch: get feed rows first, then batch-fetch profiles.
-			let query = supabase.from(table).select("*");
+			let query = supabase.from(table).select(select);
 
 			// Sort
 			if (params.sort === "new") {
 				query = query.order("shared_at", { ascending: false });
-			} else if (params.sort === "top") {
-				query = query.order("vote_count", { ascending: false });
 			} else {
-				query = query.order("hot_score", { ascending: false });
+				query = query
+					.order("vote_count", { ascending: false })
+					.order("shared_at", { ascending: false });
 			}
 
 			// Creator filter
@@ -80,45 +131,9 @@ export function communityFeedOptions(params: FeedParams) {
 			const { data, error } = await query;
 			if (error) throw error;
 
-			// Batch-fetch profiles for all non-null user_ids in this page
-			const userIds = [
-				...new Set(
-					(data as { user_id: string | null }[])
-						.map((row) => row.user_id)
-						.filter((id): id is string => id !== null),
-				),
-			];
-
-			const profileMap: Record<
-				string,
-				{ display_name: string | null; avatar_url: string | null }
-			> = {};
-
-			if (userIds.length > 0) {
-				const { data: profiles } = await supabase
-					.from("public_profiles")
-					.select("id, display_name, avatar_url")
-					.in("id", userIds);
-
-				if (profiles) {
-					for (const p of profiles as {
-						id: string | null;
-						display_name: string | null;
-						avatar_url: string | null;
-					}[]) {
-						if (!p.id) continue;
-						profileMap[p.id] = {
-							display_name: p.display_name,
-							avatar_url: p.avatar_url,
-						};
-					}
-				}
-			}
-
-			const merged = (data as { user_id: string | null }[]).map((row) => ({
-				...row,
-				profiles: row.user_id ? (profileMap[row.user_id] ?? null) : null,
-			}));
+			const merged = await hydrateProfiles(
+				data as { user_id: string | null }[],
+			);
 
 			return schema.parse(merged);
 		},
@@ -127,6 +142,37 @@ export function communityFeedOptions(params: FeedParams) {
 			if (lastPage.length < PAGE_SIZE) return undefined;
 			return allPages.reduce((total, page) => total + page.length, 0);
 		},
+	});
+}
+
+export function communityItemDetailOptions(
+	itemType: "routine" | "cycle",
+	itemId: string,
+) {
+	const table = itemType === "routine" ? "shared_routines" : "shared_cycles";
+	const select =
+		itemType === "routine" ? ROUTINE_DETAIL_SELECT : CYCLE_DETAIL_SELECT;
+	const schema =
+		itemType === "routine"
+			? sharedRoutineDetailSchema
+			: sharedCycleDetailSchema;
+
+	return queryOptions({
+		queryKey: queryKeys.community.detail(itemType, itemId),
+		queryFn: async () => {
+			const { data, error } = await supabase
+				.from(table)
+				.select(select)
+				.eq("id", itemId)
+				.single();
+			if (error) throw error;
+
+			const [merged] = await hydrateProfiles([
+				data as { user_id: string | null },
+			]);
+			return schema.parse(merged);
+		},
+		enabled: !!itemId,
 	});
 }
 

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -140,6 +140,8 @@ export const queryKeys = {
 			search?: string;
 			userId?: string;
 		}) => [...queryKeys.community.all, "feed", params] as const,
+		detail: (itemType: "routine" | "cycle", itemId: string) =>
+			[...queryKeys.community.all, "detail", itemType, itemId] as const,
 		creators: {
 			all: [...["community"], "creators"] as const,
 			featured: () =>

--- a/src/schemas/__tests__/community.test.ts
+++ b/src/schemas/__tests__/community.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+	cycleSnapshotSchema,
+	routineExercisesSnapshotSchema,
+} from "@/schemas/community";
+
+describe("community snapshot schemas", () => {
+	it("accepts full routine exercise snapshots", () => {
+		const result = routineExercisesSnapshotSchema.parse([
+			{
+				name: "Bench Press",
+				muscle_group: "Chest",
+				exercise_id: "bench-press",
+				sets: 3,
+				reps: 8,
+				weight: 40,
+				rest_seconds: 90,
+				duration_seconds: null,
+				mode: "OLD_SCHOOL",
+				order_index: 0,
+				superset_id: "push-a",
+				superset_color: "#ff6b35",
+				superset_order: 0,
+				per_set_weights: [40, 42.5, 45],
+				per_set_rest: [90, 90, 120],
+				per_set_reps: [8, 8, 6],
+				per_set_echo_levels: null,
+				is_amrap: false,
+				is_bodyweight: false,
+				pr_percentage: null,
+				rep_count_timing: "top",
+				stop_at_position: null,
+				stall_detection: true,
+				eccentric_load: "medium",
+				echo_level: null,
+				warmup_sets: null,
+			},
+		]);
+
+		expect(result[0]?.name).toBe("Bench Press");
+		expect(result[0]?.per_set_weights).toEqual([40, 42.5, 45]);
+	});
+
+	it("accepts full cycle snapshots with embedded routines", () => {
+		const result = cycleSnapshotSchema.safeParse({
+			duration_weeks: 7,
+			workout_days: 1,
+			rest_days: 1,
+			progression_settings: { type: "percentage", amount: 5 },
+			deload_settings: null,
+			days: [
+				{
+					day_number: 1,
+					day_type: "workout",
+					routine_id: "source-routine",
+					weight_adjustment: 5,
+					rep_modifier: 0,
+					rest_override: null,
+					notes: "Push day",
+					rest_type: null,
+					routine: {
+						source_routine_id: "source-routine",
+						name: "Push Routine",
+						description: "Upper body",
+						exercise_count: 1,
+						estimated_duration: 2700,
+						tags: ["Chest"],
+						exercises: [
+							{
+								name: "Bench Press",
+								muscle_group: "Chest",
+								sets: 3,
+								reps: 8,
+								weight: 40,
+								rest_seconds: 90,
+								mode: "OLD_SCHOOL",
+								order_index: 0,
+							},
+						],
+					},
+				},
+			],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects malformed cycle snapshots", () => {
+		const result = cycleSnapshotSchema.safeParse({
+			duration_weeks: "seven",
+			days: "not an array",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/schemas/community.ts
+++ b/src/schemas/community.ts
@@ -3,6 +3,101 @@ import { z } from "zod";
 const difficultyEnum = z.enum(["Beginner", "Intermediate", "Advanced"]);
 const itemTypeEnum = z.enum(["routine", "cycle"]);
 
+const profileSummarySchema = z
+	.object({
+		display_name: z.string().nullable(),
+		avatar_url: z.string().nullable(),
+	})
+	.optional()
+	.nullable();
+
+const nullableUnknownSchema = z.unknown().nullable().optional();
+
+export const routineExerciseSnapshotSchema = z.object({
+	name: z.string().default("Exercise"),
+	muscle_group: z.string().default("General"),
+	exercise_id: z.string().nullable().optional(),
+	sets: z.number().default(3),
+	reps: z.number().default(10),
+	weight: z.number().default(0),
+	rest_seconds: z.number().default(90),
+	duration_seconds: z.number().nullable().optional(),
+	mode: z.string().default("OLD_SCHOOL"),
+	order_index: z.number().default(0),
+	superset_id: z.string().nullable().optional(),
+	superset_color: z.string().nullable().optional(),
+	superset_order: z.number().nullable().optional(),
+	per_set_weights: nullableUnknownSchema,
+	per_set_rest: nullableUnknownSchema,
+	per_set_reps: nullableUnknownSchema,
+	per_set_echo_levels: nullableUnknownSchema,
+	is_amrap: z.boolean().nullable().optional().default(false),
+	is_bodyweight: z.boolean().nullable().optional().default(false),
+	pr_percentage: z.number().nullable().optional(),
+	rep_count_timing: z.string().nullable().optional(),
+	stop_at_position: z.string().nullable().optional(),
+	stall_detection: z.boolean().nullable().optional().default(true),
+	eccentric_load: z.string().nullable().optional(),
+	echo_level: z.string().nullable().optional(),
+	warmup_sets: nullableUnknownSchema,
+});
+
+export const routineExercisesSnapshotSchema = z.array(
+	routineExerciseSnapshotSchema,
+);
+
+export type RoutineExerciseSnapshot = z.infer<
+	typeof routineExerciseSnapshotSchema
+>;
+
+export const embeddedRoutineSnapshotSchema = z.object({
+	source_routine_id: z.string().nullable().optional(),
+	name: z.string().default("Imported Routine"),
+	description: z.string().nullable().optional().default(""),
+	exercise_count: z.number().default(0),
+	estimated_duration: z.number().default(0),
+	tags: z.array(z.string()).nullable().optional().default([]),
+	exercises: routineExercisesSnapshotSchema.default([]),
+});
+
+export type EmbeddedRoutineSnapshot = z.infer<
+	typeof embeddedRoutineSnapshotSchema
+>;
+
+export const cycleDaySnapshotSchema = z.object({
+	day_number: z.number(),
+	day_type: z.string().default("workout"),
+	routine_id: z.string().nullable().optional(),
+	weight_adjustment: z.number().default(0),
+	rep_modifier: z.number().default(0),
+	rest_override: z.number().nullable().optional(),
+	notes: z.string().nullable().optional(),
+	rest_type: z.string().nullable().optional(),
+	routine: embeddedRoutineSnapshotSchema.nullable().optional(),
+});
+
+export const cycleSnapshotSchema = z.object({
+	duration_weeks: z.number(),
+	workout_days: z.number().optional(),
+	rest_days: z.number().optional(),
+	progression_settings: nullableUnknownSchema,
+	deload_settings: nullableUnknownSchema,
+	days: z.array(cycleDaySnapshotSchema).default([]),
+});
+
+export type CycleSnapshot = z.infer<typeof cycleSnapshotSchema>;
+
+const routineSnapshotValueSchema = z
+	.preprocess(
+		(value) => value ?? null,
+		routineExercisesSnapshotSchema.nullable(),
+	)
+	.catch(null);
+
+const cycleSnapshotValueSchema = z
+	.preprocess((value) => value ?? null, cycleSnapshotSchema.nullable())
+	.catch(null);
+
 // --- Shared Routine ---
 
 export const sharedRoutineSchema = z.object({
@@ -13,7 +108,6 @@ export const sharedRoutineSchema = z.object({
 	description: z.string(),
 	exercise_count: z.number(),
 	estimated_duration: z.number(),
-	exercises_snapshot: z.unknown(),
 	tags: z.array(z.string()),
 	difficulty: difficultyEnum,
 	vote_count: z.number(),
@@ -22,16 +116,16 @@ export const sharedRoutineSchema = z.object({
 	comment_count: z.number().default(0),
 	shared_at: z.string().transform((s) => new Date(s)),
 	updated_at: z.string().transform((s) => new Date(s)),
-	profiles: z
-		.object({
-			display_name: z.string().nullable(),
-			avatar_url: z.string().nullable(),
-		})
-		.optional()
-		.nullable(),
+	profiles: profileSummarySchema,
 });
 
 export type SharedRoutine = z.infer<typeof sharedRoutineSchema>;
+
+export const sharedRoutineDetailSchema = sharedRoutineSchema.extend({
+	exercises_snapshot: routineSnapshotValueSchema,
+});
+
+export type SharedRoutineDetail = z.infer<typeof sharedRoutineDetailSchema>;
 
 // --- Shared Cycle ---
 
@@ -50,16 +144,16 @@ export const sharedCycleSchema = z.object({
 	comment_count: z.number().default(0),
 	shared_at: z.string().transform((s) => new Date(s)),
 	updated_at: z.string().transform((s) => new Date(s)),
-	profiles: z
-		.object({
-			display_name: z.string().nullable(),
-			avatar_url: z.string().nullable(),
-		})
-		.optional()
-		.nullable(),
+	profiles: profileSummarySchema,
 });
 
 export type SharedCycle = z.infer<typeof sharedCycleSchema>;
+
+export const sharedCycleDetailSchema = sharedCycleSchema.extend({
+	cycle_snapshot: cycleSnapshotValueSchema,
+});
+
+export type SharedCycleDetail = z.infer<typeof sharedCycleDetailSchema>;
 
 // --- Community Vote ---
 
@@ -80,6 +174,8 @@ export const savedItemSchema = z.object({
 	user_id: z.string().uuid(),
 	shared_item_id: z.string().uuid(),
 	item_type: itemTypeEnum,
+	imported_routine_id: z.string().uuid().nullable().optional(),
+	imported_cycle_id: z.string().uuid().nullable().optional(),
 	saved_at: z.string().transform((s) => new Date(s)),
 });
 
@@ -123,3 +219,4 @@ export const blockUserSchema = z.object({
 // --- Union type for feed items ---
 
 export type CommunityFeedItem = SharedRoutine | SharedCycle;
+export type CommunityItemDetail = SharedRoutineDetail | SharedCycleDetail;

--- a/src/stores/__tests__/useCommunityStore.test.ts
+++ b/src/stores/__tests__/useCommunityStore.test.ts
@@ -5,7 +5,7 @@ describe("useCommunityStore", () => {
 	beforeEach(() => {
 		useCommunityStore.setState({
 			activeTab: "routines",
-			sort: "hot",
+			sort: "top",
 			search: "",
 			filters: {},
 			selectedItemId: null,
@@ -16,7 +16,7 @@ describe("useCommunityStore", () => {
 	it("has correct initial state", () => {
 		const state = useCommunityStore.getState();
 		expect(state.activeTab).toBe("routines");
-		expect(state.sort).toBe("hot");
+		expect(state.sort).toBe("top");
 		expect(state.search).toBe("");
 		expect(state.filters).toEqual({});
 		expect(state.selectedItemId).toBeNull();
@@ -71,7 +71,7 @@ describe("useCommunityStore", () => {
 		useCommunityStore.getState().resetAll();
 		const state = useCommunityStore.getState();
 		expect(state.activeTab).toBe("routines");
-		expect(state.sort).toBe("hot");
+		expect(state.sort).toBe("top");
 		expect(state.search).toBe("");
 		expect(state.filters).toEqual({});
 		expect(state.selectedItemId).toBeNull();

--- a/src/stores/useCommunityStore.ts
+++ b/src/stores/useCommunityStore.ts
@@ -23,7 +23,7 @@ interface CommunityState {
 
 const initialState = {
 	activeTab: "routines" as const,
-	sort: "hot" as const,
+	sort: "top" as const,
 	search: "",
 	filters: {},
 	selectedItemId: null,

--- a/supabase/migrations/20260526120000_community_snapshots_and_imports.sql
+++ b/supabase/migrations/20260526120000_community_snapshots_and_imports.sql
@@ -1,0 +1,578 @@
+-- Community shared content snapshots and personal-library imports.
+-- Shared rows store public snapshots so viewers do not need RLS access to the
+-- author's private routines, routine_exercises, training_cycles, or cycle_days.
+
+ALTER TABLE public.shared_cycles
+  ADD COLUMN IF NOT EXISTS cycle_snapshot JSONB;
+
+ALTER TABLE public.saved_community_items
+  ADD COLUMN IF NOT EXISTS imported_routine_id UUID REFERENCES public.routines(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS imported_cycle_id UUID REFERENCES public.training_cycles(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_saved_community_items_imported_routine
+  ON public.saved_community_items(imported_routine_id)
+  WHERE imported_routine_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_saved_community_items_imported_cycle
+  ON public.saved_community_items(imported_cycle_id)
+  WHERE imported_cycle_id IS NOT NULL;
+
+GRANT INSERT (cycle_snapshot) ON TABLE public.shared_cycles TO authenticated;
+GRANT UPDATE (cycle_snapshot) ON TABLE public.shared_cycles TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.saved_community_items TO authenticated;
+
+-- Backfill routine exercise snapshots from source routines that still exist.
+UPDATE public.shared_routines sr
+SET exercises_snapshot = COALESCE(
+  (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'name', re.name,
+        'muscle_group', re.muscle_group,
+        'exercise_id', re.exercise_id,
+        'sets', re.sets,
+        'reps', re.reps,
+        'weight', re.weight,
+        'rest_seconds', re.rest_seconds,
+        'duration_seconds', re.duration_seconds,
+        'mode', re.mode,
+        'order_index', re.order_index,
+        'superset_id', re.superset_id,
+        'superset_color', re.superset_color,
+        'superset_order', re.superset_order,
+        'per_set_weights', re.per_set_weights,
+        'per_set_rest', re.per_set_rest,
+        'per_set_reps', re.per_set_reps,
+        'per_set_echo_levels', re.per_set_echo_levels,
+        'is_amrap', re.is_amrap,
+        'is_bodyweight', re.is_bodyweight,
+        'pr_percentage', re.pr_percentage,
+        'rep_count_timing', re.rep_count_timing,
+        'stop_at_position', re.stop_at_position,
+        'stall_detection', re.stall_detection,
+        'eccentric_load', re.eccentric_load,
+        'echo_level', re.echo_level,
+        'warmup_sets', re.warmup_sets
+      )
+      ORDER BY re.order_index
+    )
+    FROM public.routine_exercises re
+    WHERE re.routine_id = sr.routine_id
+  ),
+  '[]'::jsonb
+)
+WHERE sr.exercises_snapshot IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM public.routines r
+    WHERE r.id = sr.routine_id
+  );
+
+-- Backfill cycle snapshots, embedding each referenced routine and its exercise
+-- snapshot where the source routine still exists.
+UPDATE public.shared_cycles sc
+SET cycle_snapshot = jsonb_build_object(
+  'duration_weeks', tc.duration_weeks,
+  'workout_days', tc.workout_days,
+  'rest_days', tc.rest_days,
+  'progression_settings', tc.progression_settings,
+  'deload_settings', tc.deload_settings,
+  'days', COALESCE(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'day_number', cd.day_number,
+          'day_type', cd.day_type,
+          'routine_id', cd.routine_id,
+          'weight_adjustment', cd.weight_adjustment,
+          'rep_modifier', cd.rep_modifier,
+          'rest_override', cd.rest_override,
+          'notes', cd.notes,
+          'rest_type', cd.rest_type,
+          'routine',
+            CASE
+              WHEN r.id IS NULL THEN NULL
+              ELSE jsonb_build_object(
+                'source_routine_id', r.id,
+                'name', r.name,
+                'description', r.description,
+                'exercise_count', r.exercise_count,
+                'estimated_duration', r.estimated_duration,
+                'tags', COALESCE(to_jsonb(r.tags), '[]'::jsonb),
+                'exercises', COALESCE(
+                  (
+                    SELECT jsonb_agg(
+                      jsonb_build_object(
+                        'name', re.name,
+                        'muscle_group', re.muscle_group,
+                        'exercise_id', re.exercise_id,
+                        'sets', re.sets,
+                        'reps', re.reps,
+                        'weight', re.weight,
+                        'rest_seconds', re.rest_seconds,
+                        'duration_seconds', re.duration_seconds,
+                        'mode', re.mode,
+                        'order_index', re.order_index,
+                        'superset_id', re.superset_id,
+                        'superset_color', re.superset_color,
+                        'superset_order', re.superset_order,
+                        'per_set_weights', re.per_set_weights,
+                        'per_set_rest', re.per_set_rest,
+                        'per_set_reps', re.per_set_reps,
+                        'per_set_echo_levels', re.per_set_echo_levels,
+                        'is_amrap', re.is_amrap,
+                        'is_bodyweight', re.is_bodyweight,
+                        'pr_percentage', re.pr_percentage,
+                        'rep_count_timing', re.rep_count_timing,
+                        'stop_at_position', re.stop_at_position,
+                        'stall_detection', re.stall_detection,
+                        'eccentric_load', re.eccentric_load,
+                        'echo_level', re.echo_level,
+                        'warmup_sets', re.warmup_sets
+                      )
+                      ORDER BY re.order_index
+                    )
+                    FROM public.routine_exercises re
+                    WHERE re.routine_id = r.id
+                  ),
+                  '[]'::jsonb
+                )
+              )
+            END
+        )
+        ORDER BY cd.day_number
+      )
+      FROM public.cycle_days cd
+      LEFT JOIN public.routines r ON r.id = cd.routine_id
+      WHERE cd.cycle_id = tc.id
+    ),
+    '[]'::jsonb
+  )
+)
+FROM public.training_cycles tc
+WHERE tc.id = sc.cycle_id
+  AND sc.cycle_snapshot IS NULL;
+
+CREATE OR REPLACE FUNCTION public.insert_routine_exercises_from_snapshot(
+  p_routine_id UUID,
+  p_snapshot JSONB
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_snapshot IS NULL OR jsonb_typeof(p_snapshot) <> 'array' THEN
+    RAISE EXCEPTION 'Routine snapshot is unavailable';
+  END IF;
+
+  INSERT INTO public.routine_exercises (
+    routine_id,
+    name,
+    muscle_group,
+    exercise_id,
+    sets,
+    reps,
+    weight,
+    rest_seconds,
+    duration_seconds,
+    mode,
+    order_index,
+    superset_id,
+    superset_color,
+    superset_order,
+    per_set_weights,
+    per_set_rest,
+    per_set_reps,
+    per_set_echo_levels,
+    is_amrap,
+    is_bodyweight,
+    pr_percentage,
+    rep_count_timing,
+    stop_at_position,
+    stall_detection,
+    eccentric_load,
+    echo_level,
+    warmup_sets
+  )
+  SELECT
+    p_routine_id,
+    COALESCE(ex.name, 'Exercise'),
+    COALESCE(ex.muscle_group, 'General'),
+    ex.exercise_id,
+    COALESCE(ex.sets, 3),
+    COALESCE(ex.reps, 10),
+    COALESCE(ex.weight, 0),
+    COALESCE(ex.rest_seconds, 90),
+    ex.duration_seconds,
+    COALESCE(ex.mode, 'OLD_SCHOOL'),
+    COALESCE(ex.order_index, 0),
+    ex.superset_id,
+    ex.superset_color,
+    ex.superset_order,
+    ex.per_set_weights,
+    ex.per_set_rest,
+    ex.per_set_reps,
+    ex.per_set_echo_levels,
+    COALESCE(ex.is_amrap, false),
+    COALESCE(ex.is_bodyweight, false),
+    ex.pr_percentage,
+    ex.rep_count_timing,
+    ex.stop_at_position,
+    COALESCE(ex.stall_detection, true),
+    ex.eccentric_load,
+    ex.echo_level,
+    ex.warmup_sets
+  FROM jsonb_to_recordset(p_snapshot) AS ex(
+    name TEXT,
+    muscle_group TEXT,
+    exercise_id TEXT,
+    sets INT,
+    reps INT,
+    weight NUMERIC,
+    rest_seconds INT,
+    duration_seconds INT,
+    mode TEXT,
+    order_index INT,
+    superset_id TEXT,
+    superset_color TEXT,
+    superset_order INT,
+    per_set_weights JSONB,
+    per_set_rest JSONB,
+    per_set_reps JSONB,
+    per_set_echo_levels TEXT,
+    is_amrap BOOLEAN,
+    is_bodyweight BOOLEAN,
+    pr_percentage NUMERIC,
+    rep_count_timing TEXT,
+    stop_at_position TEXT,
+    stall_detection BOOLEAN,
+    eccentric_load TEXT,
+    echo_level TEXT,
+    warmup_sets TEXT
+  )
+  ORDER BY COALESCE(ex.order_index, 0);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.insert_routine_exercises_from_snapshot(UUID, JSONB) FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.import_shared_routine(
+  p_shared_routine_id UUID,
+  p_local_profile_id TEXT DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_existing_routine_id UUID;
+  v_new_routine_id UUID;
+  v_shared RECORD;
+  v_snapshot JSONB;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF p_local_profile_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1
+    FROM public.local_profiles lp
+    WHERE lp.user_id = v_user_id
+      AND lp.id = p_local_profile_id
+  ) THEN
+    RAISE EXCEPTION 'Invalid local profile';
+  END IF;
+
+  SELECT sci.imported_routine_id
+  INTO v_existing_routine_id
+  FROM public.saved_community_items sci
+  WHERE sci.user_id = v_user_id
+    AND sci.shared_item_id = p_shared_routine_id
+    AND sci.item_type = 'routine'
+    AND sci.imported_routine_id IS NOT NULL
+  LIMIT 1;
+
+  IF v_existing_routine_id IS NOT NULL AND EXISTS (
+    SELECT 1
+    FROM public.routines r
+    WHERE r.id = v_existing_routine_id
+      AND r.user_id = v_user_id
+  ) THEN
+    RETURN v_existing_routine_id;
+  END IF;
+
+  SELECT *
+  INTO v_shared
+  FROM public.shared_routines
+  WHERE id = p_shared_routine_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Shared routine not found';
+  END IF;
+
+  v_snapshot := v_shared.exercises_snapshot;
+  IF v_snapshot IS NULL OR jsonb_typeof(v_snapshot) <> 'array' THEN
+    RAISE EXCEPTION 'Routine snapshot is unavailable';
+  END IF;
+
+  INSERT INTO public.routines (
+    user_id,
+    local_profile_id,
+    name,
+    description,
+    exercise_count,
+    estimated_duration,
+    times_completed,
+    tags,
+    is_favorite
+  )
+  VALUES (
+    v_user_id,
+    p_local_profile_id,
+    v_shared.name,
+    COALESCE(v_shared.description, ''),
+    COALESCE(v_shared.exercise_count, jsonb_array_length(v_snapshot)),
+    CASE
+      WHEN COALESCE(v_shared.estimated_duration, 0) > 300 THEN v_shared.estimated_duration
+      ELSE COALESCE(v_shared.estimated_duration, 0) * 60
+    END,
+    0,
+    COALESCE(v_shared.tags, '{}'::TEXT[]),
+    false
+  )
+  RETURNING id INTO v_new_routine_id;
+
+  PERFORM public.insert_routine_exercises_from_snapshot(v_new_routine_id, v_snapshot);
+
+  INSERT INTO public.saved_community_items (
+    user_id,
+    shared_item_id,
+    item_type,
+    imported_routine_id
+  )
+  VALUES (
+    v_user_id,
+    p_shared_routine_id,
+    'routine',
+    v_new_routine_id
+  )
+  ON CONFLICT (user_id, shared_item_id, item_type)
+  DO UPDATE SET imported_routine_id = EXCLUDED.imported_routine_id;
+
+  RETURN v_new_routine_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.import_shared_cycle(
+  p_shared_cycle_id UUID,
+  p_local_profile_id TEXT DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_existing_cycle_id UUID;
+  v_new_cycle_id UUID;
+  v_new_routine_id UUID;
+  v_shared RECORD;
+  v_snapshot JSONB;
+  v_day JSONB;
+  v_days JSONB;
+  v_routine JSONB;
+  v_routine_key TEXT;
+  v_routine_map JSONB := '{}'::jsonb;
+  v_workout_days INT;
+  v_rest_days INT;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF p_local_profile_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1
+    FROM public.local_profiles lp
+    WHERE lp.user_id = v_user_id
+      AND lp.id = p_local_profile_id
+  ) THEN
+    RAISE EXCEPTION 'Invalid local profile';
+  END IF;
+
+  SELECT sci.imported_cycle_id
+  INTO v_existing_cycle_id
+  FROM public.saved_community_items sci
+  WHERE sci.user_id = v_user_id
+    AND sci.shared_item_id = p_shared_cycle_id
+    AND sci.item_type = 'cycle'
+    AND sci.imported_cycle_id IS NOT NULL
+  LIMIT 1;
+
+  IF v_existing_cycle_id IS NOT NULL AND EXISTS (
+    SELECT 1
+    FROM public.training_cycles tc
+    WHERE tc.id = v_existing_cycle_id
+      AND tc.user_id = v_user_id
+  ) THEN
+    RETURN v_existing_cycle_id;
+  END IF;
+
+  SELECT *
+  INTO v_shared
+  FROM public.shared_cycles
+  WHERE id = p_shared_cycle_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Shared cycle not found';
+  END IF;
+
+  v_snapshot := v_shared.cycle_snapshot;
+  v_days := v_snapshot -> 'days';
+
+  IF v_snapshot IS NULL OR jsonb_typeof(v_snapshot) <> 'object'
+    OR v_days IS NULL OR jsonb_typeof(v_days) <> 'array' THEN
+    RAISE EXCEPTION 'Cycle snapshot is unavailable';
+  END IF;
+
+  SELECT
+    COUNT(*) FILTER (WHERE day_item ->> 'day_type' = 'workout'),
+    COUNT(*) FILTER (WHERE day_item ->> 'day_type' = 'rest')
+  INTO v_workout_days, v_rest_days
+  FROM jsonb_array_elements(v_days) AS day_item;
+
+  INSERT INTO public.training_cycles (
+    user_id,
+    local_profile_id,
+    name,
+    description,
+    duration_weeks,
+    current_week,
+    status,
+    workout_days,
+    rest_days,
+    started_at,
+    progression_settings,
+    deload_settings
+  )
+  VALUES (
+    v_user_id,
+    p_local_profile_id,
+    v_shared.name,
+    COALESCE(v_shared.description, ''),
+    COALESCE((v_snapshot ->> 'duration_weeks')::INT, v_shared.duration_weeks),
+    1,
+    'draft',
+    COALESCE((v_snapshot ->> 'workout_days')::INT, v_workout_days, 0),
+    COALESCE((v_snapshot ->> 'rest_days')::INT, v_rest_days, 0),
+    NULL,
+    v_snapshot -> 'progression_settings',
+    v_snapshot -> 'deload_settings'
+  )
+  RETURNING id INTO v_new_cycle_id;
+
+  FOR v_day IN
+    SELECT value
+    FROM jsonb_array_elements(v_days)
+    ORDER BY COALESCE((value ->> 'day_number')::INT, 0)
+  LOOP
+    v_new_routine_id := NULL;
+    v_routine := v_day -> 'routine';
+
+    IF v_day ->> 'day_type' = 'workout'
+      AND v_routine IS NOT NULL
+      AND jsonb_typeof(v_routine) = 'object' THEN
+      v_routine_key := COALESCE(
+        v_day ->> 'routine_id',
+        v_routine ->> 'source_routine_id',
+        'day-' || COALESCE(v_day ->> 'day_number', 'unknown')
+      );
+
+      IF v_routine_map ? v_routine_key THEN
+        v_new_routine_id := (v_routine_map ->> v_routine_key)::UUID;
+      ELSE
+        INSERT INTO public.routines (
+          user_id,
+          local_profile_id,
+          name,
+          description,
+          exercise_count,
+          estimated_duration,
+          times_completed,
+          tags,
+          is_favorite
+        )
+        VALUES (
+          v_user_id,
+          p_local_profile_id,
+          COALESCE(v_routine ->> 'name', 'Imported Routine'),
+          COALESCE(v_routine ->> 'description', ''),
+          COALESCE((v_routine ->> 'exercise_count')::INT, jsonb_array_length(COALESCE(v_routine -> 'exercises', '[]'::jsonb))),
+          COALESCE((v_routine ->> 'estimated_duration')::INT, 0),
+          0,
+          COALESCE(
+            ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_routine -> 'tags', '[]'::jsonb))),
+            '{}'::TEXT[]
+          ),
+          false
+        )
+        RETURNING id INTO v_new_routine_id;
+
+        PERFORM public.insert_routine_exercises_from_snapshot(
+          v_new_routine_id,
+          COALESCE(v_routine -> 'exercises', '[]'::jsonb)
+        );
+
+        v_routine_map := v_routine_map || jsonb_build_object(v_routine_key, v_new_routine_id);
+      END IF;
+    END IF;
+
+    INSERT INTO public.cycle_days (
+      cycle_id,
+      day_number,
+      day_type,
+      routine_id,
+      weight_adjustment,
+      rep_modifier,
+      rest_override,
+      notes,
+      rest_type
+    )
+    VALUES (
+      v_new_cycle_id,
+      COALESCE((v_day ->> 'day_number')::INT, 1),
+      COALESCE(v_day ->> 'day_type', 'rest'),
+      v_new_routine_id,
+      COALESCE((v_day ->> 'weight_adjustment')::NUMERIC, 0),
+      COALESCE((v_day ->> 'rep_modifier')::INT, 0),
+      NULLIF(v_day ->> 'rest_override', '')::INT,
+      NULLIF(v_day ->> 'notes', ''),
+      NULLIF(v_day ->> 'rest_type', '')
+    );
+  END LOOP;
+
+  INSERT INTO public.saved_community_items (
+    user_id,
+    shared_item_id,
+    item_type,
+    imported_cycle_id
+  )
+  VALUES (
+    v_user_id,
+    p_shared_cycle_id,
+    'cycle',
+    v_new_cycle_id
+  )
+  ON CONFLICT (user_id, shared_item_id, item_type)
+  DO UPDATE SET imported_cycle_id = EXCLUDED.imported_cycle_id;
+
+  RETURN v_new_cycle_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.import_shared_routine(UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.import_shared_cycle(UUID, TEXT) TO authenticated;

--- a/supabase/migrations/20260526120000_community_snapshots_and_imports.sql
+++ b/supabase/migrations/20260526120000_community_snapshots_and_imports.sql
@@ -241,7 +241,7 @@ BEGIN
     per_set_weights JSONB,
     per_set_rest JSONB,
     per_set_reps JSONB,
-    per_set_echo_levels TEXT,
+    per_set_echo_levels JSONB,
     is_amrap BOOLEAN,
     is_bodyweight BOOLEAN,
     pr_percentage NUMERIC,
@@ -337,8 +337,10 @@ BEGIN
     COALESCE(v_shared.description, ''),
     COALESCE(v_shared.exercise_count, jsonb_array_length(v_snapshot)),
     CASE
-      WHEN COALESCE(v_shared.estimated_duration, 0) > 300 THEN v_shared.estimated_duration
-      ELSE COALESCE(v_shared.estimated_duration, 0) * 60
+      WHEN COALESCE(v_shared.estimated_duration, 0) <= 0 THEN 0
+      WHEN COALESCE(v_shared.estimated_duration, 0) < GREATEST(COALESCE(v_shared.exercise_count, jsonb_array_length(v_snapshot), 1), 1) * 150
+        THEN COALESCE(v_shared.estimated_duration, 0) * 60
+      ELSE COALESCE(v_shared.estimated_duration, 0)
     END,
     0,
     COALESCE(v_shared.tags, '{}'::TEXT[]),
@@ -574,5 +576,7 @@ BEGIN
 END;
 $$;
 
+REVOKE ALL ON FUNCTION public.import_shared_routine(UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.import_shared_cycle(UUID, TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.import_shared_routine(UUID, TEXT) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.import_shared_cycle(UUID, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary
- Added durable public snapshots for shared routines and cycles so community items can be viewed in full without exposing private source rows.
- Reworked community detail UI to show complete read-only routine and cycle breakdowns, including embedded cycle routines and configuration details.
- Changed save behavior so community routines and cycles import into the user’s personal library and stay linked to the imported copy.
- Updated community ordering to sort by vote count descending with a stable tie-breaker, so upvotes no longer cause random reordering.

## Testing
- Added and updated unit tests for snapshot schemas, community queries, save/import mutations, store sort behavior, and the new preview components.
- Ran lint, typecheck, targeted Vitest coverage, `test:sync`, and full verification successfully.