### PR TITLE
Fix comment routine realtime subscription crash

### DIFF
--- a/src/hooks/__tests__/useCommentRealtime.test.tsx
+++ b/src/hooks/__tests__/useCommentRealtime.test.tsx
@@ -1,0 +1,95 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useCommentRealtime } from "../useCommentRealtime";
+
+const ITEM_ID = "00000000-0000-4000-8000-000000000059";
+
+type MockChannel = {
+	on: ReturnType<typeof vi.fn>;
+	subscribe: ReturnType<typeof vi.fn>;
+	topic: string;
+};
+
+const mocks = vi.hoisted(() => {
+	const invalidateQueries = vi.fn();
+	const removeChannel = vi.fn();
+	const channels = new Map<string, MockChannel & { subscribed: boolean }>();
+	const channelTopics: string[] = [];
+
+	function createChannel(topic: string): MockChannel & { subscribed: boolean } {
+		const channel = {
+			topic,
+			subscribed: false,
+			on: vi.fn((type: string) => {
+				if (channel.subscribed && type === "postgres_changes") {
+					throw new Error(
+						`cannot add \`${type}\` callbacks for ${topic} after \`subscribe()\`.`,
+					);
+				}
+				return channel;
+			}),
+			subscribe: vi.fn(() => {
+				channel.subscribed = true;
+				return channel;
+			}),
+		};
+		return channel;
+	}
+
+	return {
+		channels,
+		channelTopics,
+		invalidateQueries,
+		removeChannel,
+		mockSupabase: {
+			channel: vi.fn((topic: string) => {
+				channelTopics.push(topic);
+				const realtimeTopic = `realtime:${topic}`;
+				const existing = channels.get(realtimeTopic);
+				if (existing) {
+					return existing;
+				}
+				const channel = createChannel(realtimeTopic);
+				channels.set(realtimeTopic, channel);
+				return channel;
+			}),
+			removeChannel,
+		},
+		reset() {
+			channels.clear();
+			channelTopics.length = 0;
+			invalidateQueries.mockClear();
+			removeChannel.mockClear();
+			this.mockSupabase.channel.mockClear();
+		},
+	};
+});
+
+vi.mock("@tanstack/react-query", () => ({
+	useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: mocks.mockSupabase,
+}));
+
+function TestComponent({ itemId = ITEM_ID }: { itemId?: string }) {
+	useCommentRealtime(itemId);
+	return null;
+}
+
+describe("useCommentRealtime", () => {
+	it("uses a fresh realtime channel topic when the same item remounts before Supabase finishes cleanup", () => {
+		mocks.reset();
+
+		const first = render(<TestComponent />);
+		first.unmount();
+
+		expect(() => render(<TestComponent />)).not.toThrow();
+		expect(mocks.channelTopics).toHaveLength(2);
+		expect(new Set(mocks.channelTopics).size).toBe(2);
+		expect(mocks.channelTopics[0]).toContain(`comments:${ITEM_ID}`);
+		expect(mocks.channelTopics[1]).toContain(`comments:${ITEM_ID}`);
+		expect(mocks.removeChannel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/hooks/useCommentRealtime.ts
+++ b/src/hooks/useCommentRealtime.ts
@@ -4,7 +4,6 @@ import { supabase } from "@/lib/supabase";
 import { queryKeys } from "@/queries/keys";
 
 const DEBOUNCE_MS = 1000;
-let nextCommentRealtimeChannelId = 0;
 
 /**
  * Subscribes to Supabase Realtime postgres_changes on community_comments,
@@ -18,8 +17,11 @@ export function useCommentRealtime(itemId: string) {
 	useEffect(() => {
 		if (!itemId) return;
 
-		const channelTopic = `comments:${itemId}:${nextCommentRealtimeChannelId}`;
-		nextCommentRealtimeChannelId += 1;
+		const channelSuffix =
+			typeof globalThis.crypto?.randomUUID === "function"
+				? globalThis.crypto.randomUUID()
+				: Math.random().toString(36).slice(2);
+		const channelTopic = `comments:${itemId}:${channelSuffix}`;
 
 		const channel = supabase
 			.channel(channelTopic)

--- a/src/hooks/useCommentRealtime.ts
+++ b/src/hooks/useCommentRealtime.ts
@@ -4,6 +4,7 @@ import { supabase } from "@/lib/supabase";
 import { queryKeys } from "@/queries/keys";
 
 const DEBOUNCE_MS = 1000;
+let nextCommentRealtimeChannelId = 0;
 
 /**
  * Subscribes to Supabase Realtime postgres_changes on community_comments,
@@ -17,8 +18,11 @@ export function useCommentRealtime(itemId: string) {
 	useEffect(() => {
 		if (!itemId) return;
 
+		const channelTopic = `comments:${itemId}:${nextCommentRealtimeChannelId}`;
+		nextCommentRealtimeChannelId += 1;
+
 		const channel = supabase
-			.channel(`comments:${itemId}`)
+			.channel(channelTopic)
 			.on(
 				"postgres_changes",
 				{


### PR DESCRIPTION
## Summary
- Make comment realtime channels unique per subscription so reopening the same routine does not reuse a subscribed Supabase topic.
- Keep the `item_id` filter unchanged so invalidation still stays scoped to the current comment thread.
- Add a regression test that reproduces the remount/subscription lifecycle and verifies it no longer throws.

## Testing
- Added a new unit test for `useCommentRealtime`.
- Verified locally with the project test suite and full UI pass via Playwright.