### PR TITLE
Add phase-aware analytics and PR breakdowns

### DIFF
--- a/docs/superpowers/plans/2026-06-03-phase-weight-analytics.md
+++ b/docs/superpowers/plans/2026-06-03-phase-weight-analytics.md
@@ -1,0 +1,1172 @@
+# Phase Weight Analytics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reliable concentric/eccentric weight-phase analytics and visualization support across Phoenix Portal without inventing phase data the portal does not store.
+
+**Architecture:** Treat mobile-provided phase data as authoritative. Use `personal_records.workout_phase` for phase-aware PR/strength analytics and `session_phase_statistics` for concentric/eccentric session metric visualizations. Keep `exercise_progress` aggregate-only unless a later migration preserves per-exercise phase statistics.
+
+**Tech Stack:** React, TypeScript, TanStack Query, Supabase/PostgREST, Zod, ECharts/Recharts, Vitest.
+
+---
+
+## Source Evidence
+
+### Official App Reference
+
+The deobfuscated official app confirms phase separation is a first-class data model, not a display-only label.
+
+- `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\Zk\j.java`: `WorkoutMetricPhases` serializes each metric as a required `(concentric, eccentric, total)` triple and averages concentric/eccentric with separate counts.
+- `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\Zk\k.java`: `WorkoutMetrics` stores `max`, `average`, and `deviation`, each as `WorkoutMetricPhases`.
+- `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\Zk\t.java`: `WorkoutStatistics` stores separate `force` and `speed` `WorkoutMetrics`.
+- `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\Zk\n.java`: `WorkoutSamples` stores left/right samples plus `phase`.
+- `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\Zk\h.java`: phase statistics are computed from samples by splitting positive velocity as concentric and non-positive velocity as eccentric.
+- `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\com\vitruvian\app\ui\shared\r.java` and `C:\Users\dasbl\AndroidStudioProjects\VitruvianDeobfuscated\java-decompiled\sources\Lj\U.java`: workout summary UI displays peak and average force as paired concentric/eccentric values.
+
+### Portal Source of Truth
+
+- `supabase/migrations/20260319120000_mobile_portal_parity.sql`: `personal_records.workout_phase` exists and `session_phase_statistics` stores concentric/eccentric kg, velocity, and watt averages/maxes.
+- `supabase/functions/_shared/pushPayloadSchema.ts`: `phaseStatistics` accepts concentric/eccentric kg, velocity, and watt fields; `personalRecords[*].workoutPhase` defaults to `COMBINED`.
+- `supabase/functions/mobile-sync-push/index.ts`: sync persists `phaseStatistics` into `session_phase_statistics` and persists dedicated personal records with `workout_phase`.
+- `src/app/components/analytics/RecordsTab.tsx`, `src/app/components/Dashboard.tsx`, and `src/lib/export/csv.ts`: records already display/export workout phase.
+
+### Current Gaps
+
+- `src/queries/analytics.ts` selects `personal_records` for strength progress without `record_type` or `workout_phase`.
+- `src/app/components/Analytics.tsx` groups strength data by exercise only, so concentric/eccentric PRs collapse into one trend.
+- `src/queries/analytics.ts` has `phaseStatisticsOptions(sessionId)` only; there is no user/period query for trend cards or charts.
+- `src/queries/progress.ts`, `src/app/components/ExerciseProgress.tsx`, and `src/app/components/analytics/ExerciseDeepDive.tsx` depend on `exercise_progress`, which has no phase column.
+- `src/app/components/SummaryReport.tsx`, `src/app/components/Goals.tsx`, `src/queries/challenges.ts`, `supabase/functions/compute-rankings/index.ts`, and `supabase/functions/generate-insights/index.ts` count or describe PRs without phase semantics.
+
+## Visualization Route
+
+Analytical jobs:
+
+- Time change: phase-aware 1RM/PR progression.
+- Comparison: concentric vs eccentric peak/average load, velocity, and power.
+- Ranking: top lifts and PR counts with phase semantics.
+
+Artifact family:
+
+- Primary: small-multiple or grouped line chart for PR progression by phase.
+- Primary: paired metric bars/cards for concentric vs eccentric load, velocity, and watts.
+- Fallback: phase badges and segmented filtering when data volume is too sparse for separate series.
+
+UX rules:
+
+- Keep essential phase values visible without hover.
+- Use phase as an explicit control: `All`, `Combined`, `Concentric`, `Eccentric`.
+- On mobile, prefer grouped bars and compact paired cards over dense multi-series lines.
+- Never show a phase-specific exercise trend from `exercise_progress`; use records or session phase stats until phase-specific exercise progress is persisted.
+
+## File Structure
+
+Create:
+
+- `src/lib/workout-phases.ts`: shared phase labels, normalization, ordering, filters, and type guards.
+- `src/lib/__tests__/workout-phases.test.ts`: phase helper tests.
+- `src/app/components/analytics/strengthPhaseTransforms.ts`: pure chart transforms for phase-aware strength data.
+- `src/app/components/analytics/strengthPhaseTransforms.test.ts`: chart transform tests.
+- `src/app/components/analytics/phaseStatisticsTransforms.ts`: pure transforms for session phase stats summary/trends.
+- `src/app/components/analytics/phaseStatisticsTransforms.test.ts`: phase metric transform tests.
+
+Modify:
+
+- `src/queries/analytics.ts`: include `workout_phase` and `record_type`; add user-period phase stats query.
+- `src/queries/__tests__/analytics.test.ts`: assert new select fields, query keys, filters, and phase stats query behavior.
+- `src/app/components/Analytics.tsx`: hold URL-backed phase filter and derive phase-aware chart data.
+- `src/app/components/analytics/ProgressTab.tsx`: render phase controls, phase-aware PR summary, and paired phase metric chart/card.
+- `src/app/components/analytics/MobileProgressTab.tsx`: render mobile top lifts by phase and paired phase cards.
+- `src/app/components/analytics/ExerciseDeepDive.tsx`: display phase-aware PR count and avoid phase-specific 1RM claims from aggregate progress.
+- `src/app/components/ExerciseProgress.tsx`: add copy/controls that identify aggregate progress as combined/overall unless a phase-specific record chart is used.
+- `src/app/components/SummaryReport.tsx`: break PR summary into combined/concentric/eccentric counts.
+- `src/app/components/Goals.tsx`: keep current goals combined by default; prepare phase-aware PR goals only if a goal has a phase field.
+- `src/queries/challenges.ts`: document and test whether `pr_count` counts phase rows separately.
+- `supabase/functions/compute-rankings/index.ts`: test the selected PR ranking semantics after phase rows are included.
+- `supabase/functions/generate-insights/index.ts`: include phase labels in recent PR insight text.
+- `src/lib/export/csv.ts`: verify record phase export remains correct.
+
+Intentionally defer:
+
+- Do not add phase filtering to `exercise_progress` in this pass. Current schema lacks phase granularity there.
+- Do not add a migration unless product scope requires exercise-level phase progress beyond records and session-level phase stats.
+
+## Task 1: Audit Analytical Consumers
+
+**Files:**
+- Review: `src/queries/analytics.ts`
+- Review: `src/queries/progress.ts`
+- Review: `src/queries/records.ts`
+- Review: `src/app/components/Analytics.tsx`
+- Review: `src/app/components/analytics/ProgressTab.tsx`
+- Review: `src/app/components/analytics/MobileProgressTab.tsx`
+- Review: `src/app/components/analytics/RecordsTab.tsx`
+- Review: `src/app/components/analytics/ExerciseDeepDive.tsx`
+- Review: `src/app/components/ExerciseProgress.tsx`
+- Review: `src/app/components/SummaryReport.tsx`
+- Review: `src/app/components/Goals.tsx`
+- Review: `src/queries/challenges.ts`
+- Review: `supabase/functions/compute-rankings/index.ts`
+- Review: `supabase/functions/generate-insights/index.ts`
+- Review: `src/lib/export/csv.ts`
+
+- [x] **Step 1: Confirm all PR consumers**
+
+Run:
+
+```powershell
+rg -n "personal_records|workout_phase|pr_count|strengthProgressOptions|RecordsTab|daysSinceLastPR" src supabase tests
+```
+
+Expected: every phase-sensitive PR consumer is listed before implementation starts.
+
+- [x] **Step 2: Confirm all phase-stat consumers**
+
+Run:
+
+```powershell
+rg -n "session_phase_statistics|phaseStatistics|concentric_kg|eccentric_kg|concentric_vel|eccentric_vel|concentric_watt|eccentric_watt" src supabase tests
+```
+
+Expected: query support exists only for single-session phase stats, and no analytics page renders the table yet.
+
+- [x] **Step 3: Confirm aggregate-only exercise progress**
+
+Run:
+
+```powershell
+rg -n "CREATE TABLE IF NOT EXISTS exercise_progress|exercise_progress|estimated_1rm_kg|max_weight_kg|total_volume_kg" supabase src tests
+```
+
+Expected: `exercise_progress` has no `workout_phase` or phase stats columns. Keep this as a documented constraint.
+
+- [x] **Step 4: Verify this audit note stays accurate after the live commands**
+
+Update the dated section below `## Audit Results` only if the live audit commands reveal additional consumers. Use one of these exact classifications:
+
+```text
+ready-current-schema: can support phase analytics now
+needs-query-update: schema supports it, query/component does not
+aggregate-only: must remain combined/overall until schema is expanded
+semantic-decision: needs product decision on count/ranking semantics
+```
+
+## Audit Results
+
+Review date: 2026-06-03.
+
+```text
+ready-current-schema:
+- src/app/components/analytics/RecordsTab.tsx
+- src/app/components/Dashboard.tsx
+- src/lib/export/csv.ts
+
+needs-query-update:
+- src/queries/analytics.ts
+- src/app/components/Analytics.tsx
+- src/app/components/analytics/ProgressTab.tsx
+- src/app/components/analytics/MobileProgressTab.tsx
+- src/app/components/analytics/ExerciseDeepDive.tsx
+- src/app/components/SummaryReport.tsx
+- supabase/functions/generate-insights/index.ts
+
+aggregate-only:
+- src/queries/progress.ts
+- src/app/components/ExerciseProgress.tsx
+- exercise_progress-backed 1RM, max weight, and volume charts
+
+semantic-decision:
+- src/app/components/Goals.tsx
+- src/queries/challenges.ts
+- supabase/functions/compute-rankings/index.ts
+- supabase/migrations/20260412_leaderboard_functions.sql
+```
+
+Default decision: phase-specific PR rows count separately because `personal_records.workout_phase` is part of the sync identity and the official app treats concentric/eccentric metrics as independent first-class values. The UI copy should make this explicit where users may expect one PR per exercise.
+
+## Task 2: Add Shared Phase Helpers
+
+**Files:**
+- Create: `src/lib/workout-phases.ts`
+- Create: `src/lib/__tests__/workout-phases.test.ts`
+
+- [x] **Step 1: Write failing tests for normalization and display**
+
+Add `src/lib/__tests__/workout-phases.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+	formatWorkoutPhase,
+	isWorkoutPhase,
+	isNonCombinedWorkoutPhase,
+	normalizeWorkoutPhase,
+	WORKOUT_PHASE_FILTERS,
+} from "@/lib/workout-phases";
+
+describe("workout phase helpers", () => {
+	it("normalizes API, database, and display phase values", () => {
+		expect(normalizeWorkoutPhase("COMBINED")).toBe("Combined");
+		expect(normalizeWorkoutPhase("Concentric")).toBe("Concentric");
+		expect(normalizeWorkoutPhase("eccentric")).toBe("Eccentric");
+		expect(normalizeWorkoutPhase(null)).toBe("Combined");
+	});
+
+	it("keeps phase filter order stable", () => {
+		expect(WORKOUT_PHASE_FILTERS).toEqual([
+			"all",
+			"Combined",
+			"Concentric",
+			"Eccentric",
+		]);
+	});
+
+	it("detects valid and non-combined phases", () => {
+		expect(isWorkoutPhase("Concentric")).toBe(true);
+		expect(isWorkoutPhase("Other")).toBe(false);
+		expect(isNonCombinedWorkoutPhase("CONCENTRIC")).toBe(true);
+		expect(isNonCombinedWorkoutPhase("COMBINED")).toBe(false);
+	});
+
+	it("formats unknown values defensively as Combined", () => {
+		expect(formatWorkoutPhase("unexpected")).toBe("Combined");
+	});
+});
+```
+
+- [x] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```powershell
+npm test -- src/lib/__tests__/workout-phases.test.ts
+```
+
+Expected: FAIL because `src/lib/workout-phases.ts` does not exist.
+
+- [x] **Step 3: Implement the helper**
+
+Create `src/lib/workout-phases.ts`:
+
+```ts
+export const WORKOUT_PHASES = ["Combined", "Concentric", "Eccentric"] as const;
+export const WORKOUT_PHASE_FILTERS = ["all", ...WORKOUT_PHASES] as const;
+
+export type WorkoutPhase = (typeof WORKOUT_PHASES)[number];
+export type WorkoutPhaseFilter = (typeof WORKOUT_PHASE_FILTERS)[number];
+
+const phaseMap: Record<string, WorkoutPhase> = {
+	COMBINED: "Combined",
+	Combined: "Combined",
+	combined: "Combined",
+	CONCENTRIC: "Concentric",
+	Concentric: "Concentric",
+	concentric: "Concentric",
+	ECCENTRIC: "Eccentric",
+	Eccentric: "Eccentric",
+	eccentric: "Eccentric",
+};
+
+export function normalizeWorkoutPhase(
+	phase: string | null | undefined,
+): WorkoutPhase {
+	if (!phase) return "Combined";
+	return phaseMap[phase] ?? "Combined";
+}
+
+export function formatWorkoutPhase(
+	phase: string | null | undefined,
+): WorkoutPhase {
+	return normalizeWorkoutPhase(phase);
+}
+
+export function isWorkoutPhase(value: string): value is WorkoutPhase {
+	return WORKOUT_PHASES.includes(value as WorkoutPhase);
+}
+
+export function isNonCombinedWorkoutPhase(
+	phase: string | null | undefined,
+): boolean {
+	return normalizeWorkoutPhase(phase) !== "Combined";
+}
+```
+
+- [x] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```powershell
+npm test -- src/lib/__tests__/workout-phases.test.ts
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Replace duplicate local helpers**
+
+Modify `src/app/components/analytics/RecordsTab.tsx` and `src/app/components/Dashboard.tsx` to import helpers from `@/lib/workout-phases` instead of duplicating phase formatting logic.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+git add src/lib/workout-phases.ts src/lib/__tests__/workout-phases.test.ts src/app/components/analytics/RecordsTab.tsx src/app/components/Dashboard.tsx
+git commit -m "refactor: centralize workout phase helpers"
+```
+
+## Task 3: Make Analytics Queries Phase-Aware
+
+**Files:**
+- Modify: `src/queries/analytics.ts`
+- Modify: `src/queries/__tests__/analytics.test.ts`
+- Modify: `src/queries/keys.ts`
+
+- [x] **Step 1: Write failing query tests for strength phase fields**
+
+Add assertions to `src/queries/__tests__/analytics.test.ts` under `describe("strengthProgressOptions")`:
+
+```ts
+it("selects record type and workout phase for phase-aware strength charts", async () => {
+	chain = buildChain({ data: [], error: null });
+	const { strengthProgressOptions } = await import("../analytics");
+	const opts = strengthProgressOptions("user-1");
+	await opts.queryFn?.({} as never);
+	expect(chain.select).toHaveBeenCalledWith(
+		"exercise_name, exercise_id, record_type, workout_phase, value, achieved_at",
+	);
+});
+```
+
+- [x] **Step 2: Update the strength query**
+
+In `src/queries/analytics.ts`, change the strength select to:
+
+```ts
+.select("exercise_name, exercise_id, record_type, workout_phase, value, achieved_at")
+```
+
+Keep the existing profile filter and `achieved_at` ordering.
+
+- [x] **Step 3: Add query key support for phase stats trends**
+
+In `src/queries/keys.ts`, add:
+
+```ts
+phaseStats: (userId: string, period: string, profileId?: string | null) =>
+	[
+		...queryKeys.analytics.all,
+		"phase-stats",
+		userId,
+		period,
+		profileId ?? "all",
+	] as const,
+```
+
+- [x] **Step 4: Write failing query tests for user-period phase stats**
+
+Add `describe("phaseStatisticsTrendOptions")` with tests that assert:
+
+```ts
+expect(opts.queryKey).toEqual(
+	queryKeys.analytics.phaseStats("user-1", "4w", "profile-1"),
+);
+expect(fromFn).toHaveBeenCalledWith("session_phase_statistics");
+expect(chain.select).toHaveBeenCalledWith(
+	[
+		"session_id",
+		"concentric_kg_avg",
+		"concentric_kg_max",
+		"concentric_vel_avg",
+		"concentric_vel_max",
+		"concentric_watt_avg",
+		"concentric_watt_max",
+		"eccentric_kg_avg",
+		"eccentric_kg_max",
+		"eccentric_vel_avg",
+		"eccentric_vel_max",
+		"eccentric_watt_avg",
+		"eccentric_watt_max",
+		"workout_sessions!inner(started_at, local_profile_id, name)",
+	].join(", "),
+);
+```
+
+- [x] **Step 5: Implement the phase stats query**
+
+Add to `src/queries/analytics.ts`:
+
+```ts
+export function phaseStatisticsTrendOptions(
+	userId: string,
+	period: string = "4w",
+	profileId?: string | null,
+) {
+	return queryOptions({
+		queryKey: queryKeys.analytics.phaseStats(userId, period, profileId),
+		queryFn: async () => {
+			const daysBack = periodToDays(period);
+			const since = new Date();
+			since.setDate(since.getDate() - daysBack);
+
+			let query = supabase
+				.from("session_phase_statistics")
+				.select(
+					[
+						"session_id",
+						"concentric_kg_avg",
+						"concentric_kg_max",
+						"concentric_vel_avg",
+						"concentric_vel_max",
+						"concentric_watt_avg",
+						"concentric_watt_max",
+						"eccentric_kg_avg",
+						"eccentric_kg_max",
+						"eccentric_vel_avg",
+						"eccentric_vel_max",
+						"eccentric_watt_avg",
+						"eccentric_watt_max",
+						"workout_sessions!inner(started_at, local_profile_id, name)",
+					].join(", "),
+				)
+				.eq("user_id", userId)
+				.gte("workout_sessions.started_at", since.toISOString())
+				.order("created_at", { ascending: true });
+
+			if (profileId) {
+				query = query.eq("workout_sessions.local_profile_id", profileId);
+			}
+
+			const { data, error } = await query;
+			if (error) throw error;
+			return data ?? [];
+		},
+	});
+}
+```
+
+- [x] **Step 6: Run query tests**
+
+Run:
+
+```powershell
+npm test -- src/queries/__tests__/analytics.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```powershell
+git add src/queries/analytics.ts src/queries/__tests__/analytics.test.ts src/queries/keys.ts
+git commit -m "feat: query phase-aware analytics data"
+```
+
+## Task 4: Add Pure Phase Chart Transforms
+
+**Files:**
+- Create: `src/app/components/analytics/strengthPhaseTransforms.ts`
+- Create: `src/app/components/analytics/strengthPhaseTransforms.test.ts`
+- Create: `src/app/components/analytics/phaseStatisticsTransforms.ts`
+- Create: `src/app/components/analytics/phaseStatisticsTransforms.test.ts`
+
+- [x] **Step 1: Write failing tests for strength grouping**
+
+Create `src/app/components/analytics/strengthPhaseTransforms.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildStrengthPhaseSeries } from "./strengthPhaseTransforms";
+
+describe("buildStrengthPhaseSeries", () => {
+	it("keeps concentric and eccentric records as separate series", () => {
+		const result = buildStrengthPhaseSeries(
+			[
+				{
+					exercise_name: "Bench Press",
+					exercise_id: "bench",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 100,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Bench Press",
+					exercise_id: "bench",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "ECCENTRIC",
+					value: 130,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+			],
+			"all",
+		);
+
+		expect(result.series.map((s) => s.name)).toEqual([
+			"Bench Press Concentric",
+			"Bench Press Eccentric",
+		]);
+		expect(result.points[0]).toMatchObject({
+			"bench::Concentric": 100,
+			"bench::Eccentric": 130,
+		});
+	});
+
+	it("filters by selected phase", () => {
+		const result = buildStrengthPhaseSeries(
+			[
+				{
+					exercise_name: "Squat",
+					exercise_id: "squat",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 140,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Squat",
+					exercise_id: "squat",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "ECCENTRIC",
+					value: 180,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+			],
+			"Concentric",
+		);
+
+		expect(result.series.map((s) => s.name)).toEqual(["Squat Concentric"]);
+	});
+});
+```
+
+- [x] **Step 2: Implement strength grouping**
+
+Create `src/app/components/analytics/strengthPhaseTransforms.ts` with:
+
+```ts
+import {
+	type WorkoutPhaseFilter,
+	normalizeWorkoutPhase,
+} from "@/lib/workout-phases";
+
+export interface StrengthPhaseRecord {
+	exercise_name: string;
+	exercise_id?: string | null;
+	record_type?: string | null;
+	workout_phase?: string | null;
+	value: number;
+	achieved_at: string;
+}
+
+export interface StrengthPhaseSeries {
+	key: string;
+	name: string;
+	exerciseName: string;
+	phase: string;
+	latestValue: number;
+}
+
+export function buildStrengthPhaseSeries(
+	data: StrengthPhaseRecord[],
+	phaseFilter: WorkoutPhaseFilter,
+) {
+	const filtered = data.filter((item) => {
+		const phase = normalizeWorkoutPhase(item.workout_phase);
+		return phaseFilter === "all" || phase === phaseFilter;
+	});
+
+	const dateSet = new Set<string>();
+	const valueBySeries = new Map<string, Map<string, number>>();
+	const latestBySeries = new Map<string, StrengthPhaseSeries & { at: number }>();
+
+	for (const item of filtered) {
+		const phase = normalizeWorkoutPhase(item.workout_phase);
+		const baseKey = item.exercise_id ?? item.exercise_name;
+		const key = `${baseKey}::${phase}`;
+		const name = `${item.exercise_name} ${phase}`;
+		const date = new Date(item.achieved_at).toLocaleDateString("en-US", {
+			month: "short",
+		});
+		dateSet.add(date);
+		if (!valueBySeries.has(key)) valueBySeries.set(key, new Map());
+		const existing = valueBySeries.get(key)?.get(date) ?? 0;
+		if (item.value > existing) valueBySeries.get(key)?.set(date, item.value);
+		const at = new Date(item.achieved_at).getTime();
+		const latest = latestBySeries.get(key);
+		if (!latest || at > latest.at) {
+			latestBySeries.set(key, {
+				key,
+				name,
+				exerciseName: item.exercise_name,
+				phase,
+				latestValue: item.value,
+				at,
+			});
+		}
+	}
+
+	const series = Array.from(latestBySeries.values())
+		.sort((a, b) => b.latestValue - a.latestValue)
+		.slice(0, 6)
+		.map(({ at: _at, ...s }) => s);
+
+	const points = Array.from(dateSet).map((date) => {
+		const point: Record<string, string | number> = { date };
+		for (const s of series) {
+			point[s.key] = valueBySeries.get(s.key)?.get(date) ?? 0;
+		}
+		return point;
+	});
+
+	return { points, series };
+}
+```
+
+- [x] **Step 3: Write failing tests for phase metric transforms**
+
+Create `src/app/components/analytics/phaseStatisticsTransforms.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { buildPhaseMetricSummary } from "./phaseStatisticsTransforms";
+
+describe("buildPhaseMetricSummary", () => {
+	it("summarizes peak and average kg for both phases", () => {
+		const result = buildPhaseMetricSummary([
+			{
+				concentric_kg_avg: 80,
+				concentric_kg_max: 100,
+				concentric_vel_avg: 0.5,
+				concentric_vel_max: 0.8,
+				concentric_watt_avg: 200,
+				concentric_watt_max: 300,
+				eccentric_kg_avg: 95,
+				eccentric_kg_max: 125,
+				eccentric_vel_avg: 0.4,
+				eccentric_vel_max: 0.7,
+				eccentric_watt_avg: 220,
+				eccentric_watt_max: 340,
+			},
+		]);
+
+		expect(result.load).toEqual({
+			concentricAvg: 80,
+			concentricMax: 100,
+			eccentricAvg: 95,
+			eccentricMax: 125,
+		});
+	});
+});
+```
+
+- [x] **Step 4: Implement phase metric transforms**
+
+Create `src/app/components/analytics/phaseStatisticsTransforms.ts`:
+
+```ts
+export interface PhaseStatisticsRow {
+	concentric_kg_avg: number | null;
+	concentric_kg_max: number | null;
+	concentric_vel_avg: number | null;
+	concentric_vel_max: number | null;
+	concentric_watt_avg: number | null;
+	concentric_watt_max: number | null;
+	eccentric_kg_avg: number | null;
+	eccentric_kg_max: number | null;
+	eccentric_vel_avg: number | null;
+	eccentric_vel_max: number | null;
+	eccentric_watt_avg: number | null;
+	eccentric_watt_max: number | null;
+}
+
+function avg(values: Array<number | null>): number {
+	const clean = values.filter((v): v is number => typeof v === "number");
+	return clean.length === 0
+		? 0
+		: Math.round((clean.reduce((sum, v) => sum + v, 0) / clean.length) * 10) /
+				10;
+}
+
+function max(values: Array<number | null>): number {
+	const clean = values.filter((v): v is number => typeof v === "number");
+	return clean.length === 0 ? 0 : Math.max(...clean);
+}
+
+export function buildPhaseMetricSummary(rows: PhaseStatisticsRow[]) {
+	return {
+		load: {
+			concentricAvg: avg(rows.map((r) => r.concentric_kg_avg)),
+			concentricMax: max(rows.map((r) => r.concentric_kg_max)),
+			eccentricAvg: avg(rows.map((r) => r.eccentric_kg_avg)),
+			eccentricMax: max(rows.map((r) => r.eccentric_kg_max)),
+		},
+		velocity: {
+			concentricAvg: avg(rows.map((r) => r.concentric_vel_avg)),
+			concentricMax: max(rows.map((r) => r.concentric_vel_max)),
+			eccentricAvg: avg(rows.map((r) => r.eccentric_vel_avg)),
+			eccentricMax: max(rows.map((r) => r.eccentric_vel_max)),
+		},
+		power: {
+			concentricAvg: avg(rows.map((r) => r.concentric_watt_avg)),
+			concentricMax: max(rows.map((r) => r.concentric_watt_max)),
+			eccentricAvg: avg(rows.map((r) => r.eccentric_watt_avg)),
+			eccentricMax: max(rows.map((r) => r.eccentric_watt_max)),
+		},
+	};
+}
+```
+
+- [x] **Step 5: Run transform tests**
+
+Run:
+
+```powershell
+npm test -- src/app/components/analytics/strengthPhaseTransforms.test.ts src/app/components/analytics/phaseStatisticsTransforms.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+git add src/app/components/analytics/strengthPhaseTransforms.ts src/app/components/analytics/strengthPhaseTransforms.test.ts src/app/components/analytics/phaseStatisticsTransforms.ts src/app/components/analytics/phaseStatisticsTransforms.test.ts
+git commit -m "feat: add phase analytics transforms"
+```
+
+## Task 5: Wire Analytics Page and Visualizations
+
+**Files:**
+- Modify: `src/app/components/Analytics.tsx`
+- Modify: `src/app/components/analytics/ProgressTab.tsx`
+- Modify: `src/app/components/analytics/MobileProgressTab.tsx`
+
+- [x] **Step 1: Add URL-backed phase state**
+
+In `src/app/components/Analytics.tsx`, preserve the `tab` parameter while adding a `phase` parameter:
+
+```ts
+const rawPhase = searchParams.get("phase") ?? "all";
+const phaseFilter: WorkoutPhaseFilter = WORKOUT_PHASE_FILTERS.includes(
+	rawPhase as WorkoutPhaseFilter,
+)
+	? (rawPhase as WorkoutPhaseFilter)
+	: "all";
+
+const setPhaseFilter = (phase: WorkoutPhaseFilter) => {
+	const next = new URLSearchParams(searchParams);
+	next.set("phase", phase);
+	setSearchParams(next);
+};
+```
+
+- [x] **Step 2: Query phase statistics for the analytics period**
+
+Import and call:
+
+```ts
+const { data: phaseStatsRaw } = useQuery(
+	phaseStatisticsTrendOptions(userId, queryPeriod, activeProfileId),
+);
+```
+
+Keep `enabled: !!userId` if the current query call pattern requires it.
+
+- [x] **Step 3: Replace exercise-only strength grouping**
+
+Use `buildStrengthPhaseSeries(strengthRaw ?? [], phaseFilter)` instead of the existing exercise-only `groupStrengthByExercise` for the strength ECharts series.
+
+Keep top-series limiting at six series maximum. This avoids unreadable charts when every exercise has both concentric and eccentric lines.
+
+- [x] **Step 4: Build ECharts series with phase labels**
+
+Map each `StrengthPhaseSeries` to an ECharts line:
+
+```ts
+series: strengthPhase.series.map((seriesItem, index) => ({
+	name: seriesItem.name,
+	type: "line",
+	smooth: true,
+	symbol: "circle",
+	symbolSize: 6,
+	lineStyle: { width: 2 },
+	itemStyle: { color: PHASE_SERIES_COLORS[index % PHASE_SERIES_COLORS.length] },
+	data: strengthPhase.points.map((point) => point[seriesItem.key] ?? 0),
+})),
+```
+
+- [x] **Step 5: Add phase controls to desktop progress**
+
+In `src/app/components/analytics/ProgressTab.tsx`, add props:
+
+```ts
+phaseFilter: WorkoutPhaseFilter;
+onPhaseFilterChange: (phase: WorkoutPhaseFilter) => void;
+phaseMetricSummary: ReturnType<typeof buildPhaseMetricSummary> | null;
+```
+
+Render a compact control above `1RM Progression`:
+
+```tsx
+<div className="flex flex-wrap gap-2">
+	{WORKOUT_PHASE_FILTERS.map((phase) => (
+		<Button
+			key={phase}
+			type="button"
+			variant={phaseFilter === phase ? "default" : "outline"}
+			size="sm"
+			onClick={() => onPhaseFilterChange(phase)}
+		>
+			{phase === "all" ? "All Phases" : phase}
+		</Button>
+	))}
+</div>
+```
+
+- [x] **Step 6: Add paired phase metric cards**
+
+In `ProgressTab.tsx`, render three paired metric cards when `phaseMetricSummary` exists:
+
+```tsx
+<PhaseMetricPair
+	label={`Load (${unit})`}
+	concentric={phaseMetricSummary.load.concentricAvg}
+	eccentric={phaseMetricSummary.load.eccentricAvg}
+	peakConcentric={phaseMetricSummary.load.concentricMax}
+	peakEccentric={phaseMetricSummary.load.eccentricMax}
+/>
+<PhaseMetricPair
+	label="Velocity"
+	concentric={phaseMetricSummary.velocity.concentricAvg}
+	eccentric={phaseMetricSummary.velocity.eccentricAvg}
+	peakConcentric={phaseMetricSummary.velocity.concentricMax}
+	peakEccentric={phaseMetricSummary.velocity.eccentricMax}
+/>
+<PhaseMetricPair
+	label="Power"
+	concentric={phaseMetricSummary.power.concentricAvg}
+	eccentric={phaseMetricSummary.power.eccentricAvg}
+	peakConcentric={phaseMetricSummary.power.concentricMax}
+	peakEccentric={phaseMetricSummary.power.eccentricMax}
+/>
+```
+
+Define `PhaseMetricPair` in the same file using existing `Card` styles and no nested cards.
+
+- [x] **Step 7: Update mobile progress**
+
+In `MobileProgressTab.tsx`, add props:
+
+```ts
+phaseFilter: WorkoutPhaseFilter;
+onPhaseFilterChange: (phase: WorkoutPhaseFilter) => void;
+phaseMetricSummary: ReturnType<typeof buildPhaseMetricSummary> | null;
+```
+
+Render:
+
+- Horizontal scroll phase buttons.
+- Top lift labels as `Exercise - Phase`.
+- One compact paired load card using average and peak load values.
+
+- [x] **Step 8: Run focused component and type checks**
+
+Run:
+
+```powershell
+npm test -- src/app/components/analytics/strengthPhaseTransforms.test.ts src/app/components/analytics/phaseStatisticsTransforms.test.ts
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```powershell
+git add src/app/components/Analytics.tsx src/app/components/analytics/ProgressTab.tsx src/app/components/analytics/MobileProgressTab.tsx
+git commit -m "feat: display phase-aware analytics"
+```
+
+## Task 6: Update Exercise Detail and Aggregate Progress Semantics
+
+**Files:**
+- Modify: `src/app/components/analytics/ExerciseDeepDive.tsx`
+- Modify: `src/app/components/ExerciseProgress.tsx`
+- Test: existing component tests if present; otherwise add pure transform tests only.
+
+- [x] **Step 1: Keep `exercise_progress` aggregate**
+
+Do not add a phase filter to `exerciseProgressOptions`. In `ExerciseProgress.tsx`, label current max weight, volume, and 1RM charts as aggregate/overall data.
+
+- [x] **Step 2: Make ExerciseDeepDive PR counts phase-aware**
+
+In `ExerciseDeepDive.tsx`, count PRs per phase:
+
+```ts
+const prCountsByPhase = records
+	.filter((r) => r.exercise_name.toLowerCase() === selectedExercise.toLowerCase())
+	.reduce(
+		(acc, record) => {
+			const phase = normalizeWorkoutPhase(record.workout_phase);
+			acc[phase] += 1;
+			return acc;
+		},
+		{ Combined: 0, Concentric: 0, Eccentric: 0 },
+	);
+```
+
+Apply the existing time-range cutoff before the reducer.
+
+- [x] **Step 3: Add phase badges in ExerciseDeepDive PR summary**
+
+Render only non-zero phase counts:
+
+```tsx
+{WORKOUT_PHASES.map((phase) =>
+	prCountsByPhase[phase] > 0 ? (
+		<Badge key={phase} variant="outline">
+			{phase}: {prCountsByPhase[phase]}
+		</Badge>
+	) : null,
+)}
+```
+
+- [x] **Step 4: Verify no false phase-specific 1RM claim**
+
+Search the changed files:
+
+```powershell
+rg -n "phase|concentric|eccentric|1RM|overall|aggregate" src/app/components/ExerciseProgress.tsx src/app/components/analytics/ExerciseDeepDive.tsx
+```
+
+Expected: phase-specific labels appear only for personal records, not `exercise_progress` 1RM lines.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```powershell
+git add src/app/components/analytics/ExerciseDeepDive.tsx src/app/components/ExerciseProgress.tsx
+git commit -m "feat: clarify phase semantics in exercise progress"
+```
+
+## Task 7: Update Secondary Analytics Consumers
+
+**Files:**
+- Modify: `src/app/components/SummaryReport.tsx`
+- Modify: `src/app/components/Goals.tsx`
+- Modify: `src/queries/challenges.ts`
+- Modify: `supabase/functions/compute-rankings/index.ts`
+- Modify: `supabase/functions/generate-insights/index.ts`
+- Modify: `src/lib/export/csv.ts`
+
+- [x] **Step 1: SummaryReport aggregate PR semantics**
+
+`SummaryReport.tsx` derives records from aggregate `exercise_progress`, not
+`personal_records`, so this implementation labels those values as overall
+progress records and keeps volume and exercise progress aggregate.
+
+- [x] **Step 2: Goals semantic decision**
+
+Keep existing goal progress combined unless the goal schema includes phase. Add a comment at the PR goal branch:
+
+```ts
+// Goal rows do not currently carry workout_phase, so PR goals intentionally
+// count all phases. Add a goal phase column before offering phase-specific goals.
+```
+
+- [x] **Step 3: Challenges semantic decision**
+
+For `pr_count` challenges, keep `COUNT(*)`. Add a focused test that creates combined/concentric/eccentric records for the same exercise and expects `3`.
+
+Rejected alternative: counting one PR per exercise/record type regardless of phase. That would use this distinct key count, but it conflicts with the current sync identity and official-app metric model:
+
+```ts
+new Set(records.map((r) => `${r.exercise_id ?? r.exercise_name}:${r.record_type}`)).size
+```
+
+Use the selected interpretation consistently in `src/queries/challenges.ts`, `supabase/functions/compute-rankings/index.ts`, and any follow-up migration touching `get_pr_count_rankings`.
+
+- [x] **Step 4: Rankings semantic decision**
+
+Keep leaderboard `COUNT(*)` and update labels/help text to make clear that phase-specific PRs are included.
+
+Do not edit already-pushed migrations.
+
+- [x] **Step 5: Insights include phase labels**
+
+In `generate-insights`, select `workout_phase` with recent PRs and emit text such as:
+
+```ts
+`${exerciseName} ${formatWorkoutPhase(workoutPhase)} PR: ${value}`
+```
+
+Use the edge-function local helper equivalent because browser imports are not available in Supabase functions.
+
+- [x] **Step 6: Export verification**
+
+`src/lib/export/csv.ts` already includes `Workout Phase`. Add or keep a test row with `workout_phase: "Concentric"` and assert the exported column is `Concentric`.
+
+- [x] **Step 7: Run targeted tests**
+
+Run:
+
+```powershell
+npm test -- src/lib/export/csv.test.ts src/queries/__tests__/analytics.test.ts
+npm run test:sync
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```powershell
+git add src/app/components/SummaryReport.tsx src/app/components/Goals.tsx src/queries/challenges.ts supabase/functions/compute-rankings/index.ts supabase/functions/generate-insights/index.ts src/lib/export/csv.ts
+git commit -m "feat: apply phase semantics to analytics consumers"
+```
+
+## Task 8: Document Exercise-Level Phase Progress Scope
+
+**Files:**
+- Review: `supabase/functions/_shared/pushPayloadSchema.ts`
+- Review: `supabase/functions/mobile-sync-push/index.ts`
+- Review: `supabase/migrations/20260319120000_mobile_portal_parity.sql`
+- Possible create: `supabase/migrations/<timestamp>_exercise_phase_progress.sql`
+
+- [x] **Step 1: Confirm product need**
+
+Use this exact decision rule:
+
+```text
+If the requested feature is "show phase-specific PRs and session phase metrics", current schema is enough.
+If the requested feature is "show phase-specific exercise 1RM/volume trends for every exercise", current schema is not enough.
+```
+
+- [x] **Step 2: Document no migration for this implementation**
+
+Add a note to this plan and final handoff:
+
+```text
+No migration added in this implementation. Exercise progress remains aggregate because phase-specific exercise progress is not persisted today.
+```
+
+- [ ] **Step 3: Prepare the follow-up migration only if exercise-level phase progress becomes in-scope**
+
+Create a new migration with this shape:
+
+```sql
+CREATE TABLE IF NOT EXISTS public.exercise_phase_progress (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  local_profile_id TEXT,
+  session_id UUID NOT NULL REFERENCES public.workout_sessions(id) ON DELETE CASCADE,
+  exercise_id TEXT,
+  exercise_name TEXT NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL,
+  workout_phase TEXT NOT NULL CHECK (workout_phase IN ('CONCENTRIC', 'ECCENTRIC')),
+  avg_weight_kg NUMERIC NOT NULL DEFAULT 0,
+  max_weight_kg NUMERIC NOT NULL DEFAULT 0,
+  avg_velocity_mps NUMERIC NOT NULL DEFAULT 0,
+  max_velocity_mps NUMERIC NOT NULL DEFAULT 0,
+  avg_power_w NUMERIC NOT NULL DEFAULT 0,
+  max_power_w NUMERIC NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (session_id, exercise_id, workout_phase)
+);
+
+ALTER TABLE public.exercise_phase_progress ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own exercise phase progress"
+  ON public.exercise_phase_progress
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_exercise_phase_progress_user_exercise
+  ON public.exercise_phase_progress(user_id, exercise_name, recorded_at DESC);
+```
+
+- [x] **Step 4: Only expand sync payload if mobile can send exercise-level phase rows**
+
+Do not infer exercise-level rows in the portal from session-level stats. The official app stores workout-level stats, but the portal payload currently accepts only `sessionId` in `phaseStatistics`.
+
+## Task 9: Final Verification
+
+**Files:**
+- Validate all changed files.
+
+- [x] **Step 1: Run focused tests**
+
+Run:
+
+```powershell
+npm test -- src/lib/__tests__/workout-phases.test.ts src/app/components/analytics/strengthPhaseTransforms.test.ts src/app/components/analytics/phaseStatisticsTransforms.test.ts src/queries/__tests__/analytics.test.ts
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run sync tests**
+
+Run:
+
+```powershell
+npm run test:sync
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run typecheck and lint**
+
+Run:
+
+```powershell
+npm run typecheck
+npm run lint
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Run full verification**
+
+Run:
+
+```powershell
+npm run verify:full
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Rendered smoke check**
+
+Start the dev server:
+
+```powershell
+npm run dev
+```
+
+Open the analytics page and verify:
+
+- Desktop Progress tab shows phase controls.
+- Strength chart separates concentric and eccentric series.
+- Phase metric cards show concentric/eccentric average and peak values.
+- Mobile Progress tab shows readable phase controls and paired phase metric card.
+- Records tab behavior is unchanged except shared helper usage.
+- No component claims `exercise_progress` is phase-specific.
+
+- [ ] **Step 6: Final commit**
+
+Run:
+
+```powershell
+git status --short
+git add .
+git commit -m "feat: support phase-aware analytics"
+```
+
+Use `git add .` only after `git status --short` confirms all changed files belong to this plan.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -56,6 +56,47 @@ async function mockAuthedPortal(page: Parameters<typeof mockAuthenticatedApp>[0]
 				notes: null,
 			},
 		],
+		personalRecords: [
+			{
+				id: "00000000-0000-4000-8000-000000000401",
+				user_id: "00000000-0000-4000-8000-000000000001",
+				exercise_name: "Bench Press",
+				exercise_id: SEEDED_EXERCISE_ID,
+				record_type: "MAX_WEIGHT",
+				workout_phase: "CONCENTRIC",
+				value: 100,
+				achieved_at: "2026-03-01T14:00:00.000Z",
+			},
+			{
+				id: "00000000-0000-4000-8000-000000000402",
+				user_id: "00000000-0000-4000-8000-000000000001",
+				exercise_name: "Bench Press",
+				exercise_id: SEEDED_EXERCISE_ID,
+				record_type: "MAX_WEIGHT",
+				workout_phase: "ECCENTRIC",
+				value: 125,
+				achieved_at: "2026-03-01T14:00:00.000Z",
+			},
+		],
+		phaseStatistics: [
+			{
+				session_id: SEEDED_SESSION_ID,
+				user_id: "00000000-0000-4000-8000-000000000001",
+				created_at: "2026-03-01T14:45:00.000Z",
+				concentric_kg_avg: 80,
+				concentric_kg_max: 100,
+				concentric_vel_avg: 0.5,
+				concentric_vel_max: 0.8,
+				concentric_watt_avg: 200,
+				concentric_watt_max: 300,
+				eccentric_kg_avg: 95,
+				eccentric_kg_max: 125,
+				eccentric_vel_avg: 0.4,
+				eccentric_vel_max: 0.7,
+				eccentric_watt_avg: 220,
+				eccentric_watt_max: 340,
+			},
+		],
 	});
 }
 
@@ -94,10 +135,23 @@ test.describe("Authenticated pages", () => {
 	});
 
 	test("analytics page loads", async ({ page }) => {
-			await page.goto("/analytics");
-			await expect(
-				page.getByRole("heading", { name: "Analytics Hub" }),
-			).toBeVisible({ timeout: 10000 });
+		await page.goto("/analytics");
+		await expect(
+			page.getByRole("heading", { name: "Analytics Hub" }),
+		).toBeVisible({ timeout: 10000 });
+	});
+
+	test("analytics progress tab shows phase-aware metrics", async ({ page }) => {
+		await page.goto("/analytics?tab=progress");
+
+		await expect(page.getByText("Phase Load, Speed & Power")).toBeVisible({
+			timeout: 10000,
+		});
+		await expect(page.getByRole("button", { name: "All" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Concentric" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Eccentric" })).toBeVisible();
+		await expect(page.getByText("Phase Strength Progression (kg)")).toBeVisible();
+		await expect(page.getByText("125 kg")).toBeVisible();
 	});
 
 	test("community page loads", async ({ page }) => {

--- a/e2e/support/mockSupabase.ts
+++ b/e2e/support/mockSupabase.ts
@@ -91,6 +91,8 @@ interface MockSupabaseOptions {
 	workoutSessions?: Record<string, unknown>[];
 	exercises?: ExerciseRow[];
 	sets?: SetRow[];
+	personalRecords?: Record<string, unknown>[];
+	phaseStatistics?: Record<string, unknown>[];
 }
 
 const MONTHLY_PRICE_IDS: Record<MockSubscriptionTier, string | null> = {
@@ -143,6 +145,8 @@ export async function installMockSupabase(
 		workoutSessions: options.workoutSessions ?? [],
 		exercises: options.exercises ?? [],
 		sets: options.sets ?? [],
+		personalRecords: options.personalRecords ?? [],
+		phaseStatistics: options.phaseStatistics ?? [],
 		onboarding: {
 			id: "onboarding-1",
 			user_id: userId,
@@ -180,6 +184,9 @@ export async function installMockSupabase(
 		rows.filter((row) => {
 			for (const [key, value] of url.searchParams.entries()) {
 				if (key === "select" || key === "order" || key === "limit" || key === "offset") {
+					continue;
+				}
+				if (key.includes(".")) {
 					continue;
 				}
 
@@ -370,6 +377,21 @@ export async function installMockSupabase(
 			case "sets": {
 				const sets = filterRows(state.sets, url);
 				await respondRows(route, sets, request.headers().accept);
+				return;
+			}
+			case "personal_records": {
+				const records = filterRows(state.personalRecords, url);
+				if (method === "HEAD") {
+					await respondCount(route, records.length);
+					return;
+				}
+
+				await respondRows(route, records, request.headers().accept);
+				return;
+			}
+			case "session_phase_statistics": {
+				const rows = filterRows(state.phaseStatistics, url);
+				await respondRows(route, rows, request.headers().accept);
 				return;
 			}
 			case "challenge_participants": {

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -60,7 +60,12 @@ import { convertWeight, formatVolume, type WeightUnit } from "@/lib/units";
 import type { ExerciseSessionData } from "@/lib/volume-landmarks";
 import { computeWeeklyVolume } from "@/lib/volume-landmarks";
 import {
+	WORKOUT_PHASE_FILTERS,
+	type WorkoutPhaseFilter,
+} from "@/lib/workout-phases";
+import {
 	muscleGroupOptions,
+	phaseStatisticsTrendOptions,
 	strengthProgressOptions,
 	volumeComparisonOptions,
 	volumeTrendOptions,
@@ -71,6 +76,11 @@ import { externalActivitiesOptions } from "@/queries/integrations";
 import { profileOptions } from "@/queries/profile";
 import { WEIGHT_MULTIPLIER } from "@/schemas/transforms";
 import { useProfileFilterStore } from "@/stores/useProfileFilterStore";
+import { buildPhaseMetricSummary } from "./analytics/phaseStatisticsTransforms";
+import {
+	buildMobileStrengthPhaseData,
+	buildStrengthPhaseSeries,
+} from "./analytics/strengthPhaseTransforms";
 
 // Lazy-loaded tab components for code splitting (desktop)
 const OverviewTab = lazy(
@@ -198,74 +208,6 @@ function bucketByWeek(
 		volume: Math.round(volume),
 		workouts,
 	}));
-}
-
-// Group strength progress data by exercise for line chart
-function groupStrengthByExercise(
-	data: Array<{
-		exercise_name: string;
-		exercise_id?: string | null;
-		value: number;
-		achieved_at: string;
-	}>,
-): {
-	points: Record<string, string | number>[];
-	keyToName: Map<string, string>;
-} {
-	if (!data || data.length === 0) {
-		return { points: [], keyToName: new Map<string, string>() };
-	}
-	// Get all unique dates and exercises
-	const dateSet = new Set<string>();
-	const exerciseMap = new Map<string, Map<string, number>>();
-	const latestByKey = new Map<string, { at: number; value: number }>();
-	// Map grouping key back to display name
-	const keyToName = new Map<string, string>();
-
-	for (const item of data) {
-		const key = item.exercise_id ?? item.exercise_name;
-		const achievedAtTs = new Date(item.achieved_at).getTime();
-		const date = new Date(item.achieved_at).toLocaleDateString("en-US", {
-			month: "short",
-		});
-		dateSet.add(date);
-		if (!keyToName.has(key)) {
-			keyToName.set(key, item.exercise_name);
-		}
-		if (!exerciseMap.has(key)) {
-			exerciseMap.set(key, new Map());
-		}
-		// Keep highest value per exercise per month
-		const existing = exerciseMap.get(key)?.get(date) ?? 0;
-		if (item.value > existing) {
-			exerciseMap.get(key)?.set(date, item.value);
-		}
-		const latest = latestByKey.get(key);
-		if (!latest || achievedAtTs > latest.at) {
-			latestByKey.set(key, { at: achievedAtTs, value: item.value });
-		}
-	}
-
-	const dates = Array.from(dateSet);
-	// Pick top 3 exercises by latest value
-	const topKeys = Array.from(latestByKey.entries())
-		.map(([key, latest]) => ({
-			key,
-			latestValue: latest.value,
-		}))
-		.sort((a, b) => b.latestValue - a.latestValue)
-		.slice(0, 3)
-		.map((e) => e.key);
-
-	const points = dates.map((date) => {
-		const point: Record<string, string | number> = { date };
-		for (const key of topKeys) {
-			point[key] = exerciseMap.get(key)?.get(date) ?? 0;
-		}
-		return point;
-	});
-
-	return { points, keyToName };
 }
 
 function convertStrengthSeriesPoint(
@@ -505,7 +447,27 @@ export function Analytics() {
 	const activeTab = VALID_TABS.includes(rawTab)
 		? rawTab
 		: (TAB_MIGRATION[rawTab] ?? "overview");
-	const setActiveTab = (tab: string) => setSearchParams({ tab });
+	const rawPhase = searchParams.get("phase") ?? "all";
+	const phaseFilter: WorkoutPhaseFilter = WORKOUT_PHASE_FILTERS.includes(
+		rawPhase as WorkoutPhaseFilter,
+	)
+		? (rawPhase as WorkoutPhaseFilter)
+		: "all";
+	const setActiveTab = (tab: string) => {
+		const nextParams = new URLSearchParams(searchParams);
+		nextParams.set("tab", tab);
+		setSearchParams(nextParams);
+	};
+	const setPhaseFilter = (phase: WorkoutPhaseFilter) => {
+		const nextParams = new URLSearchParams(searchParams);
+		nextParams.set("tab", "progress");
+		if (phase === "all") {
+			nextParams.delete("phase");
+		} else {
+			nextParams.set("phase", phase);
+		}
+		setSearchParams(nextParams);
+	};
 
 	const queryPeriod = periodToDays(timePeriod);
 	const insightPeriod = periodToInsightPeriod(timePeriod);
@@ -523,6 +485,9 @@ export function Analytics() {
 	);
 	const { data: strengthRaw, isPending: strengthPending } = useQuery(
 		strengthProgressOptions(userId, activeProfileId),
+	);
+	const { data: phaseStatsRaw, isPending: phaseStatsPending } = useQuery(
+		phaseStatisticsTrendOptions(userId, queryPeriod, activeProfileId),
 	);
 	const { data: externalActivities } = useQuery({
 		...externalActivitiesOptions(userId),
@@ -542,7 +507,8 @@ export function Analytics() {
 	});
 	const unit: WeightUnit = profile?.weight_unit === "lbs" ? "lbs" : "kg";
 
-	const isPending = volumePending || musclePending || strengthPending;
+	const isPending =
+		volumePending || musclePending || strengthPending || phaseStatsPending;
 
 	// --- Body Intelligence derived data ---
 
@@ -686,17 +652,26 @@ export function Analytics() {
 		}));
 	}, [muscleGroupData]);
 
-	const strengthSeries = groupStrengthByExercise(strengthRaw ?? []);
+	const strengthSeries = useMemo(
+		() => buildStrengthPhaseSeries(strengthRaw ?? [], phaseFilter),
+		[strengthRaw, phaseFilter],
+	);
 	const strengthProgressData = strengthSeries.points.map((point) =>
 		convertStrengthSeriesPoint(point, unit),
 	);
-	const strengthExerciseKeys =
-		strengthProgressData.length > 0
-			? Object.keys(strengthProgressData[0]).filter((k) => k !== "date")
-			: [];
-	const strengthExercises = strengthExerciseKeys.map(
-		(key) => strengthSeries.keyToName.get(key) ?? key,
-	);
+	const strengthExercises = strengthSeries.series.map((item) => item.name);
+	const phaseMetricSummary = useMemo(() => {
+		const summary = buildPhaseMetricSummary(phaseStatsRaw ?? []);
+		return {
+			...summary,
+			load: {
+				concentricAvg: convertWeight(summary.load.concentricAvg, unit),
+				concentricMax: convertWeight(summary.load.concentricMax, unit),
+				eccentricAvg: convertWeight(summary.load.eccentricAvg, unit),
+				eccentricMax: convertWeight(summary.load.eccentricMax, unit),
+			},
+		};
+	}, [phaseStatsRaw, unit]);
 
 	// Derive summary stats from real data
 	const totalVolume = volumeData.reduce((sum, d) => sum + d.volume, 0);
@@ -932,10 +907,10 @@ export function Analytics() {
 				name: unit,
 				nameTextStyle: { color: CHART_COLORS.axisText, fontSize: 11 },
 			},
-			series: strengthExerciseKeys.map((exerciseKey, i) => ({
-				name: strengthSeries.keyToName.get(exerciseKey) ?? exerciseKey,
+			series: strengthSeries.series.map((item, i) => ({
+				name: item.name,
 				type: "line",
-				data: strengthProgressData.map((d) => d[exerciseKey] ?? 0),
+				data: strengthProgressData.map((d) => d[item.key] ?? 0),
 				smooth: true,
 				lineStyle: { width: 2 },
 				itemStyle: {
@@ -945,13 +920,7 @@ export function Analytics() {
 				symbolSize: 6,
 			})),
 		};
-	}, [
-		strengthProgressData,
-		strengthExerciseKeys,
-		strengthExercises,
-		strengthSeries.keyToName,
-		unit,
-	]);
+	}, [strengthProgressData, strengthExercises, strengthSeries.series, unit]);
 
 	// --- ECharts: Volume trend area (for Progress tab) ---
 	const volumeAreaOption = useMemo(() => {
@@ -1059,28 +1028,17 @@ export function Analytics() {
 		color: MUSCLE_GROUP_COLORS_MOBILE[m.name] ?? PHOENIX.ashGray,
 		fill: MUSCLE_GROUP_COLORS_MOBILE[m.name] ?? PHOENIX.ashGray,
 	}));
-	const strengthMap = new Map<string, number>();
-	const strengthNameMap = new Map<string, string>();
-	for (const item of strengthRaw ?? []) {
-		const key = item.exercise_id ?? item.exercise_name;
-		if (!strengthNameMap.has(key)) {
-			strengthNameMap.set(key, item.exercise_name);
-		}
-		const existing = strengthMap.get(key) ?? 0;
-		if (item.value > existing) {
-			strengthMap.set(key, item.value);
-		}
-	}
-	const mobileStrengthData = Array.from(strengthMap.entries())
-		.sort((a, b) => b[1] - a[1])
-		.slice(0, 5)
-		.map(([key, weight]) => {
-			const exercise = strengthNameMap.get(key) ?? key;
-			return {
-				exercise: exercise.length > 8 ? exercise.slice(0, 8) : exercise,
-				weight: Math.round(convertWeight(weight, unit) * 10) / 10,
-			};
-		});
+	const mobileStrengthData = buildMobileStrengthPhaseData(
+		strengthRaw ?? [],
+		phaseFilter,
+	).map((item) => ({
+		...item,
+		exercise:
+			item.exercise.length > 14
+				? `${item.exercise.slice(0, 13)}...`
+				: item.exercise,
+		weight: Math.round(convertWeight(item.weight, unit) * 10) / 10,
+	}));
 	const mobileTotalWorkouts = (volumeRaw ?? []).length;
 	const mobileHasData =
 		mobileVolumeData.length > 0 || mobileMusclData.length > 0;
@@ -1206,7 +1164,7 @@ export function Analytics() {
 							icon: <Flame className="w-5 h-5" />,
 						},
 						{
-							label: "PRs",
+							label: "Phase PRs",
 							value: `${prCount}`,
 							icon: <Target className="w-5 h-5" />,
 						},
@@ -1282,6 +1240,9 @@ export function Analytics() {
 										mobileVolumeData={mobileVolumeData}
 										prCount={prCount}
 										daysSinceLastPR={daysSinceLastPR}
+										phaseFilter={phaseFilter}
+										onPhaseFilterChange={setPhaseFilter}
+										phaseMetricSummary={phaseMetricSummary}
 									/>
 								</Suspense>
 							)}
@@ -1398,7 +1359,7 @@ export function Analytics() {
 										badge: trainingLoad.zone,
 									},
 									{
-										label: "PRs",
+										label: "Phase PRs",
 										value: `${prCount}`,
 										delta: null,
 										icon: <Target className="w-4 h-4" />,
@@ -1506,6 +1467,9 @@ export function Analytics() {
 											daysSinceLastPR={daysSinceLastPR}
 											strengthExercises={strengthExercises}
 											insights={insights}
+											phaseFilter={phaseFilter}
+											onPhaseFilterChange={setPhaseFilter}
+											phaseMetricSummary={phaseMetricSummary}
 										/>
 									</Suspense>
 								</TabsContent>

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -80,6 +80,7 @@ import { buildPhaseMetricSummary } from "./analytics/phaseStatisticsTransforms";
 import {
 	buildMobileStrengthPhaseData,
 	buildStrengthPhaseSeries,
+	buildStrengthPhaseSummary,
 } from "./analytics/strengthPhaseTransforms";
 
 // Lazy-loaded tab components for code splitting (desktop)
@@ -1004,19 +1005,12 @@ export function Analytics() {
 	}, [muscleGroupData]);
 
 	// --- PR stats ---
-	const prCount = (strengthRaw ?? []).length;
-	const daysSinceLastPR = useMemo(() => {
-		if (!strengthRaw || strengthRaw.length === 0) return null;
-		const sorted = [...strengthRaw].sort(
-			(a, b) =>
-				new Date(b.achieved_at).getTime() - new Date(a.achieved_at).getTime(),
-		);
-		const lastPR = new Date(sorted[0].achieved_at);
-		const now = new Date();
-		return Math.floor(
-			(now.getTime() - lastPR.getTime()) / (1000 * 60 * 60 * 24),
-		);
-	}, [strengthRaw]);
+	const strengthPhaseSummary = useMemo(
+		() => buildStrengthPhaseSummary(strengthRaw ?? [], phaseFilter),
+		[strengthRaw, phaseFilter],
+	);
+	const prCount = strengthPhaseSummary.prCount;
+	const daysSinceLastPR = strengthPhaseSummary.daysSinceLastPR;
 
 	// Mobile-specific derived data
 	const mobileVolumeData = bucketByWeekMobile(volumeRaw ?? []).map((entry) => ({

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -44,6 +44,10 @@ import {
 	type WeightUnit,
 } from "@/lib/units";
 import {
+	formatWorkoutPhase,
+	isNonCombinedWorkoutPhase,
+} from "@/lib/workout-phases";
+import {
 	challengeProgressOptions,
 	userChallengesOptions,
 } from "@/queries/challenges";
@@ -87,21 +91,6 @@ function deriveWeeklyVolume(
 		day,
 		volume: Math.round(volumeByDay[day]),
 	}));
-}
-
-function formatWorkoutPhaseLabel(phase: string | null | undefined): string {
-	switch ((phase ?? "Combined").toUpperCase()) {
-		case "CONCENTRIC":
-			return "Concentric";
-		case "ECCENTRIC":
-			return "Eccentric";
-		default:
-			return "Combined";
-	}
-}
-
-function isNonCombinedWorkoutPhase(phase: string | null | undefined): boolean {
-	return formatWorkoutPhaseLabel(phase) !== "Combined";
 }
 
 /** Format a relative time string from a Date */
@@ -1000,7 +989,7 @@ export function Dashboard() {
 											</div>
 											<div>
 												<div className="text-sm text-muted-foreground mb-1">
-													Personal Records
+													Phase PRs
 												</div>
 												<div className="text-2xl font-semibold text-white font-data">
 													<NumberFlow
@@ -1334,7 +1323,7 @@ export function Dashboard() {
 										<div className="flex flex-col items-center justify-center py-6 text-center">
 											<Trophy className="w-8 h-8 text-secondary mb-2" />
 											<p className="text-sm text-muted-foreground">
-												No personal records yet
+												No phase PRs yet
 											</p>
 										</div>
 									) : (
@@ -1360,7 +1349,7 @@ export function Dashboard() {
 													</div>
 													{isNonCombinedWorkoutPhase(pr.workout_phase) ? (
 														<Badge className="mt-2 bg-secondary/20 text-secondary-foreground border-secondary/30 text-xs">
-															{formatWorkoutPhaseLabel(pr.workout_phase)}
+															{formatWorkoutPhase(pr.workout_phase)}
 														</Badge>
 													) : null}
 												</div>

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -89,6 +89,21 @@ function deriveWeeklyVolume(
 	}));
 }
 
+function formatWorkoutPhaseLabel(phase: string | null | undefined): string {
+	switch ((phase ?? "Combined").toUpperCase()) {
+		case "CONCENTRIC":
+			return "Concentric";
+		case "ECCENTRIC":
+			return "Eccentric";
+		default:
+			return "Combined";
+	}
+}
+
+function isNonCombinedWorkoutPhase(phase: string | null | undefined): boolean {
+	return formatWorkoutPhaseLabel(phase) !== "Combined";
+}
+
 /** Format a relative time string from a Date */
 function formatRelativeTime(date: Date): string {
 	const now = new Date();
@@ -1343,6 +1358,11 @@ export function Dashboard() {
 															{formatRelativeTime(pr.achieved_at)}
 														</span>
 													</div>
+													{isNonCombinedWorkoutPhase(pr.workout_phase) ? (
+														<Badge className="mt-2 bg-secondary/20 text-secondary-foreground border-secondary/30 text-xs">
+															{formatWorkoutPhaseLabel(pr.workout_phase)}
+														</Badge>
+													) : null}
 												</div>
 											))}
 										</div>

--- a/src/app/components/ExerciseProgress.tsx
+++ b/src/app/components/ExerciseProgress.tsx
@@ -295,19 +295,19 @@ export function ExerciseProgress({
 						animate={{ opacity: 1, y: 0 }}
 					>
 						<StatCard
-							label="Max Weight"
+							label="Overall Max Weight"
 							stat={weightTrend}
 							color={PHOENIX.ember}
 							unit={getUnitLabel(unit)}
 						/>
 						<StatCard
-							label="Total Volume"
+							label="Overall Volume"
 							stat={volumeTrend}
 							color={PHOENIX.gold}
 							unit={getUnitLabel(unit)}
 						/>
 						<StatCard
-							label="Est. 1RM"
+							label="Overall Est. 1RM"
 							stat={oneRmTrend}
 							color={PHOENIX.forgeGreen}
 							unit={getUnitLabel(unit)}
@@ -324,9 +324,9 @@ export function ExerciseProgress({
 						>
 							<Card className="p-4 bg-surface-2 border-secondary">
 								<h4 className="text-sm font-medium text-muted-foreground mb-4">
-									Max Weight Trend
+									Overall Max Weight Trend
 								</h4>
-								<div role="img" aria-label="Exercise volume trend over time">
+								<div role="img" aria-label="Overall max weight trend over time">
 									<ResponsiveContainer width="100%" height={250}>
 										<AreaChart data={chartData}>
 											<defs>
@@ -390,11 +390,11 @@ export function ExerciseProgress({
 						>
 							<Card className="p-4 bg-surface-2 border-secondary">
 								<h4 className="text-sm font-medium text-muted-foreground mb-4">
-									Total Volume Trend
+									Overall Total Volume Trend
 								</h4>
 								<div
 									role="img"
-									aria-label="Estimated one-rep max trend over time"
+									aria-label="Overall total volume trend over time"
 								>
 									<ResponsiveContainer width="100%" height={250}>
 										<AreaChart data={chartData}>
@@ -459,9 +459,12 @@ export function ExerciseProgress({
 						>
 							<Card className="p-4 bg-surface-2 border-secondary">
 								<h4 className="text-sm font-medium text-muted-foreground mb-4">
-									Estimated 1RM Trend
+									Overall Estimated 1RM Trend
 								</h4>
-								<div role="img" aria-label="Average velocity trend over time">
+								<div
+									role="img"
+									aria-label="Overall estimated one-rep max trend over time"
+								>
 									<ResponsiveContainer width="100%" height={250}>
 										<AreaChart data={chartData}>
 											<defs>

--- a/src/app/components/Goals.tsx
+++ b/src/app/components/Goals.tsx
@@ -106,8 +106,9 @@ export function useGoalProgress(
 				);
 				progress = (totalVolume / goal.target_value) * 100;
 			} else if (goal.goal_type === "pr" && records && goal.exercise_name) {
-				// Check if any PR for this exercise meets or exceeds the target
-				// PR values are already Zod-transformed (doubled)
+				// Goals do not persist a target phase yet, so any combined,
+				// concentric, or eccentric PR for the exercise can satisfy the target.
+				// PR values are already Zod-transformed (doubled).
 				const exercisePRs = records.filter((r) => {
 					// Prefer exercise_id match if both sides have it
 					if (goal.exercise_id && r.exercise_id) {

--- a/src/app/components/Leaderboard.tsx
+++ b/src/app/components/Leaderboard.tsx
@@ -263,7 +263,7 @@ function GlobalRankings({
 		},
 		{
 			key: "prCount",
-			title: "Personal Records",
+			title: "Phase-Aware PRs",
 			icon: <Medal className="size-4 text-[#9CA3AF]" />,
 			metricLabel: "count",
 		},
@@ -435,7 +435,7 @@ const METRIC_META: Record<
 		unit: "days",
 	},
 	prCount: {
-		label: "Personal Records",
+		label: "Phase-Aware PRs",
 		icon: <Medal className="size-4 text-[#9CA3AF]" />,
 		unit: "PRs",
 	},

--- a/src/app/components/Profile.tsx
+++ b/src/app/components/Profile.tsx
@@ -285,7 +285,7 @@ export function Profile() {
 			icon: Calendar,
 		},
 		{
-			label: "Personal Records",
+			label: "Phase PRs",
 			value: statsLoading ? "..." : String(stats?.prCount ?? 0),
 			icon: Trophy,
 		},
@@ -543,7 +543,7 @@ export function Profile() {
 									</div>
 									<div className="p-4 bg-gradient-to-br from-accent/10 to-warning/10 border border-accent/30 rounded-lg">
 										<div className="text-sm text-muted-foreground mb-1">
-											Personal Records
+											Phase PRs
 										</div>
 										<div className="text-3xl text-accent font-data">
 											{statsLoading ? "..." : (stats?.prCount ?? 0)}

--- a/src/app/components/SummaryReport.tsx
+++ b/src/app/components/SummaryReport.tsx
@@ -501,7 +501,7 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 					</Card>
 				</motion.div>
 
-				{/* Card C: Personal Records */}
+				{/* Card C: Overall Progress Records */}
 				<motion.div
 					initial={{ opacity: 0, y: 20 }}
 					animate={{ opacity: 1, y: 0 }}
@@ -513,12 +513,12 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 								<Trophy className="w-4 h-4 text-success" />
 							</div>
 							<span className="text-sm text-muted-foreground">
-								Personal Records
+								Overall Progress Records
 							</span>
 						</div>
 						<div className="text-2xl font-semibold text-white mb-2">
 							{summary.prs.length}{" "}
-							<span className="text-sm text-muted-foreground">PRs hit</span>
+							<span className="text-sm text-muted-foreground">records hit</span>
 						</div>
 						{summary.prs.length > 0 ? (
 							<div className="space-y-1">
@@ -538,7 +538,7 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 							</div>
 						) : (
 							<div className="text-xs text-muted-foreground">
-								No new PRs this {period}
+								No new aggregate records this {period}
 							</div>
 						)}
 					</Card>

--- a/src/app/components/__tests__/Dashboard.test.tsx
+++ b/src/app/components/__tests__/Dashboard.test.tsx
@@ -3,6 +3,23 @@ import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/test-utils";
 import { Dashboard } from "../Dashboard";
 
+const mockRecentPr = vi.hoisted(() => ({
+	record: {
+		id: "00000000-0000-4000-8000-000000000001",
+		user_id: "00000000-0000-4000-8000-000000000999",
+		exercise_name: "Bench Press",
+		exercise_id: null,
+		muscle_group: "Chest",
+		record_type: "MAX_WEIGHT",
+		value: 125,
+		unit: "kg",
+		achieved_at: new Date(),
+		previous_value: null,
+		workout_phase: "Concentric",
+		local_profile_id: null,
+	},
+}));
+
 const mockAuth = vi.hoisted(() => ({
 	useAuth: () => ({
 		user: { id: "test-user-id", email: "test@example.com" },
@@ -14,6 +31,86 @@ const mockAuth = vi.hoisted(() => ({
 
 vi.mock("@/app/hooks/useAuth", () => mockAuth);
 vi.mock("@/providers/AuthProvider", () => mockAuth);
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+	return {
+		...actual,
+		useQueries: vi.fn(() => []),
+		useQuery: vi.fn((options: { queryKey?: unknown[] }) => {
+			const key = options.queryKey ?? [];
+			if (key[0] === "records" && key[1] === "recent") {
+				return {
+					data: [mockRecentPr.record],
+					isPending: false,
+					isLoading: false,
+					isError: false,
+				};
+			}
+			if (key[0] === "workouts" && key[1] === "dashboard-stats") {
+				return {
+					data: [
+						{
+							started_at: new Date().toISOString(),
+							total_volume: 500,
+							duration_seconds: 1800,
+							pr_count: 1,
+							estimated_calories: 120,
+							form_score: 90,
+						},
+					],
+					isPending: false,
+					isLoading: false,
+					isError: false,
+				};
+			}
+			if (key[0] === "workouts" && key[1] === "list") {
+				return {
+					data: [
+						{
+							id: "00000000-0000-4000-8000-000000000010",
+							user_id: "00000000-0000-4000-8000-000000000999",
+							name: "Strength Session",
+							started_at: new Date(),
+							duration_seconds: 30,
+							total_volume: 1000,
+							set_count: 3,
+							exercise_count: 1,
+							pr_count: 1,
+							routine_name: null,
+							workout_mode: "Old School",
+							notes: null,
+						},
+					],
+					isPending: false,
+					isLoading: false,
+					isError: false,
+				};
+			}
+			if (key[0] === "profile" && key[1] === "badges") {
+				return {
+					data: [],
+					isPending: false,
+					isLoading: false,
+					isError: false,
+				};
+			}
+			if (key[0] === "profile") {
+				return {
+					data: { display_name: "Test User", weight_unit: "kg" },
+					isPending: false,
+					isLoading: false,
+					isError: false,
+				};
+			}
+			return {
+				data: [],
+				isPending: false,
+				isLoading: false,
+				isError: false,
+			};
+		}),
+	};
+});
 
 describe("Dashboard", () => {
 	it("renders without crashing", () => {
@@ -21,5 +118,12 @@ describe("Dashboard", () => {
 		expect(
 			screen.getAllByRole("heading", { name: /welcome back/i }).length,
 		).toBeGreaterThan(0);
+	});
+
+	it("shows workout phase on recent PR cards", () => {
+		renderWithProviders(<Dashboard />);
+
+		expect(screen.getByText("Bench Press")).toBeInTheDocument();
+		expect(screen.getByText("Concentric")).toBeInTheDocument();
 	});
 });

--- a/src/app/components/__tests__/ExerciseDeepDive.test.tsx
+++ b/src/app/components/__tests__/ExerciseDeepDive.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/test-utils";
 import { ExerciseDeepDive } from "../analytics/ExerciseDeepDive";
 
@@ -9,6 +9,11 @@ import { ExerciseDeepDive } from "../analytics/ExerciseDeepDive";
 // personalRecords. We intercept at the module boundary.
 // ---------------------------------------------------------------------------
 
+const mockQueryData = vi.hoisted(() => ({
+	progress: [] as unknown[],
+	records: [] as unknown[],
+}));
+
 vi.mock("@/queries/progress", () => ({
 	exerciseProgressOptions: (
 		userId: string,
@@ -16,7 +21,7 @@ vi.mock("@/queries/progress", () => ({
 		profileId?: string | null,
 	) => ({
 		queryKey: ["progress", userId, exerciseName, profileId],
-		queryFn: async () => [],
+		queryFn: async () => mockQueryData.progress,
 	}),
 	exerciseListOptions: (userId: string, profileId?: string | null) => ({
 		queryKey: ["progress-list", userId, profileId],
@@ -27,7 +32,7 @@ vi.mock("@/queries/progress", () => ({
 vi.mock("@/queries/records", () => ({
 	personalRecordsOptions: (userId: string, profileId?: string | null) => ({
 		queryKey: ["records", userId, profileId],
-		queryFn: async () => [],
+		queryFn: async () => mockQueryData.records,
 	}),
 }));
 
@@ -54,6 +59,11 @@ const BASE_PROPS = {
 // ---------------------------------------------------------------------------
 
 describe("ExerciseDeepDive", () => {
+	beforeEach(() => {
+		mockQueryData.progress = [];
+		mockQueryData.records = [];
+	});
+
 	it("renders without crashing with valid props", () => {
 		const { container } = renderWithProviders(
 			<ExerciseDeepDive {...BASE_PROPS} />,
@@ -94,6 +104,38 @@ describe("ExerciseDeepDive", () => {
 	it("shows stats row", () => {
 		renderWithProviders(<ExerciseDeepDive {...BASE_PROPS} />);
 		expect(screen.getByTestId("stats-row")).toBeInTheDocument();
+	});
+
+	it("breaks PR counts down by workout phase", async () => {
+		mockQueryData.records = [
+			{
+				exercise_name: "Bench Press",
+				achieved_at: new Date(),
+				workout_phase: "Concentric",
+			},
+			{
+				exercise_name: "Bench Press",
+				achieved_at: new Date(),
+				workout_phase: "Eccentric",
+			},
+			{
+				exercise_name: "Bench Press",
+				achieved_at: new Date(),
+				workout_phase: "Eccentric",
+			},
+			{
+				exercise_name: "Chest Fly",
+				achieved_at: new Date(),
+				workout_phase: "Concentric",
+			},
+		];
+
+		renderWithProviders(<ExerciseDeepDive {...BASE_PROPS} />);
+
+		const breakdown = await screen.findByTestId("phase-pr-breakdown");
+		expect(breakdown).toHaveTextContent("Concentric: 1");
+		expect(breakdown).toHaveTextContent("Eccentric: 2");
+		expect(breakdown).not.toHaveTextContent("Chest Fly");
 	});
 
 	it("shows empty state when exercise list is empty", () => {

--- a/src/app/components/analytics/ExerciseDeepDive.tsx
+++ b/src/app/components/analytics/ExerciseDeepDive.tsx
@@ -11,6 +11,7 @@ import {
 import { Card } from "@/app/components/ui/card";
 import { getExerciseProfile } from "@/lib/exercise-muscles";
 import { convertWeight, formatWeight, type WeightUnit } from "@/lib/units";
+import { formatWorkoutPhase, WORKOUT_PHASES } from "@/lib/workout-phases";
 import { exerciseProgressOptions } from "@/queries/progress";
 import { personalRecordsOptions } from "@/queries/records";
 import type { ExerciseProgress } from "@/schemas/telemetry";
@@ -148,8 +149,9 @@ export function ExerciseDeepDive({
 			? filteredProgress[filteredProgress.length - 1].estimated_1rm_kg
 			: null;
 
-	const prsInPeriod = useMemo(() => {
-		if (!records || !selectedExercise) return 0;
+	const prsByPhaseInPeriod = useMemo(() => {
+		const counts = new Map(WORKOUT_PHASES.map((phase) => [phase, 0]));
+		if (!records || !selectedExercise) return counts;
 		const days = TIME_RANGE_DAYS[timeRange];
 		const cutoff =
 			days === Infinity
@@ -159,15 +161,21 @@ export function ExerciseDeepDive({
 						d.setDate(d.getDate() - days);
 						return d;
 					})();
-		return records.filter((r) => {
+		for (const r of records) {
 			const exerciseMatch =
 				r.exercise_name.toLowerCase() === selectedExercise.toLowerCase();
-			if (!exerciseMatch) return false;
-			if (!cutoff) return true;
+			if (!exerciseMatch) continue;
+			if (cutoff && r.achieved_at < cutoff) continue;
 			// achieved_at is already a Date (transformed by schema)
-			return r.achieved_at >= cutoff;
-		}).length;
+			const phase = formatWorkoutPhase(r.workout_phase);
+			counts.set(phase, (counts.get(phase) ?? 0) + 1);
+		}
+		return counts;
 	}, [records, selectedExercise, timeRange]);
+	const prsInPeriod = Array.from(prsByPhaseInPeriod.values()).reduce(
+		(sum, count) => sum + count,
+		0,
+	);
 
 	const sessionCount =
 		sortedExercises.find((e) => e.name === selectedExercise)?.sessionCount ?? 0;
@@ -405,8 +413,27 @@ export function ExerciseDeepDive({
 							}
 						/>
 						<StatCard label="Sessions" value={sessionCount} />
-						<StatCard label="PRs in Period" value={prsInPeriod} />
+						<StatCard label="Phase PRs" value={prsInPeriod} />
 					</div>
+					{prsInPeriod > 0 && (
+						<div
+							className="flex flex-wrap gap-2"
+							data-testid="phase-pr-breakdown"
+						>
+							{WORKOUT_PHASES.map((phase) => {
+								const count = prsByPhaseInPeriod.get(phase) ?? 0;
+								if (count === 0) return null;
+								return (
+									<span
+										key={phase}
+										className="rounded-full border border-secondary bg-muted/10 px-2 py-1 text-[10px] text-muted-foreground"
+									>
+										{phase}: <span className="text-white">{count}</span>
+									</span>
+								);
+							})}
+						</div>
+					)}
 				</div>
 			</div>
 		</Card>

--- a/src/app/components/analytics/MobileProgressTab.tsx
+++ b/src/app/components/analytics/MobileProgressTab.tsx
@@ -11,15 +11,32 @@ import {
 } from "recharts";
 import { MobileChartCard } from "@/app/components/analytics/MobileChartCard";
 import { RechartsTooltip } from "@/app/components/charts/shared/RechartsTooltip";
+import { Button } from "@/app/components/ui/button";
 import { PHOENIX } from "@/lib/colors";
 import type { WeightUnit } from "@/lib/units";
+import {
+	WORKOUT_PHASE_FILTERS,
+	type WorkoutPhaseFilter,
+} from "@/lib/workout-phases";
+import type { PhaseMetricSummary } from "./phaseStatisticsTransforms";
 
 export interface MobileProgressTabProps {
 	unit: WeightUnit;
-	mobileStrengthData: Array<{ exercise: string; weight: number }>;
+	mobileStrengthData: Array<{
+		exercise: string;
+		weight: number;
+		phase: string;
+	}>;
 	mobileVolumeData: Array<{ date: string; volume: number }>;
 	prCount: number;
 	daysSinceLastPR: number | null;
+	phaseFilter: WorkoutPhaseFilter;
+	onPhaseFilterChange: (phase: WorkoutPhaseFilter) => void;
+	phaseMetricSummary: PhaseMetricSummary;
+}
+
+function formatMetric(value: number, decimals = 1): string {
+	return value.toFixed(decimals).replace(/\.0$/, "");
 }
 
 export default function MobileProgressTab({
@@ -28,10 +45,82 @@ export default function MobileProgressTab({
 	mobileVolumeData,
 	prCount,
 	daysSinceLastPR,
+	phaseFilter,
+	onPhaseFilterChange,
+	phaseMetricSummary,
 }: MobileProgressTabProps) {
+	const titlePhase =
+		phaseFilter === "all" ? "PHASE" : phaseFilter.toUpperCase();
+
 	return (
 		<>
-			<MobileChartCard title={`TOP LIFTS (1RM - ${unit.toUpperCase()})`}>
+			<MobileChartCard title="PHASE METRICS">
+				<div className="flex flex-wrap gap-2 mb-4">
+					{WORKOUT_PHASE_FILTERS.map((phase) => (
+						<Button
+							key={phase}
+							type="button"
+							size="sm"
+							variant={phaseFilter === phase ? "default" : "outline"}
+							onClick={() => onPhaseFilterChange(phase)}
+							className={
+								phaseFilter === phase
+									? "h-8 text-xs"
+									: "h-8 text-xs border-secondary text-muted-foreground"
+							}
+						>
+							{phase === "all" ? "All" : phase}
+						</Button>
+					))}
+				</div>
+				{phaseMetricSummary.rowCount > 0 ? (
+					<div className="grid grid-cols-3 gap-2">
+						{[
+							{
+								label: "Load",
+								value: phaseMetricSummary.load.eccentricMax,
+								unit,
+								decimals: 1,
+							},
+							{
+								label: "Velocity",
+								value: phaseMetricSummary.velocity.concentricMax,
+								unit: "m/s",
+								decimals: 2,
+							},
+							{
+								label: "Power",
+								value: phaseMetricSummary.power.eccentricMax,
+								unit: "W",
+								decimals: 0,
+							},
+						].map((item) => (
+							<div
+								key={item.label}
+								className="rounded-lg border border-secondary bg-muted/10 p-3"
+							>
+								<div className="text-[10px] uppercase text-muted-foreground">
+									{item.label}
+								</div>
+								<div className="mt-1 text-lg font-bold text-primary">
+									{formatMetric(item.value, item.decimals)}
+								</div>
+								<div className="text-[10px] text-muted-foreground">
+									{item.unit}
+								</div>
+							</div>
+						))}
+					</div>
+				) : (
+					<div className="py-8 text-center text-sm text-muted-foreground">
+						No phase statistics for this period
+					</div>
+				)}
+			</MobileChartCard>
+
+			<MobileChartCard
+				title={`TOP LIFTS (${titlePhase} - ${unit.toUpperCase()})`}
+			>
 				{mobileStrengthData.length > 0 ? (
 					<ResponsiveContainer width="100%" height={250}>
 						<BarChart data={mobileStrengthData} layout="vertical">
@@ -152,7 +241,7 @@ export default function MobileProgressTab({
 						<div className="flex flex-col items-center justify-center rounded-lg bg-primary/10 px-4 py-3">
 							<span className="text-2xl font-bold text-primary">{prCount}</span>
 							<span className="text-[10px] text-muted-foreground">
-								total PRs
+								phase PRs
 							</span>
 						</div>
 						{daysSinceLastPR != null && (

--- a/src/app/components/analytics/ProgressTab.tsx
+++ b/src/app/components/analytics/ProgressTab.tsx
@@ -1,8 +1,17 @@
 import type { LucideIcon } from "lucide-react";
 import { Clock } from "lucide-react";
 import { EChartsWrapper } from "@/app/components/charts/shared/EChartsWrapper";
+import { Button } from "@/app/components/ui/button";
 import { Card } from "@/app/components/ui/card";
 import type { WeightUnit } from "@/lib/units";
+import {
+	WORKOUT_PHASE_FILTERS,
+	type WorkoutPhaseFilter,
+} from "@/lib/workout-phases";
+import type {
+	PhaseMetricPair,
+	PhaseMetricSummary,
+} from "./phaseStatisticsTransforms";
 
 type ChartOption = Record<string, unknown>;
 
@@ -21,6 +30,55 @@ export interface ProgressTabProps {
 	daysSinceLastPR: number | null;
 	strengthExercises: string[];
 	insights: Insight[];
+	phaseFilter: WorkoutPhaseFilter;
+	onPhaseFilterChange: (phase: WorkoutPhaseFilter) => void;
+	phaseMetricSummary: PhaseMetricSummary;
+}
+
+function formatMetric(value: number, decimals = 1): string {
+	return value.toFixed(decimals).replace(/\.0$/, "");
+}
+
+function PhaseMetricPanel({
+	title,
+	pair,
+	unit,
+	decimals = 1,
+}: {
+	title: string;
+	pair: PhaseMetricPair;
+	unit: string;
+	decimals?: number;
+}) {
+	return (
+		<div className="rounded-lg border border-secondary bg-muted/10 p-4">
+			<div className="text-sm font-semibold text-white mb-3">{title}</div>
+			<div className="grid grid-cols-2 gap-4">
+				<div>
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
+						Concentric
+					</div>
+					<div className="mt-1 text-lg font-bold text-primary">
+						{formatMetric(pair.concentricMax, decimals)} {unit}
+					</div>
+					<div className="text-xs text-muted-foreground">
+						avg {formatMetric(pair.concentricAvg, decimals)} {unit}
+					</div>
+				</div>
+				<div>
+					<div className="text-xs uppercase tracking-wide text-muted-foreground">
+						Eccentric
+					</div>
+					<div className="mt-1 text-lg font-bold text-primary">
+						{formatMetric(pair.eccentricMax, decimals)} {unit}
+					</div>
+					<div className="text-xs text-muted-foreground">
+						avg {formatMetric(pair.eccentricAvg, decimals)} {unit}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }
 
 export default function ProgressTab({
@@ -31,17 +89,76 @@ export default function ProgressTab({
 	daysSinceLastPR,
 	strengthExercises,
 	insights,
+	phaseFilter,
+	onPhaseFilterChange,
+	phaseMetricSummary,
 }: ProgressTabProps) {
 	return (
 		<>
+			<Card className="p-6 bg-surface-2 border-secondary">
+				<div className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 mb-6">
+					<div>
+						<h3 className="text-xl text-white">Phase Load, Speed & Power</h3>
+						<p className="text-sm text-muted-foreground mt-1">
+							{phaseMetricSummary.rowCount} sessions with phase samples
+						</p>
+					</div>
+					<div className="flex flex-wrap gap-2">
+						{WORKOUT_PHASE_FILTERS.map((phase) => (
+							<Button
+								key={phase}
+								type="button"
+								size="sm"
+								variant={phaseFilter === phase ? "default" : "outline"}
+								onClick={() => onPhaseFilterChange(phase)}
+								className={
+									phaseFilter === phase
+										? ""
+										: "border-secondary text-muted-foreground hover:text-white"
+								}
+							>
+								{phase === "all" ? "All" : phase}
+							</Button>
+						))}
+					</div>
+				</div>
+				{phaseMetricSummary.rowCount > 0 ? (
+					<div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+						<PhaseMetricPanel
+							title="Load"
+							pair={phaseMetricSummary.load}
+							unit={unit}
+						/>
+						<PhaseMetricPanel
+							title="Velocity"
+							pair={phaseMetricSummary.velocity}
+							unit="m/s"
+							decimals={2}
+						/>
+						<PhaseMetricPanel
+							title="Power"
+							pair={phaseMetricSummary.power}
+							unit="W"
+							decimals={0}
+						/>
+					</div>
+				) : (
+					<div className="h-[140px] flex items-center justify-center text-muted-foreground">
+						No phase statistics for this period
+					</div>
+				)}
+			</Card>
+
 			{/* 1RM Progression */}
 			<Card className="p-6 bg-surface-2 border-secondary">
-				<h3 className="text-xl text-white mb-6">1RM Progression ({unit})</h3>
+				<h3 className="text-xl text-white mb-6">
+					Phase Strength Progression ({unit})
+				</h3>
 				{strengthEChartsOption ? (
 					<EChartsWrapper option={strengthEChartsOption} height={400} />
 				) : (
 					<div className="h-[400px] flex items-center justify-center text-muted-foreground">
-						No strength progress data yet. Set some PRs to see your progression!
+						No strength progress data for this phase
 					</div>
 				)}
 			</Card>
@@ -67,7 +184,7 @@ export default function ProgressTab({
 						<div className="flex flex-col items-center justify-center rounded-xl bg-primary/10 px-6 py-4">
 							<span className="text-3xl font-bold text-primary">{prCount}</span>
 							<span className="text-xs text-muted-foreground mt-1">
-								total PRs
+								phase PRs
 							</span>
 						</div>
 						{daysSinceLastPR != null && (

--- a/src/app/components/analytics/RecordsTab.tsx
+++ b/src/app/components/analytics/RecordsTab.tsx
@@ -39,6 +39,23 @@ type PhaseFilter = (typeof phaseFilters)[number];
 
 const knownGroups = ["Chest", "Back", "Legs", "Shoulders", "Arms", "Core"];
 
+function formatWorkoutPhaseLabel(
+	phase: string | null | undefined,
+): PhaseFilter {
+	switch ((phase ?? "Combined").toUpperCase()) {
+		case "CONCENTRIC":
+			return "Concentric";
+		case "ECCENTRIC":
+			return "Eccentric";
+		default:
+			return "Combined";
+	}
+}
+
+function isNonCombinedWorkoutPhase(phase: string | null | undefined): boolean {
+	return formatWorkoutPhaseLabel(phase) !== "Combined";
+}
+
 function formatRecordTypeLabel(recordType: string): string {
 	const labels: Record<string, string> = {
 		MAX_WEIGHT: "Weight PR",
@@ -144,7 +161,9 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 	const phaseFiltered =
 		phaseFilter === "all"
 			? (records ?? [])
-			: (records ?? []).filter((r) => r.workout_phase === phaseFilter);
+			: (records ?? []).filter(
+					(r) => formatWorkoutPhaseLabel(r.workout_phase) === phaseFilter,
+				);
 
 	// Group by exercise (prefer exercise_id for stable grouping, fall back to name)
 	const exerciseMap = new Map<string, PersonalRecord[]>();
@@ -572,13 +591,16 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 																		</Badge>
 																	</td>
 																	<td className="py-2.5">
-																		{entry.workout_phase &&
-																		entry.workout_phase !== "Combined" ? (
+																		{isNonCombinedWorkoutPhase(
+																			entry.workout_phase,
+																		) ? (
 																			<Badge
 																				variant="outline"
 																				className="border-accent/40 text-accent text-xs"
 																			>
-																				{entry.workout_phase}
+																				{formatWorkoutPhaseLabel(
+																					entry.workout_phase,
+																				)}
 																			</Badge>
 																		) : (
 																			<span className="text-muted-foreground text-xs">
@@ -657,15 +679,14 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 														>
 															{pr.muscle_group}
 														</Badge>
-														{pr.workout_phase &&
-															pr.workout_phase !== "Combined" && (
-																<Badge
-																	variant="outline"
-																	className="border-accent/40 text-accent text-xs flex-shrink-0"
-																>
-																	{pr.workout_phase}
-																</Badge>
-															)}
+														{isNonCombinedWorkoutPhase(pr.workout_phase) && (
+															<Badge
+																variant="outline"
+																className="border-accent/40 text-accent text-xs flex-shrink-0"
+															>
+																{formatWorkoutPhaseLabel(pr.workout_phase)}
+															</Badge>
+														)}
 													</div>
 													<p className="text-xl font-bold text-primary font-data">
 														{formatRecordMeasurement(pr.value, pr.unit, unit)}

--- a/src/app/components/analytics/RecordsTab.tsx
+++ b/src/app/components/analytics/RecordsTab.tsx
@@ -20,6 +20,12 @@ import { EmptyState } from "@/app/components/ui/empty-state";
 import { CardSkeleton, Skeleton } from "@/app/components/ui/skeleton";
 import { useAuth } from "@/app/hooks/useAuth";
 import { convertWeight, type WeightUnit } from "@/lib/units";
+import {
+	formatWorkoutPhase,
+	isNonCombinedWorkoutPhase,
+	WORKOUT_PHASE_FILTERS,
+	type WorkoutPhaseFilter,
+} from "@/lib/workout-phases";
 import { personalRecordsOptions } from "@/queries/records";
 import type { PersonalRecord } from "@/schemas/transforms";
 import { useProfileFilterStore } from "@/stores/useProfileFilterStore";
@@ -34,27 +40,7 @@ const milestones = [
 
 const TIMELINE_INITIAL_LIMIT = 5;
 
-const phaseFilters = ["all", "Combined", "Concentric", "Eccentric"] as const;
-type PhaseFilter = (typeof phaseFilters)[number];
-
 const knownGroups = ["Chest", "Back", "Legs", "Shoulders", "Arms", "Core"];
-
-function formatWorkoutPhaseLabel(
-	phase: string | null | undefined,
-): PhaseFilter {
-	switch ((phase ?? "Combined").toUpperCase()) {
-		case "CONCENTRIC":
-			return "Concentric";
-		case "ECCENTRIC":
-			return "Eccentric";
-		default:
-			return "Combined";
-	}
-}
-
-function isNonCombinedWorkoutPhase(phase: string | null | undefined): boolean {
-	return formatWorkoutPhaseLabel(phase) !== "Combined";
-}
 
 function formatRecordTypeLabel(recordType: string): string {
 	const labels: Record<string, string> = {
@@ -148,7 +134,7 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 	});
 
 	const [activeFilter, setActiveFilter] = useState("All");
-	const [phaseFilter, setPhaseFilter] = useState<PhaseFilter>("all");
+	const [phaseFilter, setPhaseFilter] = useState<WorkoutPhaseFilter>("all");
 	const [viewMode, setViewMode] = useState<"grouped" | "timeline">("grouped");
 	const [expandedExercises, setExpandedExercises] = useState<string[]>([]);
 	const [showAllTimeline, setShowAllTimeline] = useState(false);
@@ -162,7 +148,7 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 		phaseFilter === "all"
 			? (records ?? [])
 			: (records ?? []).filter(
-					(r) => formatWorkoutPhaseLabel(r.workout_phase) === phaseFilter,
+					(r) => formatWorkoutPhase(r.workout_phase) === phaseFilter,
 				);
 
 	// Group by exercise (prefer exercise_id for stable grouping, fall back to name)
@@ -318,7 +304,7 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 
 				{/* Phase filter row */}
 				<div className="flex gap-2 overflow-x-auto pb-1 flex-wrap">
-					{phaseFilters.map((phase) => (
+					{WORKOUT_PHASE_FILTERS.map((phase) => (
 						<Button
 							key={phase}
 							onClick={() => setPhaseFilter(phase)}
@@ -346,7 +332,7 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 				<Card className="p-4 bg-surface-2 border-secondary">
 					<div className="flex items-center gap-2 mb-1">
 						<Trophy className="w-4 h-4 text-accent" />
-						<span className="text-xs text-muted-foreground">Total PRs</span>
+						<span className="text-xs text-muted-foreground">Phase PRs</span>
 					</div>
 					<div className="text-2xl font-semibold text-white font-data">
 						{totalPRs}
@@ -598,7 +584,7 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 																				variant="outline"
 																				className="border-accent/40 text-accent text-xs"
 																			>
-																				{formatWorkoutPhaseLabel(
+																				{formatWorkoutPhase(
 																					entry.workout_phase,
 																				)}
 																			</Badge>
@@ -684,7 +670,7 @@ export default function RecordsTab({ unit }: RecordsTabProps) {
 																variant="outline"
 																className="border-accent/40 text-accent text-xs flex-shrink-0"
 															>
-																{formatWorkoutPhaseLabel(pr.workout_phase)}
+																{formatWorkoutPhase(pr.workout_phase)}
 															</Badge>
 														)}
 													</div>

--- a/src/app/components/analytics/phaseStatisticsTransforms.test.ts
+++ b/src/app/components/analytics/phaseStatisticsTransforms.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { buildPhaseMetricSummary } from "./phaseStatisticsTransforms";
+
+describe("buildPhaseMetricSummary", () => {
+	it("summarizes peak and average kg for both phases", () => {
+		const result = buildPhaseMetricSummary([
+			{
+				concentric_kg_avg: 80,
+				concentric_kg_max: 100,
+				concentric_vel_avg: 0.5,
+				concentric_vel_max: 0.8,
+				concentric_watt_avg: 200,
+				concentric_watt_max: 300,
+				eccentric_kg_avg: 95,
+				eccentric_kg_max: 125,
+				eccentric_vel_avg: 0.4,
+				eccentric_vel_max: 0.7,
+				eccentric_watt_avg: 220,
+				eccentric_watt_max: 340,
+			},
+		]);
+
+		expect(result.load).toEqual({
+			concentricAvg: 80,
+			concentricMax: 100,
+			eccentricAvg: 95,
+			eccentricMax: 125,
+		});
+	});
+
+	it("averages row averages and takes row maximums", () => {
+		const result = buildPhaseMetricSummary([
+			{
+				concentric_kg_avg: 80,
+				concentric_kg_max: 100,
+				concentric_vel_avg: 0.5,
+				concentric_vel_max: 0.8,
+				concentric_watt_avg: 200,
+				concentric_watt_max: 300,
+				eccentric_kg_avg: 95,
+				eccentric_kg_max: 125,
+				eccentric_vel_avg: 0.4,
+				eccentric_vel_max: 0.7,
+				eccentric_watt_avg: 220,
+				eccentric_watt_max: 340,
+			},
+			{
+				concentric_kg_avg: 90,
+				concentric_kg_max: 115,
+				concentric_vel_avg: 0.7,
+				concentric_vel_max: 0.9,
+				concentric_watt_avg: 260,
+				concentric_watt_max: 360,
+				eccentric_kg_avg: 105,
+				eccentric_kg_max: 140,
+				eccentric_vel_avg: 0.6,
+				eccentric_vel_max: 0.85,
+				eccentric_watt_avg: 280,
+				eccentric_watt_max: 390,
+			},
+		]);
+
+		expect(result.load).toEqual({
+			concentricAvg: 85,
+			concentricMax: 115,
+			eccentricAvg: 100,
+			eccentricMax: 140,
+		});
+		expect(result.velocity.eccentricMax).toBe(0.85);
+		expect(result.power.concentricAvg).toBe(230);
+	});
+});

--- a/src/app/components/analytics/phaseStatisticsTransforms.ts
+++ b/src/app/components/analytics/phaseStatisticsTransforms.ts
@@ -1,0 +1,98 @@
+export interface PhaseStatisticsTrendRow {
+	concentric_kg_avg: number | null;
+	concentric_kg_max: number | null;
+	concentric_vel_avg: number | null;
+	concentric_vel_max: number | null;
+	concentric_watt_avg: number | null;
+	concentric_watt_max: number | null;
+	eccentric_kg_avg: number | null;
+	eccentric_kg_max: number | null;
+	eccentric_vel_avg: number | null;
+	eccentric_vel_max: number | null;
+	eccentric_watt_avg: number | null;
+	eccentric_watt_max: number | null;
+}
+
+export interface PhaseMetricPair {
+	concentricAvg: number;
+	concentricMax: number;
+	eccentricAvg: number;
+	eccentricMax: number;
+}
+
+export interface PhaseMetricSummary {
+	load: PhaseMetricPair;
+	velocity: PhaseMetricPair;
+	power: PhaseMetricPair;
+	rowCount: number;
+}
+
+interface MetricKeys {
+	concentricAvg: keyof PhaseStatisticsTrendRow;
+	concentricMax: keyof PhaseStatisticsTrendRow;
+	eccentricAvg: keyof PhaseStatisticsTrendRow;
+	eccentricMax: keyof PhaseStatisticsTrendRow;
+}
+
+function roundMetric(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+function average(values: number[]): number {
+	if (values.length === 0) return 0;
+	return roundMetric(
+		values.reduce((sum, value) => sum + value, 0) / values.length,
+	);
+}
+
+function max(values: number[]): number {
+	if (values.length === 0) return 0;
+	return roundMetric(Math.max(...values));
+}
+
+function numbersFor(
+	rows: PhaseStatisticsTrendRow[],
+	key: keyof PhaseStatisticsTrendRow,
+): number[] {
+	return rows
+		.map((row) => row[key])
+		.filter((value): value is number => typeof value === "number");
+}
+
+function summarizeMetric(
+	rows: PhaseStatisticsTrendRow[],
+	keys: MetricKeys,
+): PhaseMetricPair {
+	return {
+		concentricAvg: average(numbersFor(rows, keys.concentricAvg)),
+		concentricMax: max(numbersFor(rows, keys.concentricMax)),
+		eccentricAvg: average(numbersFor(rows, keys.eccentricAvg)),
+		eccentricMax: max(numbersFor(rows, keys.eccentricMax)),
+	};
+}
+
+export function buildPhaseMetricSummary(
+	rows: PhaseStatisticsTrendRow[],
+): PhaseMetricSummary {
+	return {
+		load: summarizeMetric(rows, {
+			concentricAvg: "concentric_kg_avg",
+			concentricMax: "concentric_kg_max",
+			eccentricAvg: "eccentric_kg_avg",
+			eccentricMax: "eccentric_kg_max",
+		}),
+		velocity: summarizeMetric(rows, {
+			concentricAvg: "concentric_vel_avg",
+			concentricMax: "concentric_vel_max",
+			eccentricAvg: "eccentric_vel_avg",
+			eccentricMax: "eccentric_vel_max",
+		}),
+		power: summarizeMetric(rows, {
+			concentricAvg: "concentric_watt_avg",
+			concentricMax: "concentric_watt_max",
+			eccentricAvg: "eccentric_watt_avg",
+			eccentricMax: "eccentric_watt_max",
+		}),
+		rowCount: rows.length,
+	};
+}

--- a/src/app/components/analytics/strengthPhaseTransforms.test.ts
+++ b/src/app/components/analytics/strengthPhaseTransforms.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildStrengthPhaseSeries } from "./strengthPhaseTransforms";
+import {
+	buildMobileStrengthPhaseData,
+	buildStrengthPhaseSeries,
+	buildStrengthPhaseSummary,
+} from "./strengthPhaseTransforms";
 
 describe("buildStrengthPhaseSeries", () => {
 	it("keeps concentric and eccentric records as separate series", () => {
@@ -77,5 +81,98 @@ describe("buildStrengthPhaseSeries", () => {
 
 		expect(result.series).toEqual([]);
 		expect(result.points).toEqual([]);
+	});
+
+	it("orders mobile top lifts by latest weight before selecting the top five", () => {
+		const result = buildMobileStrengthPhaseData(
+			[
+				{
+					exercise_name: "Alpha Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 10,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Bravo Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 20,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Charlie Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 30,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Delta Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 40,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Echo Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 50,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Zulu Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 100,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+			],
+			"Concentric",
+		);
+
+		expect(result.map((item) => item.exercise)).toEqual([
+			"Zulu Press Concentric",
+			"Echo Press Concentric",
+			"Delta Press Concentric",
+			"Charlie Press Concentric",
+			"Bravo Press Concentric",
+		]);
+	});
+
+	it("summarizes PR count and recency from the selected strength phase", () => {
+		const result = buildStrengthPhaseSummary(
+			[
+				{
+					exercise_name: "Bench Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 100,
+					achieved_at: "2026-06-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Bench Press",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "ECCENTRIC",
+					value: 140,
+					achieved_at: "2026-06-09T00:00:00Z",
+				},
+				{
+					exercise_name: "Bench Press",
+					record_type: "MAX_VOLUME",
+					workout_phase: "CONCENTRIC",
+					value: 2500,
+					achieved_at: "2026-06-10T00:00:00Z",
+				},
+			],
+			"Concentric",
+			new Date("2026-06-10T00:00:00Z"),
+		);
+
+		expect(result).toEqual({
+			prCount: 1,
+			daysSinceLastPR: 9,
+		});
 	});
 });

--- a/src/app/components/analytics/strengthPhaseTransforms.test.ts
+++ b/src/app/components/analytics/strengthPhaseTransforms.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { buildStrengthPhaseSeries } from "./strengthPhaseTransforms";
+
+describe("buildStrengthPhaseSeries", () => {
+	it("keeps concentric and eccentric records as separate series", () => {
+		const result = buildStrengthPhaseSeries(
+			[
+				{
+					exercise_name: "Bench Press",
+					exercise_id: "bench",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 100,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Bench Press",
+					exercise_id: "bench",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "ECCENTRIC",
+					value: 130,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+			],
+			"all",
+		);
+
+		expect(result.series.map((s) => s.name)).toEqual([
+			"Bench Press Concentric",
+			"Bench Press Eccentric",
+		]);
+		expect(result.points[0]).toMatchObject({
+			"bench::Concentric": 100,
+			"bench::Eccentric": 130,
+		});
+	});
+
+	it("filters by selected phase", () => {
+		const result = buildStrengthPhaseSeries(
+			[
+				{
+					exercise_name: "Squat",
+					exercise_id: "squat",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "CONCENTRIC",
+					value: 140,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+				{
+					exercise_name: "Squat",
+					exercise_id: "squat",
+					record_type: "MAX_WEIGHT",
+					workout_phase: "ECCENTRIC",
+					value: 180,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+			],
+			"Concentric",
+		);
+
+		expect(result.series.map((s) => s.name)).toEqual(["Squat Concentric"]);
+	});
+
+	it("excludes non-weight personal records from strength charts", () => {
+		const result = buildStrengthPhaseSeries(
+			[
+				{
+					exercise_name: "Squat",
+					record_type: "MAX_VOLUME",
+					workout_phase: "COMBINED",
+					value: 5000,
+					achieved_at: "2026-05-01T00:00:00Z",
+				},
+			],
+			"all",
+		);
+
+		expect(result.series).toEqual([]);
+		expect(result.points).toEqual([]);
+	});
+});

--- a/src/app/components/analytics/strengthPhaseTransforms.ts
+++ b/src/app/components/analytics/strengthPhaseTransforms.ts
@@ -20,6 +20,11 @@ export interface StrengthPhaseSeries {
 	latestValue: number;
 }
 
+export interface StrengthPhaseSummary {
+	prCount: number;
+	daysSinceLastPR: number | null;
+}
+
 const strengthRecordTypes = new Set(["MAX_WEIGHT", "1RM"]);
 const phaseOrder = new Map([
 	["Combined", 0],
@@ -32,6 +37,17 @@ function isStrengthRecord(recordType: string | null | undefined): boolean {
 	return strengthRecordTypes.has(recordType.toUpperCase());
 }
 
+function filterStrengthPhaseRecords(
+	data: StrengthPhaseRecord[],
+	phaseFilter: WorkoutPhaseFilter,
+): StrengthPhaseRecord[] {
+	return data.filter((item) => {
+		if (!isStrengthRecord(item.record_type)) return false;
+		const phase = normalizeWorkoutPhase(item.workout_phase);
+		return phaseFilter === "all" || phase === phaseFilter;
+	});
+}
+
 export function buildStrengthPhaseSeries(
 	data: StrengthPhaseRecord[],
 	phaseFilter: WorkoutPhaseFilter,
@@ -39,11 +55,7 @@ export function buildStrengthPhaseSeries(
 	points: Record<string, string | number>[];
 	series: StrengthPhaseSeries[];
 } {
-	const filtered = data.filter((item) => {
-		if (!isStrengthRecord(item.record_type)) return false;
-		const phase = normalizeWorkoutPhase(item.workout_phase);
-		return phaseFilter === "all" || phase === phaseFilter;
-	});
+	const filtered = filterStrengthPhaseRecords(data, phaseFilter);
 
 	const dateSet = new Set<string>();
 	const dateOrder = new Map<string, number>();
@@ -121,9 +133,35 @@ export function buildMobileStrengthPhaseData(
 	phaseFilter: WorkoutPhaseFilter,
 ): Array<{ exercise: string; weight: number; phase: string }> {
 	const { series } = buildStrengthPhaseSeries(data, phaseFilter);
-	return series.slice(0, 5).map((item) => ({
-		exercise: item.name,
-		weight: item.latestValue,
-		phase: item.phase,
-	}));
+	return [...series]
+		.sort((a, b) => b.latestValue - a.latestValue)
+		.slice(0, 5)
+		.map((item) => ({
+			exercise: item.name,
+			weight: item.latestValue,
+			phase: item.phase,
+		}));
+}
+
+export function buildStrengthPhaseSummary(
+	data: StrengthPhaseRecord[],
+	phaseFilter: WorkoutPhaseFilter,
+	now = new Date(),
+): StrengthPhaseSummary {
+	const filtered = filterStrengthPhaseRecords(data, phaseFilter);
+	if (filtered.length === 0) {
+		return { prCount: 0, daysSinceLastPR: null };
+	}
+
+	const latestTime = filtered.reduce((latest, item) => {
+		const achievedAt = new Date(item.achieved_at).getTime();
+		return Number.isFinite(achievedAt) ? Math.max(latest, achievedAt) : latest;
+	}, Number.NEGATIVE_INFINITY);
+
+	return {
+		prCount: filtered.length,
+		daysSinceLastPR: Number.isFinite(latestTime)
+			? Math.floor((now.getTime() - latestTime) / (1000 * 60 * 60 * 24))
+			: null,
+	};
 }

--- a/src/app/components/analytics/strengthPhaseTransforms.ts
+++ b/src/app/components/analytics/strengthPhaseTransforms.ts
@@ -1,0 +1,129 @@
+import {
+	normalizeWorkoutPhase,
+	type WorkoutPhaseFilter,
+} from "@/lib/workout-phases";
+
+export interface StrengthPhaseRecord {
+	exercise_name: string;
+	exercise_id?: string | null;
+	record_type?: string | null;
+	workout_phase?: string | null;
+	value: number;
+	achieved_at: string;
+}
+
+export interface StrengthPhaseSeries {
+	key: string;
+	name: string;
+	exerciseName: string;
+	phase: string;
+	latestValue: number;
+}
+
+const strengthRecordTypes = new Set(["MAX_WEIGHT", "1RM"]);
+const phaseOrder = new Map([
+	["Combined", 0],
+	["Concentric", 1],
+	["Eccentric", 2],
+]);
+
+function isStrengthRecord(recordType: string | null | undefined): boolean {
+	if (!recordType) return true;
+	return strengthRecordTypes.has(recordType.toUpperCase());
+}
+
+export function buildStrengthPhaseSeries(
+	data: StrengthPhaseRecord[],
+	phaseFilter: WorkoutPhaseFilter,
+): {
+	points: Record<string, string | number>[];
+	series: StrengthPhaseSeries[];
+} {
+	const filtered = data.filter((item) => {
+		if (!isStrengthRecord(item.record_type)) return false;
+		const phase = normalizeWorkoutPhase(item.workout_phase);
+		return phaseFilter === "all" || phase === phaseFilter;
+	});
+
+	const dateSet = new Set<string>();
+	const dateOrder = new Map<string, number>();
+	const valueBySeries = new Map<string, Map<string, number>>();
+	const latestBySeries = new Map<
+		string,
+		StrengthPhaseSeries & { at: number }
+	>();
+
+	for (const item of filtered) {
+		const phase = normalizeWorkoutPhase(item.workout_phase);
+		const baseKey = item.exercise_id ?? item.exercise_name;
+		const key = `${baseKey}::${phase}`;
+		const name = `${item.exercise_name} ${phase}`;
+		const achievedAt = new Date(item.achieved_at);
+		const date = achievedAt.toLocaleDateString("en-US", {
+			month: "short",
+		});
+
+		dateSet.add(date);
+		const existingDateOrder = dateOrder.get(date);
+		if (!existingDateOrder || achievedAt.getTime() < existingDateOrder) {
+			dateOrder.set(date, achievedAt.getTime());
+		}
+		if (!valueBySeries.has(key)) {
+			valueBySeries.set(key, new Map());
+		}
+
+		const existing = valueBySeries.get(key)?.get(date) ?? 0;
+		if (item.value > existing) {
+			valueBySeries.get(key)?.set(date, item.value);
+		}
+
+		const at = achievedAt.getTime();
+		const latest = latestBySeries.get(key);
+		if (!latest || at > latest.at) {
+			latestBySeries.set(key, {
+				key,
+				name,
+				exerciseName: item.exercise_name,
+				phase,
+				latestValue: item.value,
+				at,
+			});
+		}
+	}
+
+	const selectedSeries = Array.from(latestBySeries.values())
+		.sort((a, b) => b.latestValue - a.latestValue)
+		.slice(0, 6);
+
+	const series = selectedSeries
+		.sort((a, b) => {
+			const exerciseCompare = a.exerciseName.localeCompare(b.exerciseName);
+			if (exerciseCompare !== 0) return exerciseCompare;
+			return (phaseOrder.get(a.phase) ?? 99) - (phaseOrder.get(b.phase) ?? 99);
+		})
+		.map(({ at: _at, ...item }) => item);
+
+	const points = Array.from(dateSet)
+		.sort((a, b) => (dateOrder.get(a) ?? 0) - (dateOrder.get(b) ?? 0))
+		.map((date) => {
+			const point: Record<string, string | number> = { date };
+			for (const item of series) {
+				point[item.key] = valueBySeries.get(item.key)?.get(date) ?? 0;
+			}
+			return point;
+		});
+
+	return { points, series };
+}
+
+export function buildMobileStrengthPhaseData(
+	data: StrengthPhaseRecord[],
+	phaseFilter: WorkoutPhaseFilter,
+): Array<{ exercise: string; weight: number; phase: string }> {
+	const { series } = buildStrengthPhaseSeries(data, phaseFilter);
+	return series.slice(0, 5).map((item) => ({
+		exercise: item.name,
+		weight: item.latestValue,
+		phase: item.phase,
+	}));
+}

--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildDedicatedPersonalRecordRows,
 	buildPersonalRecordRows,
+	buildPersonalRecordRowsForPush,
 	personalRecordIdentityKey,
 } from "../../../supabase/functions/_shared/personalRecordRow.ts";
 
@@ -179,6 +181,104 @@ describe("buildPersonalRecordRows", () => {
 	});
 });
 
+describe("buildDedicatedPersonalRecordRows", () => {
+	it("maps mobile personalRecords rows to supported personal_records columns", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					exerciseName: "Bench Press",
+					exerciseId: "catalog-bench-press",
+					muscleGroup: "Chest",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					weightKg: 125,
+					reps: 3,
+					workoutPhase: "CONCENTRIC",
+					sessionId: "22222222-2222-4222-8222-222222222222",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					updatedAt: "2026-04-21T12:30:00.000Z",
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+		);
+
+		expect(out).toEqual([
+			{
+				id: "11111111-1111-4111-8111-111111111111",
+				user_id: USER_ID,
+				local_profile_id: PROFILE_ID,
+				exercise_name: "Bench Press",
+				exercise_id: "catalog-bench-press",
+				muscle_group: "Chest",
+				record_type: "MAX_WEIGHT",
+				value: 125,
+				weight_kg: 125,
+				reps: 3,
+				unit: "kg",
+				session_id: "22222222-2222-4222-8222-222222222222",
+				achieved_at: "2026-04-21T12:00:00.000Z",
+				updated_at: "2026-04-21T12:30:00.000Z",
+				workout_phase: "CONCENTRIC",
+			},
+		]);
+	});
+
+	it("uses volume as the value for MAX_VOLUME records when value is absent", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Squat",
+					muscleGroup: null,
+					recordType: "MAX_VOLUME",
+					value: null,
+					volume: 1800,
+					weightKg: 90,
+					reps: 20,
+					workoutPhase: null,
+					achievedAt: "2026-04-21T12:00:00.000Z",
+				},
+			],
+			USER_ID,
+			null,
+		);
+
+		expect(out[0]?.value).toBe(1800);
+		expect(out[0]?.unit).toBe("kg×reps");
+		expect(out[0]?.muscle_group).toBe("General");
+		expect(out[0]?.workout_phase).toBe("COMBINED");
+		expect(out[0]?.local_profile_id).toBeNull();
+	});
+});
+
+describe("buildPersonalRecordRowsForPush", () => {
+	it("treats dedicated personalRecords as authoritative over set-derived fallback", () => {
+		const dedicated = [
+			{
+				exerciseName: "Bench Press",
+				muscleGroup: "Chest",
+				recordType: "MAX_WEIGHT",
+				value: 125,
+				workoutPhase: "ECCENTRIC",
+				achievedAt: "2026-04-21T12:00:00.000Z",
+			},
+		];
+
+		const rows = buildPersonalRecordRowsForPush(
+			[baseSession({ prType: "MAX_VOLUME", prPhase: "CONCENTRIC" })],
+			dedicated,
+			USER_ID,
+			PROFILE_ID,
+		);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.exercise_name).toBe("Bench Press");
+		expect(rows[0]?.record_type).toBe("MAX_WEIGHT");
+		expect(rows[0]?.workout_phase).toBe("ECCENTRIC");
+	});
+});
+
 describe("personalRecordIdentityKey", () => {
 	const baseRecord = {
 		local_profile_id: PROFILE_ID,
@@ -227,6 +327,34 @@ describe("personalRecordIdentityKey", () => {
 			personalRecordIdentityKey({
 				...baseRecord,
 				value: "40",
+			}),
+		);
+	});
+
+	it("dedupes corrected values for the same achieved record identity", () => {
+		expect(
+			personalRecordIdentityKey({
+				...baseRecord,
+				value: 40,
+			}),
+		).toBe(
+			personalRecordIdentityKey({
+				...baseRecord,
+				value: 42.5,
+			}),
+		);
+	});
+
+	it("separates matching records by workout phase", () => {
+		expect(
+			personalRecordIdentityKey({
+				...baseRecord,
+				workout_phase: "CONCENTRIC",
+			}),
+		).not.toBe(
+			personalRecordIdentityKey({
+				...baseRecord,
+				workout_phase: "ECCENTRIC",
 			}),
 		);
 	});

--- a/src/lib/__tests__/sync-push-schema.test.ts
+++ b/src/lib/__tests__/sync-push-schema.test.ts
@@ -103,6 +103,7 @@ describe("pushPayloadSchema", () => {
 		expect(parsed.phaseStatistics).toEqual([]);
 		expect(parsed.exerciseSignatures).toEqual([]);
 		expect(parsed.assessments).toEqual([]);
+		expect(parsed.personalRecords).toEqual([]);
 	});
 
 	it("coerces non-array values in array positions to []", () => {
@@ -256,6 +257,55 @@ describe("pushPayloadSchema", () => {
 				muscleGroup: "Chest",
 				equipment: "HANDLES,BENCH",
 				defaultCableConfig: "DOUBLE",
+			},
+		]);
+	});
+
+	it("preserves top-level mobile personalRecords through validation", () => {
+		const parsed = pushPayloadSchema.parse({
+			deviceId: "d1",
+			platform: "android",
+			profileId: "default",
+			personalRecords: [
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					userId: "u1",
+					exerciseName: "Bench Press",
+					exerciseId: "catalog-bench-press",
+					muscleGroup: "Chest",
+					recordType: "MAX_VOLUME",
+					value: null,
+					volume: 1875,
+					weightKg: 125,
+					reps: 15,
+					workoutPhase: "ECCENTRIC",
+					sessionId: "22222222-2222-4222-8222-222222222222",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					updatedAt: "2026-04-21T12:30:00.000Z",
+					localProfileId: "default",
+					workoutMode: "OLD_SCHOOL",
+				},
+			],
+		});
+
+		expect(parsed.personalRecords).toEqual([
+			{
+				id: "11111111-1111-4111-8111-111111111111",
+				userId: "u1",
+				exerciseName: "Bench Press",
+				exerciseId: "catalog-bench-press",
+				muscleGroup: "Chest",
+				recordType: "MAX_VOLUME",
+				value: null,
+				volume: 1875,
+				weightKg: 125,
+				reps: 15,
+				workoutPhase: "ECCENTRIC",
+				sessionId: "22222222-2222-4222-8222-222222222222",
+				achievedAt: "2026-04-21T12:00:00.000Z",
+				updatedAt: "2026-04-21T12:30:00.000Z",
+				localProfileId: "default",
+				workoutMode: "OLD_SCHOOL",
 			},
 		]);
 	});

--- a/src/lib/__tests__/workout-phases.test.ts
+++ b/src/lib/__tests__/workout-phases.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatWorkoutPhase,
+	isNonCombinedWorkoutPhase,
+	isWorkoutPhase,
+	normalizeWorkoutPhase,
+	WORKOUT_PHASE_FILTERS,
+} from "@/lib/workout-phases";
+
+describe("workout phase helpers", () => {
+	it("normalizes API, database, and display phase values", () => {
+		expect(normalizeWorkoutPhase("COMBINED")).toBe("Combined");
+		expect(normalizeWorkoutPhase("Concentric")).toBe("Concentric");
+		expect(normalizeWorkoutPhase("eccentric")).toBe("Eccentric");
+		expect(normalizeWorkoutPhase(null)).toBe("Combined");
+	});
+
+	it("keeps phase filter order stable", () => {
+		expect(WORKOUT_PHASE_FILTERS).toEqual([
+			"all",
+			"Combined",
+			"Concentric",
+			"Eccentric",
+		]);
+	});
+
+	it("detects valid and non-combined phases", () => {
+		expect(isWorkoutPhase("Concentric")).toBe(true);
+		expect(isWorkoutPhase("Other")).toBe(false);
+		expect(isNonCombinedWorkoutPhase("CONCENTRIC")).toBe(true);
+		expect(isNonCombinedWorkoutPhase("COMBINED")).toBe(false);
+	});
+
+	it("formats unknown values defensively as Combined", () => {
+		expect(formatWorkoutPhase("unexpected")).toBe("Combined");
+	});
+});

--- a/src/lib/export/csv.test.ts
+++ b/src/lib/export/csv.test.ts
@@ -79,4 +79,27 @@ describe("CSV export formula escaping", () => {
 			expect(rows[index]["Record Type"]).toBe(`'${prefix}record`);
 		}
 	});
