### PR TITLE
feat: 1RM parity Phase 1 — store mobile estimate, fix record labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,11 @@ MOCK_EDGE_FUNCTIONS=false npm test          # Live mode against real Supabase
 - `tests/sync/hierarchy.test.ts` — Nested entity integrity (35 tests)
 - `tests/sync/helpers/mock-edge-functions.ts` — Mock implementation
 
+### 1RM Estimate Parity (PARITY-CRITICAL)
+- Estimated 1RM is computed on MOBILE (hybrid: Brzycki reps<=10, Epley reps>10) and shipped as `estimatedOneRepMaxKg` per exercise. The edge function stores it verbatim in `exercise_progress.estimated_1rm_kg`.
+- `supabase/functions/_shared/exerciseProgressRows.ts#estimateOneRepMaxKg` and `src/lib/biomechanics.ts#estimateOneRepMax` are FALLBACKS only and MUST match the mobile formula. Mirror any change in the Project-Phoenix-MP counterpart (`OneRepMaxCalculator.estimate`).
+- `personal_records` holds max-weight/max-volume PRs (a different metric) — never relabel them as "1RM". Record-type label maps (`csv.ts`, `RecordsTab.tsx`) key on the UPPERCASE DB values (`MAX_WEIGHT`, `MAX_VOLUME`, `1RM`).
+
 ### Styling
 - Dark theme by default (background: #0D0D0D)
 - Phoenix color palette in `src/styles/theme.css`:

--- a/docs/superpowers/plans/2026-05-30-1rm-parity-portal.md
+++ b/docs/superpowers/plans/2026-05-30-1rm-parity-portal.md
@@ -1,0 +1,575 @@
+# 1RM Parity (Portal) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the portal from computing its own 1RM. Accept and store the mobile-provided canonical estimate; fall back to the *same* hybrid formula only for legacy payloads; and fix the record-type label/CSV case-mismatch bugs.
+
+**Architecture:** Add an optional `estimatedOneRepMaxKg` to the push zod schema, extract the edge function's `exercise_progress` computation into a testable `_shared/exerciseProgressRows.ts` that prefers the mobile value (hybrid fallback), wire `index.ts` to it, align the client-side `biomechanics.ts` fallback to the hybrid, and fix the uppercase `record_type` mapping in CSV export and RecordsTab.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Supabase Edge Functions (Deno), Zod, Biome.
+
+**Counterpart:** `Project-Phoenix-MP` plan `docs/superpowers/plans/2026-05-30-1rm-parity-mobile.md`. The wire field is optional, so deploy order is flexible; the legacy fallback keeps pre-field mobile builds working.
+
+**No DB change:** `exercise_progress.estimated_1rm_kg` already exists — no migration, no `npm run gen:types`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `supabase/functions/_shared/pushPayloadSchema.ts` | Modify `exerciseSchema` (lines 124-132) | Accept optional `estimatedOneRepMaxKg` |
+| `supabase/functions/_shared/exerciseProgressRows.ts` | Create | Hybrid estimator + progress-row builder (mobile value first) |
+| `src/lib/__tests__/sync-exercise-progress.test.ts` | Create | Unit tests for the builder |
+| `supabase/functions/mobile-sync-push/index.ts` | Modify (lines 1322-1361) | Use the extracted builder |
+| `src/lib/biomechanics.ts` | Modify `estimateOneRepMax` (lines 19-26) | Align client fallback to hybrid |
+| `src/lib/__tests__/biomechanics.test.ts` | Modify | Update/extend 1RM assertions |
+| `src/lib/export/csv.ts` | Modify `formatRecordType` (lines 62-72) | Fix uppercase `record_type` mapping |
+| `src/lib/export/__tests__/csv.test.ts` | Create | Lock in record-type labels |
+| `src/app/components/analytics/RecordsTab.tsx` | Modify `formatRecordTypeLabel` (~line 45) | Same uppercase fix as CSV |
+| `phoenix-portal/CLAUDE.md` | Modify | Document the parity constant |
+
+---
+
+## Task 1: Accept `estimatedOneRepMaxKg` in the push schema
+
+**Files:**
+- Modify: `supabase/functions/_shared/pushPayloadSchema.ts:124-132`
+- Test: `src/lib/__tests__/sync-push-schema.test.ts` is the existing schema test; add one case there. (If unsure of its helpers, the assertion below is self-contained.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/__tests__/sync-push-schema.test.ts` (imports `pushPayloadSchema` from `../../supabase/functions/_shared/pushPayloadSchema.ts`):
+
+```ts
+it("parses estimatedOneRepMaxKg on an exercise", () => {
+	const parsed = pushPayloadSchema.parse({
+		deviceId: "dev-1",
+		platform: "android",
+		sessions: [
+			{
+				id: "11111111-1111-1111-1111-111111111111",
+				userId: "u1",
+				startedAt: "2026-04-20T12:00:00.000Z",
+				exercises: [
+					{
+						id: "22222222-2222-2222-2222-222222222222",
+						sessionId: "11111111-1111-1111-1111-111111111111",
+						name: "Squat",
+						estimatedOneRepMaxKg: 133.33,
+						sets: [],
+					},
+				],
+			},
+		],
+	});
+	expect(parsed.sessions[0].exercises[0].estimatedOneRepMaxKg).toBeCloseTo(133.33);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- sync-push-schema`
+Expected: FAIL — parsed value is `undefined` (field stripped by the schema).
+
+- [ ] **Step 3: Add the field**
+
+In `pushPayloadSchema.ts`, add to `exerciseSchema` (after `orderIndex`, before `sets`, lines 124-132):
+
+```ts
+const exerciseSchema = z.object({
+	id: uuid,
+	sessionId: uuid,
+	exerciseId: nullableField(z.string()),
+	name: z.string(),
+	muscleGroup: z.string().nullish().transform((v) => v ?? "General"),
+	orderIndex: z.number().int().nullish().transform((v) => v ?? 0),
+	// Mobile-provided canonical estimated 1RM (per-cable kg). Optional for
+	// backward compat; absent → server recomputes (see exerciseProgressRows).
+	estimatedOneRepMaxKg: nullableField(z.number()),
+	sets: arrayOf(setSchema).default([]),
+});
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- sync-push-schema`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/_shared/pushPayloadSchema.ts src/lib/__tests__/sync-push-schema.test.ts
+git commit -m "feat: accept estimatedOneRepMaxKg on push exercise schema"
+```
+
+---
+
+## Task 2: Extract the progress-row builder with mobile-value preference
+
+**Files:**
+- Create: `supabase/functions/_shared/exerciseProgressRows.ts`
+- Test: `src/lib/__tests__/sync-exercise-progress.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/sync-exercise-progress.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	buildExerciseProgressRows,
+	estimateOneRepMaxKg,
+} from "../../../supabase/functions/_shared/exerciseProgressRows.ts";
+
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+
+describe("estimateOneRepMaxKg (hybrid)", () => {
+	it("uses Brzycki at or below 10 reps", () => {
+		expect(estimateOneRepMaxKg(100, 5)).toBeCloseTo(112.5); // 100*36/32
+	});
+	it("is continuous at 10 reps", () => {
+		expect(estimateOneRepMaxKg(100, 10)).toBeCloseTo(133.333, 2);
+	});
+	it("uses Epley above 10 reps", () => {
+		expect(estimateOneRepMaxKg(100, 11)).toBeCloseTo(136.667, 2);
+	});
+	it("returns 0 for invalid input and weight for a single rep", () => {
+		expect(estimateOneRepMaxKg(0, 5)).toBe(0);
+		expect(estimateOneRepMaxKg(100, 0)).toBe(0);
+		expect(estimateOneRepMaxKg(100, 1)).toBe(100);
+	});
+});
+
+describe("buildExerciseProgressRows", () => {
+	const session = (estimatedOneRepMaxKg?: number) => ({
+		id: "s1",
+		startedAt: "2026-04-20T12:00:00.000Z",
+		exercises: [
+			{
+				name: "Squat",
+				exerciseId: null,
+				estimatedOneRepMaxKg,
+				sets: [{ weightKg: 60, actualReps: 5 }],
+			},
+		],
+	});
+
+	it("stores the mobile-provided estimate verbatim (rounded to 2dp)", () => {
+		const rows = buildExerciseProgressRows([session(133.33)], USER_ID, "default");
+		expect(rows).toHaveLength(1);
+		expect(rows[0].estimated_1rm_kg).toBe(133.33);
+	});
+
+	it("falls back to the hybrid when the field is absent", () => {
+		const rows = buildExerciseProgressRows([session(undefined)], USER_ID, "default");
+		// Brzycki(60, 5) = 60*36/32 = 67.5
+		expect(rows[0].estimated_1rm_kg).toBe(67.5);
+	});
+
+	it("skips exercises with no sets", () => {
+		const rows = buildExerciseProgressRows(
+			[{ id: "s2", startedAt: "x", exercises: [{ name: "E", exerciseId: null, sets: [] }] }],
+			USER_ID,
+			null,
+		);
+		expect(rows).toHaveLength(0);
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- sync-exercise-progress`
+Expected: FAIL — module `exerciseProgressRows.ts` does not exist.
+
+- [ ] **Step 3: Create the helper**
+
+Create `supabase/functions/_shared/exerciseProgressRows.ts`:
+
+```ts
+/**
+ * exercise_progress row builder.
+ *
+ * Source of truth for estimated 1RM is the MOBILE app, which ships
+ * `estimatedOneRepMaxKg` per exercise. This builder stores that value
+ * verbatim. It only recomputes (via the canonical hybrid) when the field is
+ * absent — i.e. legacy payloads from pre-parity mobile builds.
+ *
+ * PARITY-CRITICAL: estimateOneRepMaxKg must match mobile
+ * OneRepMaxCalculator.estimate (Brzycki for reps <= 10, Epley for reps > 10).
+ */
+
+export interface ProgressSetInput {
+	weightKg: number;
+	actualReps: number;
+}
+
+export interface ProgressExerciseInput {
+	name: string;
+	exerciseId?: string | null;
+	estimatedOneRepMaxKg?: number | null;
+	sets: ProgressSetInput[];
+}
+
+export interface ProgressSessionInput {
+	id: string;
+	startedAt: string;
+	exercises: ProgressExerciseInput[];
+}
+
+export interface ExerciseProgressRow {
+	user_id: string;
+	local_profile_id: string | null;
+	exercise_name: string;
+	exercise_id: string | null;
+	session_id: string;
+	recorded_at: string;
+	max_weight_kg: number;
+	total_volume_kg: number;
+	estimated_1rm_kg: number;
+	max_reps: number;
+	set_count: number;
+}
+
+/** Canonical hybrid 1RM estimate (per-cable kg). Continuous at reps == 10. */
+export function estimateOneRepMaxKg(weightKg: number, reps: number): number {
+	if (weightKg <= 0 || reps <= 0) return 0;
+	if (reps === 1) return weightKg;
+	if (reps <= 10) return weightKg * (36 / (37 - reps));
+	return weightKg * (1 + reps / 30);
+}
+
+function bestEstimateFromSets(sets: ProgressSetInput[]): number {
+	let best = 0;
+	for (const s of sets) {
+		const e1rm = estimateOneRepMaxKg(s.weightKg, s.actualReps);
+		if (e1rm > best) best = e1rm;
+	}
+	return best;
+}
+
+export function buildExerciseProgressRows(
+	sessions: ProgressSessionInput[],
+	userId: string,
+	localProfileId: string | null,
+): ExerciseProgressRow[] {
+	const rows: ExerciseProgressRow[] = [];
+	for (const session of sessions) {
+		for (const exercise of session.exercises) {
+			if (exercise.sets.length === 0) continue;
+
+			const maxWeight = Math.max(...exercise.sets.map((s) => s.weightKg));
+			const totalVolume = exercise.sets.reduce(
+				(sum, s) => sum + s.weightKg * s.actualReps,
+				0,
+			);
+			const maxReps = Math.max(...exercise.sets.map((s) => s.actualReps));
+			const setCount = exercise.sets.length;
+
+			const estimated1rm =
+				exercise.estimatedOneRepMaxKg != null && exercise.estimatedOneRepMaxKg > 0
+					? exercise.estimatedOneRepMaxKg
+					: bestEstimateFromSets(exercise.sets);
+
+			rows.push({
+				user_id: userId,
+				local_profile_id: localProfileId,
+				exercise_name: exercise.name,
+				exercise_id: exercise.exerciseId ?? null,
+				session_id: session.id,
+				recorded_at: session.startedAt,
+				max_weight_kg: maxWeight,
+				total_volume_kg: totalVolume,
+				estimated_1rm_kg: Math.round(estimated1rm * 100) / 100,
+				max_reps: maxReps,
+				set_count: setCount,
+			});
+		}
+	}
+	return rows;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- sync-exercise-progress`
+Expected: PASS (7 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/_shared/exerciseProgressRows.ts src/lib/__tests__/sync-exercise-progress.test.ts
+git commit -m "feat: extract exercise_progress builder preferring mobile 1RM"
+```
+
+---
+
+## Task 3: Wire the edge function to the extracted builder
+
+**Files:**
+- Modify: `supabase/functions/mobile-sync-push/index.ts:1322-1361`
+
+- [ ] **Step 1: Add the import**
+
+Near the top of `index.ts`, alongside the other `../_shared/...` imports, add:
+
+```ts
+import { buildExerciseProgressRows } from "../_shared/exerciseProgressRows.ts";
+```
+
+- [ ] **Step 2: Replace the inline computation**
+
+Replace the entire block from line 1322 (`// 5. Compute exercise_progress...`) through the close of the `progressRows.push({...})` loop at line 1361 with:
+
+```ts
+      // =====================================================================
+      // 5. Compute exercise_progress (mobile-provided 1RM, hybrid fallback)
+      // =====================================================================
+      const progressRows = buildExerciseProgressRows(
+        payload.sessions,
+        userId,
+        localProfileId,
+      );
+```
+
+Leave the dedupe + insert block (current lines 1363-1401) unchanged — `progressRows` keeps the same row shape (`session_id`, `exercise_id`, `exercise_name`, `estimated_1rm_kg`, …).
+
+- [ ] **Step 3: Verify typecheck and full suite**
+
+Run: `npm run typecheck && npm test -- sync`
+Expected: typecheck clean; sync tests pass (the existing round-trip/validation tests still see `estimated_1rm_kg` populated).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/functions/mobile-sync-push/index.ts
+git commit -m "refactor: use shared builder for exercise_progress in sync-push"
+```
+
+---
+
+## Task 4: Align the client-side fallback formula
+
+**Files:**
+- Modify: `src/lib/biomechanics.ts:19-26`
+- Test: `src/lib/__tests__/biomechanics.test.ts` (modify)
+
+- [ ] **Step 1: Update the test**
+
+In `biomechanics.test.ts`, replace/extend the `estimateOneRepMax` assertions with the hybrid expectations (the function still returns a rounded integer):
+
+```ts
+it("estimateOneRepMax uses Brzycki at or below 10 reps", () => {
+	expect(estimateOneRepMax(100, 5)).toBe(113); // 112.5 -> 113
+});
+it("estimateOneRepMax is continuous at 10 reps", () => {
+	expect(estimateOneRepMax(100, 10)).toBe(133); // 133.33 -> 133
+});
+it("estimateOneRepMax uses Epley above 10 reps", () => {
+	expect(estimateOneRepMax(100, 11)).toBe(137); // 136.67 -> 137
+});
+it("estimateOneRepMax returns weight for 1 rep and 0 for invalid", () => {
+	expect(estimateOneRepMax(100, 1)).toBe(100);
+	expect(estimateOneRepMax(0, 5)).toBe(0);
+});
+```
+
+Delete any pre-existing `estimateOneRepMax` assertion that encoded the old pure-Epley value (e.g. `estimateOneRepMax(100, 5) === 117`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- biomechanics`
+Expected: FAIL on the reps=5 / reps=10 cases (old Epley values).
+
+- [ ] **Step 3: Update the implementation**
+
+Replace `estimateOneRepMax` (lines 19-26):
+
+```ts
+/**
+ * Estimate one-rep max using the canonical hybrid (parity with mobile
+ * OneRepMaxCalculator.estimate): Brzycki for reps <= 10, Epley for reps > 10.
+ * Returns a rounded integer; 0 for invalid input; weight itself for 1 rep.
+ *
+ * NOTE: After 1RM parity, the portal reads estimated_1rm_kg from
+ * exercise_progress (mobile-provided). This client computation is a fallback
+ * only and MUST use the same formula.
+ */
+export function estimateOneRepMax(weight: number, reps: number): number {
+	if (weight <= 0 || reps <= 0) return 0;
+	if (reps === 1) return weight;
+	const raw =
+		reps <= 10 ? weight * (36 / (37 - reps)) : weight * (1 + reps / 30);
+	return Math.round(raw);
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- biomechanics`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/biomechanics.ts src/lib/__tests__/biomechanics.test.ts
+git commit -m "fix: align client 1RM fallback to canonical hybrid"
+```
+
+---
+
+## Task 5: Fix CSV record-type mapping
+
+**Files:**
+- Modify: `src/lib/export/csv.ts:62-72`
+- Test: `src/lib/export/__tests__/csv.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/export/__tests__/csv.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { generateRecordsCSV } from "../csv";
+
+// Use the function's own parameter type so we don't depend on the import path
+// of the PersonalRecord type.
+type Records = Parameters<typeof generateRecordsCSV>[0];
+
+function record(recordType: string): Records[number] {
+	return {
+		exercise_name: "Squat",
+		muscle_group: "Legs",
+		record_type: recordType,
+		value: 100,
+		previous_value: null,
+		unit: "kg",
+		achieved_at: new Date("2026-04-20T00:00:00.000Z"),
+	} as unknown as Records[number];
+}
+
+describe("generateRecordsCSV record type labels", () => {
+	it("maps uppercase MAX_WEIGHT to 'Max Weight'", () => {
+		const csv = generateRecordsCSV([record("MAX_WEIGHT")] as Records);
+		expect(csv).toContain("Max Weight");
+		expect(csv).not.toContain("MAX_WEIGHT");
+	});
+
+	it("maps MAX_VOLUME to 'Max Volume'", () => {
+		const csv = generateRecordsCSV([record("MAX_VOLUME")] as Records);
+		expect(csv).toContain("Max Volume");
+	});
+
+	it("maps 1RM to 'Estimated 1RM'", () => {
+		const csv = generateRecordsCSV([record("1RM")] as Records);
+		expect(csv).toContain("Estimated 1RM");
+	});
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -- export/__tests__/csv`
+Expected: FAIL — current map is lowercase-keyed, so the CSV contains raw `MAX_WEIGHT`.
+
+- [ ] **Step 3: Fix `formatRecordType`**
+
+Replace `formatRecordType` (lines 62-72):
+
+```ts
+function formatRecordType(type: string): string {
+	const types: Record<string, string> = {
+		MAX_WEIGHT: "Max Weight",
+		MAX_REPS: "Max Reps",
+		MAX_VOLUME: "Max Volume",
+		"1RM": "Estimated 1RM",
+		FASTEST_TIME: "Fastest Time",
+		LONGEST_DISTANCE: "Longest Distance",
+	};
+	// Normalize so legacy lowercase values map too.
+	return types[(type ?? "").toUpperCase()] ?? type;
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -- export/__tests__/csv`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/export/csv.ts src/lib/export/__tests__/csv.test.ts
+git commit -m "fix: map uppercase record_type values in CSV export"
+```
+
+---
+
+## Task 6: Fix RecordsTab record-type labels (same root cause)
+
+**Files:**
+- Modify: `src/app/components/analytics/RecordsTab.tsx` — `formatRecordTypeLabel` (around line 45)
+
+- [ ] **Step 1: Apply the same normalization**
+
+Update `formatRecordTypeLabel` so it maps the actual uppercase DB values (`MAX_WEIGHT` → "Max Weight", `MAX_VOLUME` → "Max Volume", `MAX_REPS` → "Max Reps", `1RM` → "1RM") and normalizes case with `(type ?? "").toUpperCase()`, falling through to the raw string. Mirror the `formatRecordType` map from `csv.ts` so the two stay consistent. Ensure max-weight PRs read "Max Weight", not "1RM".
+
+- [ ] **Step 2: Verify**
+
+Run: `npm test -- RecordsTab` (if a RecordsTab test exists) and `npm run typecheck`
+Expected: typecheck clean; any RecordsTab tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/components/analytics/RecordsTab.tsx
+git commit -m "fix: normalize record_type labels in RecordsTab"
+```
+
+---
+
+## Task 7: Document the parity constant + final verification
+
+**Files:**
+- Modify: `phoenix-portal/CLAUDE.md`
+
+- [ ] **Step 1: Add a parity note**
+
+Add to the portal CLAUDE.md (near the sync/transforms guidance):
+
+```markdown
+### 1RM Estimate Parity (PARITY-CRITICAL)
+- Estimated 1RM is computed on MOBILE (hybrid: Brzycki reps<=10, Epley reps>10) and shipped as `estimatedOneRepMaxKg` per exercise. The edge function stores it verbatim in `exercise_progress.estimated_1rm_kg`.
+- `_shared/exerciseProgressRows.ts#estimateOneRepMaxKg` and `src/lib/biomechanics.ts#estimateOneRepMax` are FALLBACKS only and MUST match the mobile formula.
+- `personal_records` holds max-weight/max-volume PRs (a different metric) — never relabel them as "1RM".
+```
+
+- [ ] **Step 2: Format + full verification**
+
+Run:
+```bash
+npx biome check --write src/lib/export/csv.ts src/lib/biomechanics.ts \
+  src/app/components/analytics/RecordsTab.tsx \
+  src/lib/__tests__/sync-exercise-progress.test.ts \
+  src/lib/export/__tests__/csv.test.ts
+npm run typecheck
+npm test
+```
+Expected: biome clean; typecheck clean; all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add phoenix-portal/CLAUDE.md
+git commit -m "docs: document 1RM estimate parity constant (portal)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** schema accepts field (Task 1) ✓; edge stores mobile value + hybrid fallback (Tasks 2-3) ✓; client fallback aligned (Task 4) ✓; CSV mapping fixed (Task 5) ✓; RecordsTab label fixed (Task 6) ✓; parity doc (Task 7) ✓. "Portal never computes a *different* number" satisfied: the only TS computations are fallbacks using the identical hybrid.
+- **Placeholder scan:** All code blocks concrete except Task 6, which is described precisely (mirror the `csv.ts` map) because the exact current `formatRecordTypeLabel` body must be read in-file; the mapping to apply is fully specified.
+- **Type consistency:** `estimateOneRepMaxKg(weightKg, reps)` defined in Task 2 and asserted in Task 2's test; `buildExerciseProgressRows(sessions, userId, localProfileId)` defined in Task 2 and called in Task 3; `ExerciseProgressRow.estimated_1rm_kg` produced in Task 2 and consumed by the unchanged dedupe/insert in Task 3.
+- **Coordination:** field is optional → mobile/portal deploy order independent; legacy fallback covers pre-field payloads.

--- a/docs/superpowers/specs/2026-05-30-1rm-parity-portal-design.md
+++ b/docs/superpowers/specs/2026-05-30-1rm-parity-portal-design.md
@@ -1,0 +1,71 @@
+# 1RM Feature — Parity & Full Functionality (Portal, phoenix-portal)
+
+- **Date:** 2026-05-30
+- **Repo:** phoenix-portal (React/TS + Supabase edge functions)
+- **Counterpart spec:** `Project-Phoenix-MP/docs/superpowers/specs/2026-05-30-1rm-parity-mobile-design.md` (must land together — shared sync contract)
+- **Definition of done:** the 1RM number agrees everywhere (portal stops computing its own)
+- **Sequencing:** Phase 1 correctness/parity (this spec is almost entirely Phase 1; mobile owns Phase 2)
+
+---
+
+## Problem statement
+
+"1RM" currently resolves to **three incompatible numbers**. The portal recomputes its own estimate two different ways and conflates a raw max-weight PR with "1RM". The fix: **the portal stops computing 1RM** and displays the mobile-provided canonical estimate.
+
+### Verified findings (portal-relevant, confirmed by direct inspection)
+- Portal trend charts use server-side **Brzycki** `w·(36/(37−reps))` for reps 1–12 in `mobile-sync-push/index.ts:1338-1356`, stored in `exercise_progress.estimated_1rm_kg`.
+- Portal client fallback uses **Epley** rounded in `biomechanics.ts:22-26`.
+- `personal_records` holds **correctly-labeled max-weight/max-volume PRs** (`value = weightKg`, `record_type = prType`) — `personalRecordRow.ts:95-98`. The `?? "1RM"` default essentially never fires; mobile sends uppercase `MAX_WEIGHT`/`MAX_VOLUME`.
+- **CSV bug is broad:** `formatRecordType` (`csv.ts:62-72`) maps **lowercase** keys (`max_weight`, `max_volume`, `max_e1rm`…) but mobile sends **uppercase** `record_type`. The map never matches; exports show raw uppercase strings. No `"1RM"` key exists.
+
+### What works (must not regress)
+`exercise_progress` read/display in `ExerciseDeepDive`/`ExerciseProgress`; `personal_records` timeline in `RecordsTab`; the 2× per-cable→display weight multiplier across queries/schemas; existing 1RM tests (`records.test.ts`, `ExerciseDeepDive.test.tsx`).
+
+---
+
+## Architecture: portal displays the mobile estimate, never recomputes
+
+### Canonical formula (defined on mobile; reproduced here only for the legacy fallback)
+```
+estimate1RM(weight, reps):
+  if weight <= 0 || reps <= 0  -> 0
+  if reps == 1                 -> weight
+  if reps <= 10                -> weight * (36 / (37 - reps))   // Brzycki
+  else                         -> weight * (1 + reps / 30)      // Epley
+```
+Continuous at reps = 10. Mobile is the source of truth; the portal uses this **only** as a server-side fallback when a payload lacks the synced field. Document as a parity-critical constant in CLAUDE.md.
+
+### Two distinct metrics (do not conflate)
+- **Max Weight PR** (`personal_records`) — label "Max Weight", not "1RM".
+- **Estimated 1RM** (`exercise_progress.estimated_1rm_kg`) — populated from the mobile-provided value.
+
+### Shared sync contract (must match the mobile spec exactly)
+- New optional field `estimatedOneRepMaxKg` (per-cable kg) on the exercise/set push DTO.
+- Add it to the zod schema in `supabase/functions/_shared/pushPayloadSchema.ts`.
+- Per-cable value; the existing 2× display multiplier still applies on read.
+
+---
+
+## Phase 1 — Correctness / Parity (portal tasks)
+1. `mobile-sync-push/index.ts:1338-1356`: **stop computing Brzycki**; store the mobile-provided `estimatedOneRepMaxKg` into `exercise_progress.estimated_1rm_kg`. Server-side **same-hybrid** fallback only when the field is absent (legacy payloads).
+2. `pushPayloadSchema.ts`: add the optional `estimatedOneRepMaxKg` field.
+3. `biomechanics.ts`: align the client `estimateOneRepMax` to the hybrid (or remove the recompute path) and document parity. No surface should show a number computed by a different formula than the synced one.
+4. `csv.ts:62-72`: fix `formatRecordType` to match the actual uppercase `record_type` values; add an estimated-1RM label sourced correctly.
+5. Display consistency: surfaces showing "1RM" read `exercise_progress.estimated_1rm_kg`; `personal_records` rows labeled "Max Weight".
+
+### Tests
+- Edge-function test: mobile-provided `estimatedOneRepMaxKg` stored verbatim; legacy payload uses the hybrid fallback.
+- CSV mapping test: uppercase `record_type` values render correct labels.
+- Records/progress query tests still pass.
+- Verify: `npm test`, `npm run typecheck`, sync/edge tests, `npx biome check`. No DB column change needed (`estimated_1rm_kg` exists), so no type regen required.
+
+---
+
+## Risks / open items
+- Wire-contract change must land together with the mobile spec (CLAUDE.md parity rule). Backward compatible via the absent-field server fallback.
+- Portal repo currently has unrelated WIP on `main`; commit only the spec/feature files for this effort.
+
+## Out of scope (not selected)
+- "Tested vs. estimated" 1RM as a user-facing distinction feature (data still separates them).
+- Phase 2 input-path persistence (mobile-owned).
+- User-selectable formula choice.

--- a/src/app/components/analytics/RecordsTab.tsx
+++ b/src/app/components/analytics/RecordsTab.tsx
@@ -49,7 +49,7 @@ function formatRecordTypeLabel(recordType: string): string {
 		MAX_FORCE: "Force PR",
 		MAX_VELOCITY: "Velocity PR",
 	};
-	return labels[(recordType ?? "").toUpperCase()] ?? recordType;
+	return labels[(recordType ?? "").toUpperCase()] ?? recordType ?? "";
 }
 
 function formatRecordMeasurement(

--- a/src/app/components/analytics/RecordsTab.tsx
+++ b/src/app/components/analytics/RecordsTab.tsx
@@ -49,7 +49,7 @@ function formatRecordTypeLabel(recordType: string): string {
 		MAX_FORCE: "Force PR",
 		MAX_VELOCITY: "Velocity PR",
 	};
-	return labels[recordType] ?? recordType;
+	return labels[(recordType ?? "").toUpperCase()] ?? recordType;
 }
 
 function formatRecordMeasurement(

--- a/src/lib/__tests__/biomechanics.test.ts
+++ b/src/lib/__tests__/biomechanics.test.ts
@@ -66,13 +66,25 @@ describe("estimateOneRepMax", () => {
 		expect(estimateOneRepMax(225, 1)).toBe(225);
 	});
 
-	it("applies Epley formula for reps > 1", () => {
-		// 100 * (1 + 5/30) = 100 * 1.1667 = 116.67 -> Math.round -> 117
-		expect(estimateOneRepMax(100, 5)).toBe(117);
+	it("estimateOneRepMax uses Brzycki at or below 10 reps", () => {
+		expect(estimateOneRepMax(100, 5)).toBe(113); // 112.5 -> 113
 	});
 
-	it("calculates correctly for higher reps", () => {
-		// 80 * (1 + 10/30) = 80 * 1.3333 = 106.67 -> 107
+	it("estimateOneRepMax is continuous at 10 reps", () => {
+		expect(estimateOneRepMax(100, 10)).toBe(133); // 133.33 -> 133
+	});
+
+	it("estimateOneRepMax uses Epley above 10 reps", () => {
+		expect(estimateOneRepMax(100, 11)).toBe(137); // 136.67 -> 137
+	});
+
+	it("estimateOneRepMax returns weight for 1 rep and 0 for invalid", () => {
+		expect(estimateOneRepMax(100, 1)).toBe(100);
+		expect(estimateOneRepMax(0, 5)).toBe(0);
+	});
+
+	it("calculates correctly for higher reps (Brzycki)", () => {
+		// 80 * (36 / (37 - 10)) = 80 * (36/27) = 80 * 1.3333 = 106.67 -> 107
 		expect(estimateOneRepMax(80, 10)).toBe(107);
 	});
 });

--- a/src/lib/__tests__/sync-exercise-progress.test.ts
+++ b/src/lib/__tests__/sync-exercise-progress.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildExerciseProgressRows,
+	estimateOneRepMaxKg,
+} from "../../../supabase/functions/_shared/exerciseProgressRows.ts";
+
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+
+describe("estimateOneRepMaxKg (hybrid)", () => {
+	it("uses Brzycki at or below 10 reps", () => {
+		expect(estimateOneRepMaxKg(100, 5)).toBeCloseTo(112.5);
+	});
+	it("is continuous at 10 reps", () => {
+		expect(estimateOneRepMaxKg(100, 10)).toBeCloseTo(133.333, 2);
+	});
+	it("uses Epley above 10 reps", () => {
+		expect(estimateOneRepMaxKg(100, 11)).toBeCloseTo(136.667, 2);
+	});
+	it("returns 0 for invalid input and weight for a single rep", () => {
+		expect(estimateOneRepMaxKg(0, 5)).toBe(0);
+		expect(estimateOneRepMaxKg(100, 0)).toBe(0);
+		expect(estimateOneRepMaxKg(100, 1)).toBe(100);
+	});
+});
+
+describe("buildExerciseProgressRows", () => {
+	const session = (estimatedOneRepMaxKg?: number) => ({
+		id: "s1",
+		startedAt: "2026-04-20T12:00:00.000Z",
+		exercises: [
+			{
+				name: "Squat",
+				exerciseId: null,
+				estimatedOneRepMaxKg,
+				sets: [{ weightKg: 60, actualReps: 5 }],
+			},
+		],
+	});
+
+	it("stores the mobile-provided estimate verbatim (rounded to 2dp)", () => {
+		const rows = buildExerciseProgressRows(
+			[session(133.33)],
+			USER_ID,
+			"default",
+		);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].estimated_1rm_kg).toBe(133.33);
+	});
+
+	it("falls back to the hybrid when the field is absent", () => {
+		const rows = buildExerciseProgressRows(
+			[session(undefined)],
+			USER_ID,
+			"default",
+		);
+		expect(rows[0].estimated_1rm_kg).toBe(67.5);
+	});
+
+	it("skips exercises with no sets", () => {
+		const rows = buildExerciseProgressRows(
+			[
+				{
+					id: "s2",
+					startedAt: "x",
+					exercises: [{ name: "E", exerciseId: null, sets: [] }],
+				},
+			],
+			USER_ID,
+			null,
+		);
+		expect(rows).toHaveLength(0);
+	});
+});

--- a/src/lib/__tests__/sync-push-schema.test.ts
+++ b/src/lib/__tests__/sync-push-schema.test.ts
@@ -495,6 +495,32 @@ describe("pushPayloadSchema", () => {
 		});
 	});
 
+	it("parses estimatedOneRepMaxKg on an exercise", () => {
+		const parsed = pushPayloadSchema.parse({
+			deviceId: "dev-1",
+			platform: "android",
+			sessions: [
+				{
+					id: "11111111-1111-1111-1111-111111111111",
+					userId: "u1",
+					startedAt: "2026-04-20T12:00:00.000Z",
+					exercises: [
+						{
+							id: "22222222-2222-2222-2222-222222222222",
+							sessionId: "11111111-1111-1111-1111-111111111111",
+							name: "Squat",
+							estimatedOneRepMaxKg: 133.33,
+							sets: [],
+						},
+					],
+				},
+			],
+		});
+		expect(parsed.sessions[0].exercises[0].estimatedOneRepMaxKg).toBeCloseTo(
+			133.33,
+		);
+	});
+
 	it("reports routines that claim exercises but omit the routine exercise projection", () => {
 		const routineId = "77777777-7777-4777-8777-777777777777";
 		const parsed = pushPayloadSchema.parse({

--- a/src/lib/biomechanics.ts
+++ b/src/lib/biomechanics.ts
@@ -16,13 +16,20 @@ export function calculateAsymmetry(
 }
 
 /**
- * Estimate one-rep max using the Epley formula.
- * Returns 0 for invalid inputs, weight itself for single reps.
+ * Estimate one-rep max using the canonical hybrid (parity with mobile
+ * OneRepMaxCalculator.estimate): Brzycki for reps <= 10, Epley for reps > 10.
+ * Returns a rounded integer; 0 for invalid input; weight itself for 1 rep.
+ *
+ * NOTE: After 1RM parity, the portal reads estimated_1rm_kg from
+ * exercise_progress (mobile-provided). This client computation is a fallback
+ * only and MUST use the same formula.
  */
 export function estimateOneRepMax(weight: number, reps: number): number {
 	if (weight <= 0 || reps <= 0) return 0;
 	if (reps === 1) return weight;
-	return Math.round(weight * (1 + reps / 30));
+	const raw =
+		reps <= 10 ? weight * (36 / (37 - reps)) : weight * (1 + reps / 30);
+	return Math.round(raw);
 }
 
 /**

--- a/src/lib/export/__tests__/csv.test.ts
+++ b/src/lib/export/__tests__/csv.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { generateRecordsCSV } from "../csv";
+
+// Use the function's own parameter type so we don't depend on the import path
+// of the PersonalRecord type.
+type Records = Parameters<typeof generateRecordsCSV>[0];
+
+function record(recordType: string): Records[number] {
+	return {
+		exercise_name: "Squat",
+		muscle_group: "Legs",
+		record_type: recordType,
+		value: 100,
+		previous_value: null,
+		unit: "kg",
+		achieved_at: new Date("2026-04-20T00:00:00.000Z"),
+	} as unknown as Records[number];
+}
+
+describe("generateRecordsCSV record type labels", () => {
+	it("maps uppercase MAX_WEIGHT to 'Max Weight'", () => {
+		const csv = generateRecordsCSV([record("MAX_WEIGHT")] as Records);
+		expect(csv).toContain("Max Weight");
+		expect(csv).not.toContain("MAX_WEIGHT");
+	});
+	it("maps MAX_VOLUME to 'Max Volume'", () => {
+		const csv = generateRecordsCSV([record("MAX_VOLUME")] as Records);
+		expect(csv).toContain("Max Volume");
+	});
+	it("maps 1RM to 'Estimated 1RM'", () => {
+		const csv = generateRecordsCSV([record("1RM")] as Records);
+		expect(csv).toContain("Estimated 1RM");
+	});
+});

--- a/src/lib/export/csv.ts
+++ b/src/lib/export/csv.ts
@@ -69,7 +69,7 @@ function formatRecordType(type: string): string {
 		LONGEST_DISTANCE: "Longest Distance",
 	};
 	// Normalize so legacy lowercase values map too.
-	return types[(type ?? "").toUpperCase()] ?? type;
+	return types[(type ?? "").toUpperCase()] ?? type ?? "";
 }
 
 /**

--- a/src/lib/export/csv.ts
+++ b/src/lib/export/csv.ts
@@ -61,14 +61,15 @@ export function generateRecordsCSV(
 
 function formatRecordType(type: string): string {
 	const types: Record<string, string> = {
-		max_weight: "Max Weight",
-		max_reps: "Max Reps",
-		max_volume: "Max Volume",
-		max_e1rm: "Estimated 1RM",
-		fastest_time: "Fastest Time",
-		longest_distance: "Longest Distance",
+		MAX_WEIGHT: "Max Weight",
+		MAX_REPS: "Max Reps",
+		MAX_VOLUME: "Max Volume",
+		"1RM": "Estimated 1RM",
+		FASTEST_TIME: "Fastest Time",
+		LONGEST_DISTANCE: "Longest Distance",
 	};
-	return types[type] ?? type;
+	// Normalize so legacy lowercase values map too.
+	return types[(type ?? "").toUpperCase()] ?? type;
 }
 
 /**

--- a/supabase/functions/_shared/exerciseProgressRows.ts
+++ b/supabase/functions/_shared/exerciseProgressRows.ts
@@ -1,0 +1,101 @@
+/**
+ * exercise_progress row builder.
+ *
+ * Source of truth for estimated 1RM is the MOBILE app, which ships
+ * `estimatedOneRepMaxKg` per exercise. This builder stores that value
+ * verbatim. It only recomputes (via the canonical hybrid) when the field is
+ * absent — i.e. legacy payloads from pre-parity mobile builds.
+ *
+ * PARITY-CRITICAL: estimateOneRepMaxKg must match mobile
+ * OneRepMaxCalculator.estimate (Brzycki for reps <= 10, Epley for reps > 10).
+ */
+
+export interface ProgressSetInput {
+	weightKg: number;
+	actualReps: number;
+}
+
+export interface ProgressExerciseInput {
+	name: string;
+	exerciseId?: string | null;
+	estimatedOneRepMaxKg?: number | null;
+	sets: ProgressSetInput[];
+}
+
+export interface ProgressSessionInput {
+	id: string;
+	startedAt: string;
+	exercises: ProgressExerciseInput[];
+}
+
+export interface ExerciseProgressRow {
+	user_id: string;
+	local_profile_id: string | null;
+	exercise_name: string;
+	exercise_id: string | null;
+	session_id: string;
+	recorded_at: string;
+	max_weight_kg: number;
+	total_volume_kg: number;
+	estimated_1rm_kg: number;
+	max_reps: number;
+	set_count: number;
+}
+
+/** Canonical hybrid 1RM estimate (per-cable kg). Continuous at reps == 10. */
+export function estimateOneRepMaxKg(weightKg: number, reps: number): number {
+	if (weightKg <= 0 || reps <= 0) return 0;
+	if (reps === 1) return weightKg;
+	if (reps <= 10) return weightKg * (36 / (37 - reps));
+	return weightKg * (1 + reps / 30);
+}
+
+function bestEstimateFromSets(sets: ProgressSetInput[]): number {
+	let best = 0;
+	for (const s of sets) {
+		const e1rm = estimateOneRepMaxKg(s.weightKg, s.actualReps);
+		if (e1rm > best) best = e1rm;
+	}
+	return best;
+}
+
+export function buildExerciseProgressRows(
+	sessions: ProgressSessionInput[],
+	userId: string,
+	localProfileId: string | null,
+): ExerciseProgressRow[] {
+	const rows: ExerciseProgressRow[] = [];
+	for (const session of sessions) {
+		for (const exercise of session.exercises) {
+			if (exercise.sets.length === 0) continue;
+
+			const maxWeight = Math.max(...exercise.sets.map((s) => s.weightKg));
+			const totalVolume = exercise.sets.reduce(
+				(sum, s) => sum + s.weightKg * s.actualReps,
+				0,
+			);
+			const maxReps = Math.max(...exercise.sets.map((s) => s.actualReps));
+			const setCount = exercise.sets.length;
+
+			const estimated1rm =
+				exercise.estimatedOneRepMaxKg != null && exercise.estimatedOneRepMaxKg > 0
+					? exercise.estimatedOneRepMaxKg
+					: bestEstimateFromSets(exercise.sets);
+
+			rows.push({
+				user_id: userId,
+				local_profile_id: localProfileId,
+				exercise_name: exercise.name,
+				exercise_id: exercise.exerciseId ?? null,
+				session_id: session.id,
+				recorded_at: session.startedAt,
+				max_weight_kg: maxWeight,
+				total_volume_kg: totalVolume,
+				estimated_1rm_kg: Math.round(estimated1rm * 100) / 100,
+				max_reps: maxReps,
+				set_count: setCount,
+			});
+		}
+	}
+	return rows;
+}

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -128,6 +128,9 @@ const exerciseSchema = z.object({
 	name: z.string(),
 	muscleGroup: z.string().nullish().transform((v) => v ?? "General"),
 	orderIndex: z.number().int().nullish().transform((v) => v ?? 0),
+	// Mobile-provided canonical estimated 1RM (per-cable kg). Optional for
+	// backward compat; absent → server recomputes (see exerciseProgressRows).
+	estimatedOneRepMaxKg: nullableField(z.number()),
 	sets: arrayOf(setSchema).default([]),
 });
 

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -16,6 +16,7 @@ import {
   formatPushPayloadError,
   pushPayloadSchema,
 } from '../_shared/pushPayloadSchema.ts';
+import { buildExerciseProgressRows } from '../_shared/exerciseProgressRows.ts';
 
 /**
  * Per-row rejection record returned to the mobile client when an LWW RPC
@@ -1319,46 +1320,13 @@ Deno.serve(async (req) => {
       }
 
       // =====================================================================
-      // 5. Compute exercise_progress from sets (Brzycki 1RM for reps 1-12)
+      // 5. Compute exercise_progress (mobile-provided 1RM, hybrid fallback)
       // =====================================================================
-      const progressRows: Record<string, unknown>[] = [];
-
-      for (const session of payload.sessions) {
-        for (const exercise of session.exercises) {
-          if (exercise.sets.length === 0) continue;
-
-          const maxWeight = Math.max(...exercise.sets.map((s) => s.weightKg));
-          const totalVolume = exercise.sets.reduce(
-            (sum, s) => sum + s.weightKg * s.actualReps,
-            0
-          );
-          const maxReps = Math.max(...exercise.sets.map((s) => s.actualReps));
-          const setCount = exercise.sets.length;
-
-          // Brzycki 1RM: weight * (36 / (37 - reps)), best set with reps 1-12 and weight > 0
-          let estimated1rm = 0;
-          for (const s of exercise.sets) {
-            if (s.weightKg > 0 && s.actualReps >= 1 && s.actualReps <= 12) {
-              const e1rm = s.weightKg * (36 / (37 - s.actualReps));
-              if (e1rm > estimated1rm) estimated1rm = e1rm;
-            }
-          }
-
-          progressRows.push({
-            user_id: userId,
-            local_profile_id: localProfileId,
-            exercise_name: exercise.name,
-            exercise_id: exercise.exerciseId ?? null,
-            session_id: session.id,
-            recorded_at: session.startedAt,
-            max_weight_kg: maxWeight,
-            total_volume_kg: totalVolume,
-            estimated_1rm_kg: Math.round(estimated1rm * 100) / 100,
-            max_reps: maxReps,
-            set_count: setCount,
-          });
-        }
-      }
+      const progressRows = buildExerciseProgressRows(
+        payload.sessions,
+        userId,
+        localProfileId,
+      );
 
       if (progressRows.length > 0) {
         const sessionIds = [...new Set(payload.sessions.map((session) => session.id))];


### PR DESCRIPTION
## Summary
- Accept optional \stimatedOneRepMaxKg\ on exercise sync DTO; edge function stores mobile value in \xercise_progress.estimated_1rm_kg\ (hybrid fallback for legacy payloads only)
- Align client \stimateOneRepMax\ fallback to the same hybrid formula as mobile
- Fix uppercase \ecord_type\ mapping in CSV export and RecordsTab (MAX_WEIGHT/MAX_VOLUME no longer show raw DB strings)
- Document parity constant in CLAUDE.md

## Test plan
- [x] \
px vitest run sync-exercise-progress sync-push-schema biomechanics csv\
- [x] \
pm run typecheck\
- [ ] Manual: sync from mobile with new field, confirm chart uses stored value (not server recompute)
- [ ] Land together with Project-Phoenix-MP \docs/1rm-parity-spec\ PR

Made with [Cursor](https://cursor.com)