### PR TITLE
fix: preserve core dip muscle classification

### DIFF
--- a/src/lib/__tests__/exercise-muscles.test.ts
+++ b/src/lib/__tests__/exercise-muscles.test.ts
@@ -8,10 +8,12 @@ import {
 } from "@/lib/exercise-muscles";
 
 const BACKFILL_MIGRATION = "20260529000000_backfill_exercise_muscle_groups.sql";
+const CORE_DIP_FIX_MIGRATION =
+	"20260530000000_fix_core_dip_muscle_group_backfill.sql";
 
-function readBackfillMigration(): string {
+function readMigration(filename: string): string {
 	return readFileSync(
-		join(process.cwd(), "supabase", "migrations", BACKFILL_MIGRATION),
+		join(process.cwd(), "supabase", "migrations", filename),
 		"utf8",
 	);
 }
@@ -20,7 +22,7 @@ function parseBackfillNameMap(): {
 	entries: Map<string, string>;
 	duplicates: string[];
 } {
-	const sql = readBackfillMigration();
+	const sql = readMigration(BACKFILL_MIGRATION);
 	const entries = new Map<string, string>();
 	const duplicates: string[] = [];
 	for (const match of sql.matchAll(/\('((?:''|[^'])*)',\s*'([^']+)'\)/g)) {
@@ -38,7 +40,7 @@ function parseBackfillKeywordRules(): Array<{
 	pattern: RegExp;
 	group: string;
 }> {
-	const sql = readBackfillMigration();
+	const sql = readMigration(BACKFILL_MIGRATION);
 	const [, body = ""] =
 		sql.match(
 			/keyword_rules\(priority, pattern, grp\) AS \(\s*VALUES([\s\S]*?)\),\s*exercise_names AS/,
@@ -53,6 +55,19 @@ function parseBackfillKeywordRules(): Array<{
 			group: match[3],
 		}))
 		.sort((a, b) => a.priority - b.priority);
+}
+
+function parseCoreDipFixPatterns(): RegExp[] {
+	const sql = readMigration(CORE_DIP_FIX_MIGRATION);
+	const [, body = ""] =
+		sql.match(
+			/core_dip_patterns\(pattern\) AS \(\s*VALUES([\s\S]*?)\),\s*candidate_exercises AS/,
+		) ?? [];
+
+	return [...body.matchAll(/\(\s*'((?:''|[^'])*)'\s*\)/g)].map(
+		(match) =>
+			new RegExp(match[1].replace(/''/g, "'").replace(/\\m|\\M/g, "\\b")),
+	);
 }
 
 function lookupBackfillGroupForExerciseName(
@@ -73,6 +88,28 @@ function lookupBackfillGroupForExerciseName(
 	}
 
 	return undefined;
+}
+
+function lookupBackfillGroupAfterAllMigrations(
+	name: string,
+	entries: Map<string, string>,
+	keywordRules: Array<{ pattern: RegExp; group: string }>,
+	coreDipPatterns: RegExp[],
+): string | undefined {
+	const backfillGroup = lookupBackfillGroupForExerciseName(
+		name,
+		entries,
+		keywordRules,
+	);
+	const currentGroup = backfillGroup ?? "General";
+	const normalizedName = normalizeExerciseName(name);
+	if (
+		(currentGroup === "General" || currentGroup === "Chest") &&
+		coreDipPatterns.some((pattern) => pattern.test(normalizedName))
+	) {
+		return "Core";
+	}
+	return backfillGroup;
 }
 
 describe("normalizeExerciseName", () => {
@@ -188,6 +225,9 @@ describe("getExerciseProfile", () => {
 			["Bent Over Tricep Extension", "Arms"],
 			["Tricep Kick Back", "Arms"],
 			["Alternating Oblique Punch", "Core"],
+			["Alternating Plank Dips", "Core"],
+			["Side Clam Hip Dips", "Core"],
+			["Side Plank Hip Dips", "Core"],
 			["SA Bicycle Crunch", "Core"],
 			["High Crunch", "Core"],
 			["Crunches", "Core"],
@@ -210,6 +250,17 @@ describe("getExerciseProfile", () => {
 			expect(getExerciseProfile("Rear Delt Row").primary.group).toBe(
 				"Shoulders",
 			);
+		});
+
+		it("does not let generic 'dip' override core dip variants", () => {
+			expect(
+				getExerciseProfile("Side Plank Hip Dips", "Core").primary.group,
+			).toBe("Core");
+			expect(
+				getExerciseProfile("Side Clam Hip Dips", "Core").primary.group,
+			).toBe("Core");
+			expect(getExerciseProfile("Dips").primary.group).toBe("Chest");
+			expect(getExerciseProfile("Tricep Dip").primary.group).toBe("Arms");
 		});
 
 		it("leaves genuinely unknown / ambiguous names as General", () => {
@@ -304,6 +355,7 @@ describe("exercise muscle group backfill migration", () => {
 			["Chin-ups", "Back"],
 			["Shoulder Presses", "Shoulders"],
 			["Reverse Flies", "Shoulders"],
+			["Dips", "Chest"],
 			["Crunches", "Core"],
 		];
 
@@ -316,5 +368,30 @@ describe("exercise muscle group backfill migration", () => {
 		expect(
 			lookupBackfillGroupForExerciseName("Bar Rotation", entries, keywordRules),
 		).toBeUndefined();
+	});
+
+	it("corrects core dip variants after the already-pushed keyword backfill", () => {
+		const { entries } = parseBackfillNameMap();
+		const keywordRules = parseBackfillKeywordRules();
+		const coreDipPatterns = parseCoreDipFixPatterns();
+		const cases: Array<[string, string]> = [
+			["Alternating Plank Dips", "Core"],
+			["Side Clam Hip Dips", "Core"],
+			["Side Plank Hip Dips", "Core"],
+			["Dips", "Chest"],
+			["Tricep Dip", "Arms"],
+		];
+
+		expect(coreDipPatterns.length).toBeGreaterThan(0);
+		for (const [name, expected] of cases) {
+			expect(
+				lookupBackfillGroupAfterAllMigrations(
+					name,
+					entries,
+					keywordRules,
+					coreDipPatterns,
+				),
+			).toBe(expected);
+		}
 	});
 });

--- a/src/lib/exercise-muscles.ts
+++ b/src/lib/exercise-muscles.ts
@@ -739,8 +739,7 @@ const KEYWORD_RULES: Array<{ pattern: RegExp; group: string }> = [
 	{ pattern: /\bcurls?\b/, group: "Arms" },
 	// ── Core dip variants before generic chest dips ──
 	{
-		pattern:
-			/\b(plank dips?|hip dips?|oblique dips?)\b|\b(plank|oblique)s?\b.*\bdips?\b/,
+		pattern: /\bhip dips?\b|\b(plank|oblique)s?\b.*\bdips?\b/,
 		group: "Core",
 	},
 	// ── Chest ──

--- a/src/lib/exercise-muscles.ts
+++ b/src/lib/exercise-muscles.ts
@@ -693,6 +693,7 @@ const FUZZY_THRESHOLD = 0.7;
  *   - "hamstring|leg (press|ext|curl)" -> Legs BEFORE generic "curl" -> Arms
  *   - "rear delt" -> Shoulders BEFORE generic "row" -> Back
  *   - "tricep" -> Arms BEFORE generic "dip"/"curl"
+ *   - "plank/hip dips" -> Core BEFORE generic "dip" -> Chest
  *   - "leg raise|knee raise" -> Core (never matched by the Legs rules, which
  *     only match "leg press|extension|curl")
  */
@@ -736,6 +737,12 @@ const KEYWORD_RULES: Array<{ pattern: RegExp; group: string }> = [
 	// ── Arms (tricep before generic dip/curl) ──
 	{ pattern: /\b(triceps?|skulls?|kick ?backs?)\b/, group: "Arms" },
 	{ pattern: /\bcurls?\b/, group: "Arms" },
+	// ── Core dip variants before generic chest dips ──
+	{
+		pattern:
+			/\b(plank dips?|hip dips?|oblique dips?)\b|\b(plank|oblique)s?\b.*\bdips?\b/,
+		group: "Core",
+	},
 	// ── Chest ──
 	{ pattern: /\b(fl(?:y|ies|ye?s?)|pecs?)\b/, group: "Chest" },
 	{ pattern: /\b(bench|chest) press(?:es)?\b/, group: "Chest" },

--- a/supabase/migrations/20260530000000_fix_core_dip_muscle_group_backfill.sql
+++ b/supabase/migrations/20260530000000_fix_core_dip_muscle_group_backfill.sql
@@ -1,0 +1,35 @@
+-- Correct core dip variants after the initial keyword backfill.
+--
+-- The first backfill migration had already been pushed with a generic "dips"
+-- keyword that classifies these names as Chest. Keep that migration append-only
+-- and repair only rows that are still General or were moved to Chest by that
+-- generic rule.
+
+WITH core_dip_patterns(pattern) AS (
+    VALUES
+        ('\m(plank dips?|hip dips?|oblique dips?)\M'),
+        ('\m(plank|oblique)s?\M.*\mdips?\M')
+),
+candidate_exercises AS (
+    SELECT
+        id,
+        btrim(
+            regexp_replace(
+                lower(btrim(name)),
+                '[[:space:]]*\(.*\)[[:space:]]*$',
+                ''
+            )
+        ) AS norm_name
+    FROM exercises
+    WHERE muscle_group IN ('General', 'Chest')
+)
+UPDATE exercises ex
+SET muscle_group = 'Core'
+FROM candidate_exercises candidate
+WHERE ex.id = candidate.id
+  AND ex.muscle_group IN ('General', 'Chest')
+  AND EXISTS (
+      SELECT 1
+      FROM core_dip_patterns pattern
+      WHERE candidate.norm_name ~ pattern.pattern
+  );

--- a/supabase/migrations/20260530000000_fix_core_dip_muscle_group_backfill.sql
+++ b/supabase/migrations/20260530000000_fix_core_dip_muscle_group_backfill.sql
@@ -7,7 +7,7 @@
 
 WITH core_dip_patterns(pattern) AS (
     VALUES
-        ('\m(plank dips?|hip dips?|oblique dips?)\M'),
+        ('\mhip dips?\M'),
         ('\m(plank|oblique)s?\M.*\mdips?\M')
 ),
 candidate_exercises AS (


### PR DESCRIPTION
## Summary
- classify plank/hip/oblique dip variants as Core before the generic Chest dip fallback
- add an append-only migration to correct rows already set to Chest by the pushed keyword backfill
- extend regression coverage for the classifier and migration sequence

## Validation
- npm run verify:full
- npm run test:sync

Follow-up for the unresolved review thread on #50 after that PR was merged.