+
+	it("includes workout phase in personal record exports", () => {
+		const records: PersonalRecord[] = [
+			{
+				id: "00000000-0000-4000-8000-000000000001",
+				user_id: "00000000-0000-4000-8000-000000000999",
+				exercise_name: "Bench Press",
+				exercise_id: null,
+				muscle_group: "Chest",
+				record_type: "MAX_WEIGHT",
+				value: 125,
+				unit: "kg",
+				achieved_at: new Date("2026-05-17T12:00:00Z"),
+				previous_value: null,
+				workout_phase: "Concentric",
+				local_profile_id: null,
+			},
+		];
+
+		const rows = parseCSV(generateRecordsCSV(records));
+
+		expect(rows[0]["Workout Phase"]).toBe("Concentric");
+	});
 });

--- a/src/lib/export/csv.ts
+++ b/src/lib/export/csv.ts
@@ -47,6 +47,7 @@ export function generateRecordsCSV(
 		Exercise: r.exercise_name,
 		"Muscle Group": r.muscle_group,
 		"Record Type": formatRecordType(r.record_type),
+		"Workout Phase": r.workout_phase ?? "Combined",
 		Value: r.unit === "kg" ? convertWeight(r.value, unit) : r.value,
 		Unit: r.unit === "kg" ? getUnitLabel(unit) : r.unit,
 		"Date Achieved": format(r.achieved_at, "yyyy-MM-dd"),

--- a/src/lib/workout-phases.ts
+++ b/src/lib/workout-phases.ts
@@ -1,0 +1,40 @@
+export const WORKOUT_PHASES = ["Combined", "Concentric", "Eccentric"] as const;
+export const WORKOUT_PHASE_FILTERS = ["all", ...WORKOUT_PHASES] as const;
+
+export type WorkoutPhase = (typeof WORKOUT_PHASES)[number];
+export type WorkoutPhaseFilter = (typeof WORKOUT_PHASE_FILTERS)[number];
+
+const phaseMap: Record<string, WorkoutPhase> = {
+	COMBINED: "Combined",
+	Combined: "Combined",
+	combined: "Combined",
+	CONCENTRIC: "Concentric",
+	Concentric: "Concentric",
+	concentric: "Concentric",
+	ECCENTRIC: "Eccentric",
+	Eccentric: "Eccentric",
+	eccentric: "Eccentric",
+};
+
+export function normalizeWorkoutPhase(
+	phase: string | null | undefined,
+): WorkoutPhase {
+	if (!phase) return "Combined";
+	return phaseMap[phase] ?? "Combined";
+}
+
+export function formatWorkoutPhase(
+	phase: string | null | undefined,
+): WorkoutPhase {
+	return normalizeWorkoutPhase(phase);
+}
+
+export function isWorkoutPhase(value: string): value is WorkoutPhase {
+	return WORKOUT_PHASES.includes(value as WorkoutPhase);
+}
+
+export function isNonCombinedWorkoutPhase(
+	phase: string | null | undefined,
+): boolean {
+	return normalizeWorkoutPhase(phase) !== "Combined";
+}

--- a/src/queries/__tests__/analytics.test.ts
+++ b/src/queries/__tests__/analytics.test.ts
@@ -191,6 +191,8 @@ describe("strengthProgressOptions", () => {
 		const raw = [
 			{
 				exercise_name: "Bench Press",
+				record_type: "MAX_WEIGHT",
+				workout_phase: "CONCENTRIC",
 				value: 100,
 				achieved_at: "2026-03-01T00:00:00Z",
 			},
@@ -203,6 +205,16 @@ describe("strengthProgressOptions", () => {
 		expect(result[0].exercise_name).toBe("Bench Press");
 	});
 
+	it("selects record type and workout phase for phase-aware strength charts", async () => {
+		chain = buildChain({ data: [], error: null });
+		const { strengthProgressOptions } = await import("../analytics");
+		const opts = strengthProgressOptions("user-1");
+		await opts.queryFn?.({} as never);
+		expect(chain.select).toHaveBeenCalledWith(
+			"exercise_name, exercise_id, record_type, workout_phase, value, achieved_at",
+		);
+	});
+
 	it("throws on Supabase error", async () => {
 		chain = buildChain({
 			data: null,
@@ -212,6 +224,55 @@ describe("strengthProgressOptions", () => {
 		const opts = strengthProgressOptions("user-1");
 		await expect(opts.queryFn?.({} as never)).rejects.toEqual(
 			expect.objectContaining({ message: "query error" }),
+		);
+	});
+});
+
+describe("phaseStatisticsTrendOptions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fromFn.mockImplementation(() => chain);
+	});
+
+	it("uses a user, period, and profile-specific query key", async () => {
+		chain = buildChain({ data: [], error: null });
+		const { phaseStatisticsTrendOptions } = await import("../analytics");
+		const opts = phaseStatisticsTrendOptions("user-1", "4w", "profile-1");
+		expect(opts.queryKey).toEqual(
+			queryKeys.analytics.phaseStats("user-1", "4w", "profile-1"),
+		);
+	});
+
+	it("queries session phase statistics with workout session context", async () => {
+		chain = buildChain({ data: [], error: null });
+		const { phaseStatisticsTrendOptions } = await import("../analytics");
+		const opts = phaseStatisticsTrendOptions("user-1", "4w", "profile-1");
+		const result = await opts.queryFn?.({} as never);
+
+		expect(result).toEqual([]);
+		expect(fromFn).toHaveBeenCalledWith("session_phase_statistics");
+		expect(chain.select).toHaveBeenCalledWith(
+			[
+				"session_id",
+				"concentric_kg_avg",
+				"concentric_kg_max",
+				"concentric_vel_avg",
+				"concentric_vel_max",
+				"concentric_watt_avg",
+				"concentric_watt_max",
+				"eccentric_kg_avg",
+				"eccentric_kg_max",
+				"eccentric_vel_avg",
+				"eccentric_vel_max",
+				"eccentric_watt_avg",
+				"eccentric_watt_max",
+				"workout_sessions!inner(started_at, local_profile_id, name)",
+			].join(", "),
+		);
+		expect(chain.eq).toHaveBeenCalledWith("user_id", "user-1");
+		expect(chain.eq).toHaveBeenCalledWith(
+			"workout_sessions.local_profile_id",
+			"profile-1",
 		);
 	});
 });

--- a/src/queries/__tests__/challenges.test.ts
+++ b/src/queries/__tests__/challenges.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function buildChain(terminal: { data: unknown; error: unknown }) {
+	const self: Record<string, ReturnType<typeof vi.fn>> = {};
+	const methods = ["select", "eq", "gte", "lte", "order"];
+	for (const method of methods) {
+		self[method] = vi.fn();
+	}
+	for (const method of methods) {
+		self[method].mockReturnValue({ ...self, ...terminal });
+	}
+	return self;
+}
+
+let chain: ReturnType<typeof buildChain>;
+const fromFn = vi.fn(() => chain);
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: { from: (...args: unknown[]) => fromFn(...args) },
+}));
+
+describe("challengeProgressOptions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("counts phase-specific personal record rows separately for PR challenges", async () => {
+		chain = buildChain({
+			data: [
+				{ id: "combined-pr" },
+				{ id: "concentric-pr" },
+				{ id: "eccentric-pr" },
+			],
+			error: null,
+		});
+
+		const { challengeProgressOptions } = await import("../challenges");
+		const opts = challengeProgressOptions(
+			"user-1",
+			"challenge-1",
+			"pr_count",
+			3,
+			"2026-05-01T00:00:00Z",
+			"2026-05-31T23:59:59Z",
+		);
+
+		const result = await opts.queryFn?.({} as never);
+
+		expect(fromFn).toHaveBeenCalledWith("personal_records");
+		expect(result).toEqual({ current: 3, target: 3, percentage: 100 });
+	});
+});

--- a/src/queries/analytics.ts
+++ b/src/queries/analytics.ts
@@ -112,7 +112,9 @@ export function strengthProgressOptions(
 		queryFn: async () => {
 			let query = supabase
 				.from("personal_records")
-				.select("exercise_name, exercise_id, value, achieved_at")
+				.select(
+					"exercise_name, exercise_id, record_type, workout_phase, value, achieved_at",
+				)
 				.eq("user_id", userId);
 
 			if (profileId) {
@@ -300,6 +302,54 @@ export function calorieHistoryOptions(
 				.order("started_at", { ascending: true });
 			if (error) throw error;
 			return data;
+		},
+	});
+}
+
+/** Phase statistics over time for concentric/eccentric analytics */
+export function phaseStatisticsTrendOptions(
+	userId: string,
+	period: string = "4w",
+	profileId?: string | null,
+) {
+	return queryOptions({
+		queryKey: queryKeys.analytics.phaseStats(userId, period, profileId),
+		queryFn: async () => {
+			const daysBack = periodToDays(period);
+			const since = new Date();
+			since.setDate(since.getDate() - daysBack);
+
+			let query = supabase
+				.from("session_phase_statistics")
+				.select(
+					[
+						"session_id",
+						"concentric_kg_avg",
+						"concentric_kg_max",
+						"concentric_vel_avg",
+						"concentric_vel_max",
+						"concentric_watt_avg",
+						"concentric_watt_max",
+						"eccentric_kg_avg",
+						"eccentric_kg_max",
+						"eccentric_vel_avg",
+						"eccentric_vel_max",
+						"eccentric_watt_avg",
+						"eccentric_watt_max",
+						"workout_sessions!inner(started_at, local_profile_id, name)",
+					].join(", "),
+				)
+				.eq("user_id", userId)
+				.gte("workout_sessions.started_at", since.toISOString())
+				.order("created_at", { ascending: true });
+
+			if (profileId) {
+				query = query.eq("workout_sessions.local_profile_id", profileId);
+			}
+
+			const { data, error } = await query;
+			if (error) throw error;
+			return data ?? [];
 		},
 	});
 }

--- a/src/queries/challenges.ts
+++ b/src/queries/challenges.ts
@@ -35,7 +35,7 @@ export function userChallengesOptions(userId: string) {
 	});
 }
 
-/** Compute challenge progress from workout_sessions */
+/** Compute challenge progress from workout_sessions or phase-aware PR rows */
 export function challengeProgressOptions(
 	userId: string,
 	challengeId: string,
@@ -92,6 +92,8 @@ export function challengeProgressOptions(
 					break;
 				}
 				case "pr_count": {
+					// Phase-specific records are distinct rows in personal_records and
+					// intentionally count separately for PR-count challenges.
 					const { data, error } = await supabase
 						.from("personal_records")
 						.select("id")

--- a/src/queries/keys.ts
+++ b/src/queries/keys.ts
@@ -48,6 +48,14 @@ export const queryKeys = {
 			] as const,
 		sessionSetWeights: (sessionId: string) =>
 			[...queryKeys.analytics.all, "session-set-weights", sessionId] as const,
+		phaseStats: (userId: string, period: string, profileId?: string | null) =>
+			[
+				...queryKeys.analytics.all,
+				"phase-stats",
+				userId,
+				period,
+				profileId ?? "all",
+			] as const,
 	},
 	routines: {
 		all: ["routines"] as const,

--- a/src/queries/profile.ts
+++ b/src/queries/profile.ts
@@ -65,7 +65,7 @@ export function profileStatsOptions(userId: string, profileId?: string | null) {
 			// Compute best streak from sessions
 			const bestStreak = computeBestStreak(sessions ?? []);
 
-			// Count personal records
+			// Count personal_records rows. Phase-specific records are distinct PRs.
 			let prQuery = supabase
 				.from("personal_records")
 				.select("id", { count: "exact", head: true })

--- a/supabase/functions/_shared/oauthTokenCrypto.ts
+++ b/supabase/functions/_shared/oauthTokenCrypto.ts
@@ -2,9 +2,10 @@
  * AES-GCM encryption for oauth_tokens sensitive columns (access_token, refresh_token, api_key).
  *
  * Set OAUTH_TOKEN_ENCRYPTION_KEY to a base64-encoded 32-byte key. When unset:
- *   - In deployed Supabase Edge runtimes (SUPABASE_URL + DENO_DEPLOYMENT_ID
- *     present), this module throws on first use so we fail loud instead of
- *     silently persisting OAuth tokens as plaintext.
+ *   - In deployed Supabase Edge runtimes or self-hosted production
+ *     (SUPABASE_URL plus DENO_DEPLOYMENT_ID, SUPABASE_PUBLIC_URL, or
+ *     ENVIRONMENT=production present), this module throws on first use so we
+ *     fail loud instead of silently persisting OAuth tokens as plaintext.
  *   - In local dev, values pass through unencrypted with a single warning so
  *     contributors can iterate without secrets set.
  */
@@ -15,11 +16,13 @@ let keyCache: CryptoKey | null | undefined;
 let devPlaintextWarned = false;
 
 function isProductionRuntime(): boolean {
-  // Supabase Edge runtimes always set DENO_DEPLOYMENT_ID. Local `supabase
-  // functions serve` does not. We additionally require SUPABASE_URL to avoid
-  // tripping inside pure unit-test environments.
+  // Hosted Supabase sets DENO_DEPLOYMENT_ID. The self-hosted edge runtime does
+  // not, so include the production markers we pass through in Docker Compose.
+  if (!Deno.env.get('SUPABASE_URL')) return false;
   return Boolean(
-    Deno.env.get('DENO_DEPLOYMENT_ID') && Deno.env.get('SUPABASE_URL'),
+    Deno.env.get('DENO_DEPLOYMENT_ID') ||
+      Deno.env.get('SUPABASE_PUBLIC_URL') ||
+      Deno.env.get('ENVIRONMENT') === 'production',
   );
 }
 

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -41,6 +41,7 @@ export interface PrSessionInput {
 }
 
 export interface PersonalRecordRow {
+	id?: string;
 	user_id: string;
 	local_profile_id: string | null;
 	exercise_name: string;
@@ -48,9 +49,32 @@ export interface PersonalRecordRow {
 	muscle_group: string;
 	record_type: string;
 	value: number;
+	weight_kg?: number | null;
+	reps?: number | null;
 	unit: string;
+	session_id?: string | null;
 	achieved_at: string;
+	updated_at?: string;
 	workout_phase: string;
+}
+
+export interface DedicatedPersonalRecordInput {
+	id?: string | null;
+	userId?: string | null;
+	exerciseName: string;
+	exerciseId?: string | null;
+	muscleGroup?: string | null;
+	recordType?: string | null;
+	value?: number | null;
+	volume?: number | null;
+	weightKg?: number | null;
+	reps?: number | null;
+	workoutPhase?: string | null;
+	sessionId?: string | null;
+	achievedAt?: string | null;
+	updatedAt?: string | null;
+	localProfileId?: string | null;
+	workoutMode?: string | null;
 }
 
 export interface PersonalRecordIdentityInput {
@@ -74,10 +98,76 @@ export function personalRecordIdentityKey(
 		profileKey,
 		exerciseKey,
 		row.achieved_at ?? "",
-		String(row.value ?? ""),
 		row.record_type ?? "",
 		row.workout_phase ?? "COMBINED",
 	]);
+}
+
+function unitForRecordType(recordType: string): string {
+	return recordType === "MAX_VOLUME" ? "kg×reps" : "kg";
+}
+
+function valueForDedicatedRecord(
+	record: DedicatedPersonalRecordInput,
+	recordType: string,
+): number {
+	if (record.value != null) return record.value;
+	if (recordType === "MAX_VOLUME") {
+		if (record.volume != null) return record.volume;
+		if (record.weightKg != null && record.reps != null) {
+			return record.weightKg * record.reps;
+		}
+	}
+	return record.weightKg ?? 0;
+}
+
+export function buildDedicatedPersonalRecordRows(
+	records: DedicatedPersonalRecordInput[],
+	userId: string,
+	localProfileId: string | null,
+): PersonalRecordRow[] {
+	return records.map((record) => {
+		const recordType = record.recordType ?? "1RM";
+		const row: PersonalRecordRow = {
+			user_id: userId,
+			local_profile_id:
+				record.localProfileId === undefined
+					? localProfileId
+					: record.localProfileId,
+			exercise_name: record.exerciseName,
+			exercise_id: record.exerciseId ?? null,
+			muscle_group: record.muscleGroup ?? "General",
+			record_type: recordType,
+			value: valueForDedicatedRecord(record, recordType),
+			weight_kg: record.weightKg ?? null,
+			reps: record.reps ?? null,
+			unit: unitForRecordType(recordType),
+			session_id: record.sessionId ?? null,
+			achieved_at: record.achievedAt ?? new Date().toISOString(),
+			workout_phase: record.workoutPhase ?? "COMBINED",
+		};
+
+		if (record.id) row.id = record.id;
+		if (record.updatedAt) row.updated_at = record.updatedAt;
+		return row;
+	});
+}
+
+export function buildPersonalRecordRowsForPush(
+	sessions: PrSessionInput[],
+	personalRecords: DedicatedPersonalRecordInput[],
+	userId: string,
+	localProfileId: string | null,
+): PersonalRecordRow[] {
+	if (personalRecords.length > 0) {
+		return buildDedicatedPersonalRecordRows(
+			personalRecords,
+			userId,
+			localProfileId,
+		);
+	}
+
+	return buildPersonalRecordRows(sessions, userId, localProfileId);
 }
 
 export function buildPersonalRecordRows(
@@ -105,7 +195,9 @@ export function buildPersonalRecordRows(
 					muscle_group: exercise.muscleGroup ?? "General",
 					record_type: recordType,
 					value,
-					unit: recordType === "MAX_VOLUME" ? "kg×reps" : "kg",
+					weight_kg: set.weightKg,
+					reps: set.actualReps,
+					unit: unitForRecordType(recordType),
 					achieved_at: session.startedAt,
 					workout_phase: set.prPhase ?? "COMBINED",
 				});

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -363,6 +363,30 @@ const externalActivitySchema = z.object({
 	syncedAt: nullableField(z.string()),
 });
 
+const personalRecordSchema = z.object({
+	id: uuid.optional(),
+	userId: nullableField(z.string()),
+	exerciseName: z.string(),
+	exerciseId: nullableField(z.string()),
+	muscleGroup: z.string().nullish().transform((v) => v ?? "General"),
+	recordType: z.string().nullish().transform((v) => v ?? "1RM"),
+	value: nullableField(z.number()),
+	volume: nullableField(z.number()),
+	weightKg: nullableField(z.number()),
+	reps: nullableField(z.number().int()),
+	workoutPhase: z.string().nullish().transform((v) => v ?? "COMBINED"),
+	sessionId: nullableField(uuid),
+	achievedAt: z
+		.string()
+		.nullish()
+		.transform((v) => v ?? new Date().toISOString()),
+	updatedAt: nullableField(z.string()),
+	localProfileId: localProfileIdSchema.nullable().optional(),
+	// Accepted for wire compatibility; personal_records has no workout_mode
+	// column, so the push handler can only preserve this through session_id.
+	workoutMode: nullableField(z.string()),
+});
+
 // ─── Top-level ───────────────────────────────────────────────────────────
 
 export const pushPayloadSchema = z.object({
@@ -382,6 +406,7 @@ export const pushPayloadSchema = z.object({
 	exerciseSignatures: arrayOf(exerciseSignatureSchema).default([]),
 	assessments: arrayOf(assessmentResultSchema).default([]),
 	externalActivities: arrayOf(externalActivitySchema).nullable().optional(),
+	personalRecords: arrayOf(personalRecordSchema).default([]),
 	customExercises: arrayOf(customExerciseSchema).default([]),
 	profileId: localProfileIdSchema.nullable().optional(),
 	profileName: nullableField(z.string()),

--- a/supabase/functions/compute-rankings/index.ts
+++ b/supabase/functions/compute-rankings/index.ts
@@ -72,7 +72,7 @@ type SupabaseAnyClient = SupabaseClient<any, 'public', any>;
 const WEEKLY_METRICS = [
   { metric: 'total_volume_kg', label: 'Total Volume (kg)' },
   { metric: 'total_workouts', label: 'Workouts Completed' },
-  { metric: 'pr_count', label: 'Personal Records' },
+  { metric: 'pr_count', label: 'Phase-Aware Personal Records' },
   { metric: 'current_streak', label: 'Current Streak' },
 ] as const;
 
@@ -462,7 +462,8 @@ async function computeWeeklyRankings(
 
     entries = buildRankings(eligibleUserIds, valueGetter, profilesByUserId, LIMIT);
   } else if (metricConfig.metric === 'pr_count') {
-    // Count PRs achieved during the week
+    // Count personal_records rows achieved during the week. Dedicated
+    // concentric/eccentric records count separately from combined records.
     const { data: prs } = await supabase
       .from('personal_records')
       .select('user_id')

--- a/supabase/functions/generate-insights/index.ts
+++ b/supabase/functions/generate-insights/index.ts
@@ -21,7 +21,12 @@ interface InsightInput {
   avgSessionsPerWeek: number;
   currentStreak: number;
   bestStreak: number;
-  recentPRs: Array<{ exercise: string; value: number; previousValue?: number }>;
+  recentPRs: Array<{
+    exercise: string;
+    displayName: string;
+    value: number;
+    previousValue?: number;
+  }>;
   plateauExercises: string[];
   trainingLoadScore: number;
 }
@@ -29,6 +34,42 @@ interface InsightInput {
 // ── Insight rule engine (duplicate of src/lib/insights.ts) ───────────────────
 
 const STREAK_MILESTONES = [7, 14, 21, 30];
+
+function formatWorkoutPhase(phase: string | null | undefined): string {
+  switch ((phase ?? 'COMBINED').toUpperCase()) {
+    case 'CONCENTRIC':
+      return 'Concentric';
+    case 'ECCENTRIC':
+      return 'Eccentric';
+    default:
+      return 'Combined';
+  }
+}
+
+function formatRecordType(recordType: string | null | undefined): string {
+  switch ((recordType ?? '').toUpperCase()) {
+    case 'MAX_WEIGHT':
+      return 'Max Weight';
+    case 'MAX_VOLUME':
+      return 'Max Volume';
+    case '1RM':
+      return '1RM';
+    default:
+      return 'PR';
+  }
+}
+
+function formatPersonalRecordName(
+  exercise: string,
+  recordType: string | null | undefined,
+  phase: string | null | undefined
+): string {
+  const formattedType = formatRecordType(recordType);
+  const formattedPhase = formatWorkoutPhase(phase);
+  return formattedPhase === 'Combined'
+    ? `${exercise} ${formattedType}`
+    : `${exercise} ${formattedPhase} ${formattedType}`;
+}
 
 function generateInsights(input: InsightInput): TrainingInsight[] {
   const insights: TrainingInsight[] = [];
@@ -125,15 +166,15 @@ function generateInsights(input: InsightInput): TrainingInsight[] {
     const delta =
       pr.previousValue !== undefined ? pr.value - pr.previousValue : undefined;
     insights.push({
-      id: `pr-${pr.exercise.toLowerCase().replace(/\s+/g, '-')}`,
+      id: `pr-${pr.displayName.toLowerCase().replace(/\s+/g, '-')}`,
       type: 'achievement',
-      title: `New PR: ${pr.exercise}`,
+      title: `New PR: ${pr.displayName}`,
       description:
         delta !== undefined
-          ? `You set a personal record on ${pr.exercise} — ${pr.value} lbs (up ${delta} lbs from ${pr.previousValue} lbs).`
-          : `You set a personal record on ${pr.exercise} — ${pr.value} lbs.`,
+          ? `You set a personal record on ${pr.displayName} — ${pr.value} lbs (up ${delta} lbs from ${pr.previousValue} lbs).`
+          : `You set a personal record on ${pr.displayName} — ${pr.value} lbs.`,
       metric: {
-        name: pr.exercise,
+        name: pr.displayName,
         value: pr.value,
         unit: 'lbs',
         delta,
@@ -352,13 +393,18 @@ Deno.serve(async (req) => {
     // ── 3. Recent personal records ────────────────────────────────────────────
     const { data: prRows } = await supabaseAdmin
       .from('personal_records')
-      .select('exercise_name, value, previous_value')
+      .select('exercise_name, record_type, workout_phase, value, previous_value')
       .eq('user_id', userId)
       .gte('achieved_at', currentStart.toISOString())
       .order('achieved_at', { ascending: false });
 
     const recentPRs = (prRows ?? []).map((r) => ({
       exercise: r.exercise_name,
+      displayName: formatPersonalRecordName(
+        r.exercise_name,
+        r.record_type,
+        r.workout_phase
+      ),
       value: r.value,
       previousValue: r.previous_value ?? undefined,
     }));

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -5,7 +5,7 @@ import { requireSubscription } from '../_shared/requireSubscription.ts';
 import { SYNC_LWW_ENABLED } from '../_shared/flags.ts';
 import { describeSyncPlatformInput } from '../_shared/syncPlatform.ts';
 import {
-  buildPersonalRecordRows,
+  buildPersonalRecordRowsForPush,
   personalRecordIdentityKey,
 } from '../_shared/personalRecordRow.ts';
 import {
@@ -311,6 +311,25 @@ interface ExternalActivityAckDto {
   updatedAt: string;
 }
 
+interface PersonalRecordDto {
+  id?: string | null;
+  userId?: string | null;
+  exerciseName: string;
+  exerciseId?: string | null;
+  muscleGroup?: string | null;
+  recordType?: string | null;
+  value?: number | null;
+  volume?: number | null;
+  weightKg?: number | null;
+  reps?: number | null;
+  workoutPhase?: string | null;
+  sessionId?: string | null;
+  achievedAt?: string | null;
+  updatedAt?: string | null;
+  localProfileId?: string | null;
+  workoutMode?: string | null;
+}
+
 interface PushPayload {
   deviceId: string;
   platform: string;
@@ -326,6 +345,7 @@ interface PushPayload {
   exerciseSignatures: ExerciseSignatureDto[];
   assessments: AssessmentResultDto[];
   externalActivities?: ExternalActivityDto[] | null;
+  personalRecords: PersonalRecordDto[];
   customExercises?: CustomExerciseDto[];
   profileId?: string | null;
   profileName?: string | null;
@@ -696,6 +716,12 @@ Deno.serve(async (req) => {
         { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
       );
     }
+    if (payload.personalRecords && payload.personalRecords.length > MAX_ENTITIES_PER_TYPE) {
+      return new Response(
+        JSON.stringify({ error: `Too many personalRecords. Maximum is ${MAX_ENTITIES_PER_TYPE}.` }),
+        { status: 400, headers: { ...cors, 'Content-Type': 'application/json' } }
+      );
+    }
     // fix(audit #6): align cycles cap with sessions/routines (10000).
     // Prior 1000 cap was a silent cliff for users with large cycle histories.
     if (payload.cycles && payload.cycles.length > MAX_ENTITIES_PER_TYPE) {
@@ -900,6 +926,9 @@ Deno.serve(async (req) => {
     );
     const allCycleIds = (payload.cycles ?? []).map((c) => c.id);
     const allCycleDayIds = (payload.cycles ?? []).flatMap((c) => c.days.map((d) => d.id));
+    const allPersonalRecordIds = (payload.personalRecords ?? [])
+      .map((pr) => pr.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
     const sessionIdSet = new Set(allSessionIds);
     const exerciseIdSet = new Set(allExerciseIds);
     const setIdSet = new Set(allSetIds);
@@ -957,6 +986,7 @@ Deno.serve(async (req) => {
       ['rep_telemetry', allTelemetryIds],
       ['routines', allRoutineIds],
       ['training_cycles', allCycleIds],
+      ['personal_records', allPersonalRecordIds],
     ];
     for (const [table, ids] of directOwnerChecks) {
       const blocked = await assertRowsOwnedByUser(supabase, table, ids, userId, cors);
@@ -1060,6 +1090,18 @@ Deno.serve(async (req) => {
       cors,
     );
     if (sessionRoutineBlocked) return sessionRoutineBlocked;
+
+    const personalRecordSessionIdsToVerify = (payload.personalRecords ?? [])
+      .map((pr) => pr.sessionId)
+      .filter((sid): sid is string => typeof sid === 'string' && sid.length > 0 && !sessionIdSet.has(sid));
+    const personalRecordSessionBlocked = await assertRowsOwnedByUser(
+      supabase,
+      'workout_sessions',
+      personalRecordSessionIdsToVerify,
+      userId,
+      cors,
+    );
+    if (personalRecordSessionBlocked) return personalRecordSessionBlocked;
 
     // =========================================================================
     // LWW reject tracking. When SYNC_LWW_ENABLED is false, these remain empty
@@ -1400,47 +1442,65 @@ Deno.serve(async (req) => {
         }
       }
 
-      // =====================================================================
-      // 6. Extract personal_records from is_pr sets
-      //
-      // Row construction delegated to _shared/personalRecordRow.ts so the
-      // NOT-NULL-DEFAULT guards (record_type, muscle_group, unit,
-      // workout_phase) are unit-testable in isolation.
-      // =====================================================================
-      const prRows = buildPersonalRecordRows(
-        payload.sessions,
-        userId,
-        localProfileId,
+    }
+
+    // =========================================================================
+    // 6. Persist personal_records.
+    //
+    // Dedicated top-level personalRecords are authoritative for current mobile
+    // clients. Set-derived rows remain the fallback for old clients that only
+    // send isPr/prType/prPhase/prVolume on sets.
+    // =========================================================================
+    const prRows = buildPersonalRecordRowsForPush(
+      payload.sessions ?? [],
+      payload.personalRecords ?? [],
+      userId,
+      localProfileId,
+    );
+
+    if (prRows.length > 0) {
+      const dedicatedPrsPresent = (payload.personalRecords ?? []).length > 0;
+      const achievedAtValues = [...new Set(prRows.map((row) => row.achieved_at as string))];
+      const { data: existingPrs, error: existingPrErr } = await supabase
+        .from('personal_records')
+        .select('id, local_profile_id, exercise_id, exercise_name, achieved_at, record_type, workout_phase')
+        .eq('user_id', userId)
+        .in('achieved_at', achievedAtValues);
+      if (existingPrErr) {
+        throw new Error(`personal_records lookup failed: ${existingPrErr.message}`);
+      }
+
+      const existingPrIdsByIdentity = new Map<string, string | null>(
+        (existingPrs ?? []).map((row) => [
+          personalRecordIdentityKey(row),
+          typeof row.id === 'string' ? row.id : null,
+        ])
       );
 
-      if (prRows.length > 0) {
-        const achievedAtValues = [...new Set(prRows.map((row) => row.achieved_at as string))];
-        const { data: existingPrs, error: existingPrErr } = await supabase
-          .from('personal_records')
-          .select('local_profile_id, exercise_id, exercise_name, achieved_at, value, record_type, workout_phase')
-          .eq('user_id', userId)
-          .in('achieved_at', achievedAtValues);
-        if (existingPrErr) {
-          throw new Error(`personal_records lookup failed: ${existingPrErr.message}`);
-        }
+      const latestPayloadRowsByIdentity = new Map<string, typeof prRows[number]>();
+      for (const row of prRows) {
+        latestPayloadRowsByIdentity.set(personalRecordIdentityKey(row), row);
+      }
 
-        const existingPrKeys = new Set(
-          (existingPrs ?? []).map((row) => personalRecordIdentityKey(row))
-        );
-        const dedupedPrRows = prRows.filter((row) => {
-          const key = personalRecordIdentityKey(row);
-          if (existingPrKeys.has(key)) return false;
-          existingPrKeys.add(key);
-          return true;
-        });
+      const dedupedPrRows = [...latestPayloadRowsByIdentity.values()].filter((row) => {
+        const key = personalRecordIdentityKey(row);
+        const existingId = existingPrIdsByIdentity.get(key);
+        if (existingId && (!row.id || row.id !== existingId)) return false;
+        existingPrIdsByIdentity.set(key, row.id ?? existingId ?? null);
+        return true;
+      });
 
-        if (dedupedPrRows.length > 0) {
-          const { error: prErr } = await supabase
-            .from('personal_records')
-            .insert(dedupedPrRows);
-          if (prErr) throw new Error(`personal_records insert failed: ${prErr.message}`);
-          personalRecordsInserted = dedupedPrRows.length;
-        }
+      if (dedupedPrRows.length > 0) {
+        const write = dedicatedPrsPresent
+          ? supabase
+              .from('personal_records')
+              .upsert(dedupedPrRows, { onConflict: 'id' })
+          : supabase
+              .from('personal_records')
+              .insert(dedupedPrRows);
+        const { error: prErr } = await write;
+        if (prErr) throw new Error(`personal_records ${dedicatedPrsPresent ? 'upsert' : 'insert'} failed: ${prErr.message}`);
+        personalRecordsInserted = dedupedPrRows.length;
       }
     }
 

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1091,9 +1091,13 @@ Deno.serve(async (req) => {
     );
     if (sessionRoutineBlocked) return sessionRoutineBlocked;
 
-    const personalRecordSessionIdsToVerify = (payload.personalRecords ?? [])
-      .map((pr) => pr.sessionId)
-      .filter((sid): sid is string => typeof sid === 'string' && sid.length > 0 && !sessionIdSet.has(sid));
+    const personalRecordSessionIdsToVerify = [
+      ...new Set(
+        (payload.personalRecords ?? [])
+          .map((pr) => pr.sessionId)
+          .filter((sid): sid is string => typeof sid === 'string' && sid.length > 0 && !sessionIdSet.has(sid)),
+      ),
+    ];
     const personalRecordSessionBlocked = await assertRowsOwnedByUser(
       supabase,
       'workout_sessions',

--- a/tests/sync/helpers/edge-function-harness.ts
+++ b/tests/sync/helpers/edge-function-harness.ts
@@ -44,6 +44,7 @@ export interface PushPayload {
   exerciseSignatures?: ExerciseSignatureDto[];
   assessments?: AssessmentResultDto[];
   externalActivities?: ExternalActivityDto[] | null;
+  personalRecords?: PersonalRecordDto[];
   customExercises?: CustomExerciseDto[];
   profileId?: string | null;
   profileName?: string | null;
@@ -374,15 +375,19 @@ export interface PersonalRecordDto {
   id: string;
   userId: string;
   exerciseName: string;
+  exerciseId?: string | null;
   muscleGroup: string;
   recordType: string;
   value: number;
+  volume?: number | null;
   weightKg: number | null;
   reps: number | null;
   workoutPhase: string | null;
   sessionId: string | null;
   achievedAt: string;
   updatedAt: string;
+  localProfileId?: string | null;
+  workoutMode?: string | null;
 }
 export interface RpgAttributesResponseDto extends RpgAttributesDto {
   updatedAt: string;


### PR DESCRIPTION
## Summary
- Add end-to-end smoke coverage for the analytics progress tab, including phase-aware filters and phase statistics mocks.
- Update analytics, dashboard, profile, leaderboard, summary, and exercise deep-dive views to surface phase-aware PR language and breakdowns.
- Extend mock Supabase support for personal records and phase statistics queries used by the new analytics flow.

## Testing
- Added and updated automated tests for analytics progress rendering and exercise phase PR breakdowns.
- Not run (not requested).