### PR TITLE
Add customer-facing visualization V1 for analytics and replay

### DIFF
--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -15,6 +15,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { ExtendedBodyPart, Slug } from "react-muscle-highlighter";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
+import { DataFreshnessStrip } from "@/app/components/analytics/DataFreshnessStrip";
 import {
 	CHART_COLORS,
 	ECHARTS_GRID,
@@ -47,6 +48,8 @@ import { useAuth } from "@/app/hooks/useAuth";
 import { PHOENIX } from "@/lib/colors";
 import { getExerciseProfile } from "@/lib/exercise-muscles";
 import { downloadCSV } from "@/lib/export/csv";
+import { buildFreshnessState } from "@/lib/freshness";
+import { buildProgressionWorkbenchModel } from "@/lib/progression-workbench";
 import type { Recommendation } from "@/lib/recommendations";
 import {
 	generateSraRecommendations,
@@ -71,9 +74,11 @@ import {
 	volumeTrendOptions,
 } from "@/queries/analytics";
 import { bodyIntelligenceOptions } from "@/queries/body-intelligence";
+import { dashboardFreshnessOptions } from "@/queries/freshness";
 import { insightsOptions } from "@/queries/insights";
 import { externalActivitiesOptions } from "@/queries/integrations";
 import { profileOptions } from "@/queries/profile";
+import { progressionWorkbenchOptions } from "@/queries/progress";
 import { WEIGHT_MULTIPLIER } from "@/schemas/transforms";
 import { useProfileFilterStore } from "@/stores/useProfileFilterStore";
 import { buildPhaseMetricSummary } from "./analytics/phaseStatisticsTransforms";
@@ -441,6 +446,8 @@ const muscleSlugToGroup: Record<string, string> = {
 export function Analytics() {
 	const { user } = useAuth();
 	const [timePeriod, setTimePeriod] = useState("30D");
+	const [selectedProgressionExercise, setSelectedProgressionExercise] =
+		useState<string | null>(null);
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	// Map old tab names to new ones for backward compatibility
@@ -478,16 +485,34 @@ export function Analytics() {
 		...profileOptions(userId),
 		enabled: !!userId,
 	});
-	const { data: volumeRaw, isPending: volumePending } = useQuery(
-		volumeTrendOptions(userId, queryPeriod, activeProfileId),
-	);
-	const { data: muscleGroupRaw, isPending: musclePending } = useQuery(
-		muscleGroupOptions(userId, activeProfileId),
-	);
-	const { data: strengthRaw, isPending: strengthPending } = useQuery(
-		strengthProgressOptions(userId, activeProfileId),
-	);
-	const { data: phaseStatsRaw, isPending: phaseStatsPending } = useQuery(
+	const {
+		data: volumeRaw,
+		isPending: volumePending,
+		isFetching: volumeFetching,
+		dataUpdatedAt: volumeUpdatedAt,
+		error: volumeError,
+	} = useQuery(volumeTrendOptions(userId, queryPeriod, activeProfileId));
+	const {
+		data: muscleGroupRaw,
+		isPending: musclePending,
+		isFetching: muscleFetching,
+		dataUpdatedAt: muscleUpdatedAt,
+		error: muscleError,
+	} = useQuery(muscleGroupOptions(userId, activeProfileId));
+	const {
+		data: strengthRaw,
+		isPending: strengthPending,
+		isFetching: strengthFetching,
+		dataUpdatedAt: strengthUpdatedAt,
+		error: strengthError,
+	} = useQuery(strengthProgressOptions(userId, activeProfileId));
+	const {
+		data: phaseStatsRaw,
+		isPending: phaseStatsPending,
+		isFetching: phaseStatsFetching,
+		dataUpdatedAt: phaseStatsUpdatedAt,
+		error: phaseStatsError,
+	} = useQuery(
 		phaseStatisticsTrendOptions(userId, queryPeriod, activeProfileId),
 	);
 	const { data: externalActivities } = useQuery({
@@ -504,6 +529,24 @@ export function Analytics() {
 	});
 	const { data: bodyIntelData } = useQuery({
 		...bodyIntelligenceOptions(userId, 7, activeProfileId),
+		enabled: !!userId,
+	});
+	const {
+		data: progressionWorkbenchData,
+		isFetching: progressionFetching,
+		dataUpdatedAt: progressionUpdatedAt,
+		error: progressionError,
+	} = useQuery({
+		...progressionWorkbenchOptions(userId, activeProfileId),
+		enabled: !!userId,
+	});
+	const {
+		data: dashboardFreshness,
+		isFetching: freshnessFetching,
+		dataUpdatedAt: freshnessUpdatedAt,
+		error: freshnessError,
+	} = useQuery({
+		...dashboardFreshnessOptions(userId, activeProfileId),
 		enabled: !!userId,
 	});
 	const unit: WeightUnit = profile?.weight_unit === "lbs" ? "lbs" : "kg";
@@ -1012,6 +1055,71 @@ export function Analytics() {
 	const prCount = strengthPhaseSummary.prCount;
 	const daysSinceLastPR = strengthPhaseSummary.daysSinceLastPR;
 
+	const progressionModel = useMemo(
+		() =>
+			buildProgressionWorkbenchModel({
+				progressRows: progressionWorkbenchData?.progressRows ?? [],
+				records: progressionWorkbenchData?.records ?? [],
+				selectedExercise: selectedProgressionExercise,
+				phaseFilter,
+				unit,
+			}),
+		[progressionWorkbenchData, selectedProgressionExercise, phaseFilter, unit],
+	);
+
+	const analyticsFreshness = useMemo(() => {
+		const queryUpdatedAt = Math.max(
+			volumeUpdatedAt,
+			muscleUpdatedAt,
+			strengthUpdatedAt,
+			phaseStatsUpdatedAt,
+			progressionUpdatedAt,
+			freshnessUpdatedAt,
+		);
+		const serverUpdatedAt = dashboardFreshness?.lastWorkoutUpdatedAt
+			? Date.parse(dashboardFreshness.lastWorkoutUpdatedAt)
+			: null;
+
+		return buildFreshnessState({
+			dataUpdatedAt: serverUpdatedAt || queryUpdatedAt || null,
+			staleAfterMs: 30 * 60 * 1000,
+			isFetching:
+				volumeFetching ||
+				muscleFetching ||
+				strengthFetching ||
+				phaseStatsFetching ||
+				progressionFetching ||
+				freshnessFetching,
+			hasError:
+				volumeError != null ||
+				muscleError != null ||
+				strengthError != null ||
+				phaseStatsError != null ||
+				progressionError != null ||
+				freshnessError != null,
+		});
+	}, [
+		dashboardFreshness,
+		freshnessError,
+		freshnessFetching,
+		freshnessUpdatedAt,
+		muscleError,
+		muscleFetching,
+		muscleUpdatedAt,
+		phaseStatsError,
+		phaseStatsFetching,
+		phaseStatsUpdatedAt,
+		progressionError,
+		progressionFetching,
+		progressionUpdatedAt,
+		strengthError,
+		strengthFetching,
+		strengthUpdatedAt,
+		volumeError,
+		volumeFetching,
+		volumeUpdatedAt,
+	]);
+
 	// Mobile-specific derived data
 	const mobileVolumeData = bucketByWeekMobile(volumeRaw ?? []).map((entry) => ({
 		...entry,
@@ -1123,6 +1231,10 @@ export function Analytics() {
 							</button>
 						</div>
 					</div>
+				</div>
+
+				<div className="px-4 pb-3">
+					<DataFreshnessStrip state={analyticsFreshness} />
 				</div>
 
 				{/* Horizontal Scroll Stats */}
@@ -1237,6 +1349,8 @@ export function Analytics() {
 										phaseFilter={phaseFilter}
 										onPhaseFilterChange={setPhaseFilter}
 										phaseMetricSummary={phaseMetricSummary}
+										progressionModel={progressionModel}
+										onSelectProgressionExercise={setSelectedProgressionExercise}
 									/>
 								</Suspense>
 							)}
@@ -1261,7 +1375,7 @@ export function Analytics() {
 
 							{activeTab === "performance" && (
 								<Suspense fallback={<AnalyticsTabSkeleton />}>
-									<MobilePerformanceTab />
+									<MobilePerformanceTab userId={userId} unit={unit} />
 								</Suspense>
 							)}
 
@@ -1321,6 +1435,8 @@ export function Analytics() {
 							</Button>
 						</div>
 					</div>
+
+					<DataFreshnessStrip state={analyticsFreshness} className="mb-8" />
 
 					{!hasData ? (
 						<EmptyState
@@ -1464,6 +1580,10 @@ export function Analytics() {
 											phaseFilter={phaseFilter}
 											onPhaseFilterChange={setPhaseFilter}
 											phaseMetricSummary={phaseMetricSummary}
+											progressionModel={progressionModel}
+											onSelectProgressionExercise={
+												setSelectedProgressionExercise
+											}
 										/>
 									</Suspense>
 								</TabsContent>
@@ -1495,6 +1615,7 @@ export function Analytics() {
 										<PerformanceTab
 											volumeComparison={volumeComparison}
 											unit={unit}
+											userId={userId}
 										/>
 									</Suspense>
 								</TabsContent>

--- a/src/app/components/CommunityRankings.tsx
+++ b/src/app/components/CommunityRankings.tsx
@@ -11,6 +11,7 @@ export interface RankingItem {
 	totalUsers: number;
 	color: string;
 	percentiles: Record<string, number>;
+	estimated?: boolean;
 }
 
 export interface CommunityRankingsProps {
@@ -82,7 +83,8 @@ export function CommunityRankings({
 
 						{/* Value + rank */}
 						<p className="text-xs text-muted-foreground">
-							{item.value} {item.unit}&nbsp;&middot;&nbsp;Rank #{item.rank}
+							{item.value} {item.unit}&nbsp;&middot;&nbsp;
+							{item.estimated ? "Est. rank" : "Rank"} #{item.rank}
 						</p>
 
 						{/* Distribution chart */}

--- a/src/app/components/__tests__/VisualizationV1Components.test.tsx
+++ b/src/app/components/__tests__/VisualizationV1Components.test.tsx
@@ -1,0 +1,283 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CommunityPercentileAtlas } from "@/app/components/analytics/CommunityPercentileAtlas";
+import { DataFreshnessStrip } from "@/app/components/analytics/DataFreshnessStrip";
+import { ProgressionWorkbench } from "@/app/components/analytics/ProgressionWorkbench";
+import type { RankingItem } from "@/app/components/CommunityRankings";
+import { ReplayIntelligencePanel } from "@/app/components/session-replay/ReplayIntelligencePanel";
+import type { FreshnessState } from "@/lib/freshness";
+import type { ProgressionWorkbenchModel } from "@/lib/progression-workbench";
+import type { ReplayIntelligence } from "@/lib/replay-intelligence";
+import { renderWithProviders } from "@/test/test-utils";
+
+vi.mock("@/app/components/charts/CommunityDistribution", () => ({
+	CommunityDistribution: () => <div data-testid="distribution-chart" />,
+}));
+
+const freshState: FreshnessState = {
+	status: "live",
+	label: "Up to date",
+	description: "Last updated 12:00 PM.",
+	flags: [],
+	lastUpdatedLabel: "12:00 PM",
+};
+
+const partialFreshState: FreshnessState = {
+	status: "partial",
+	label: "Partial data",
+	description: "Some telemetry is missing.",
+	flags: ["Partial telemetry", "Processing unavailable"],
+	lastUpdatedLabel: null,
+};
+
+const replayIntelligence: ReplayIntelligence = {
+	status: "ready",
+	partialReason: null,
+	repCount: 3,
+	repInsights: [
+		{
+			repNumber: 1,
+			startMs: 0,
+			endMs: 1200,
+			meanVelocityMps: 0.6,
+			peakVelocityMps: 0.8,
+			peakForceN: 900,
+			velocityLossPct: 0,
+			consistencyPct: 88,
+			stickingPoint: null,
+		},
+		{
+			repNumber: 2,
+			startMs: 1500,
+			endMs: 2700,
+			meanVelocityMps: 0.48,
+			peakVelocityMps: 0.65,
+			peakForceN: 990,
+			velocityLossPct: 20,
+			consistencyPct: 88,
+			stickingPoint: {
+				repNumber: 2,
+				timestampMs: 2100,
+				positionMm: 175,
+				velocityMps: 0.18,
+				forceN: 990,
+			},
+		},
+		{
+			repNumber: 3,
+			startMs: 3000,
+			endMs: 4300,
+			meanVelocityMps: 0.39,
+			peakVelocityMps: 0.55,
+			peakForceN: 980,
+			velocityLossPct: 35,
+			consistencyPct: 88,
+			stickingPoint: null,
+		},
+	],
+	stickingPoints: [
+		{
+			repNumber: 2,
+			timestampMs: 2100,
+			positionMm: 175,
+			velocityMps: 0.18,
+			forceN: 990,
+		},
+	],
+	velocityLossPct: 35,
+	fatigueSlopePctPerRep: -11.7,
+	repConsistencyPct: 88,
+	forcePeakN: 990,
+	durationMs: 4300,
+};
+
+const percentileRankings: RankingItem[] = [
+	{
+		label: "Total Volume",
+		percentile: 8,
+		value: 18_500,
+		unit: "kg",
+		rank: 4,
+		totalUsers: 50,
+		color: "#FF6B35",
+		percentiles: { p10: 1000, p50: 8000, p90: 20000 },
+	},
+];
+
+const progressionModel: ProgressionWorkbenchModel = {
+	emptyReason: null,
+	exercises: [
+		{
+			exerciseName: "Squat",
+			currentOneRm: 162,
+			currentOneRmKg: 162,
+			gainRatePctPer30Days: 21.8,
+			plateauRisk: "low",
+			phasePrCount: 1,
+			lastProgressAt: new Date("2026-06-05T00:00:00Z"),
+			lastPrAt: new Date("2026-06-05T00:00:00Z"),
+			recommendation: {
+				kind: "load",
+				label: "Add 2.5 kg",
+				description: "Recent trend supports testing about 130.5 kg next time.",
+			},
+			points: [
+				{
+					date: "May 25",
+					oneRm: 150,
+					oneRmKg: 150,
+					volume: 3000,
+					maxWeight: 120,
+				},
+				{
+					date: "Jun 5",
+					oneRm: 162,
+					oneRmKg: 162,
+					volume: 3400,
+					maxWeight: 128,
+				},
+			],
+		},
+		{
+			exerciseName: "Bench Press",
+			currentOneRm: 100.5,
+			currentOneRmKg: 100.5,
+			gainRatePctPer30Days: 0.2,
+			plateauRisk: "high",
+			phasePrCount: 1,
+			lastProgressAt: new Date("2026-05-20T00:00:00Z"),
+			lastPrAt: new Date("2026-04-15T00:00:00Z"),
+			recommendation: {
+				kind: "variation",
+				label: "Rotate stimulus",
+				description: "Progress has flattened.",
+			},
+			points: [],
+		},
+	],
+	selectedExercise: null,
+};
+progressionModel.selectedExercise = progressionModel.exercises[0];
+
+describe("DataFreshnessStrip", () => {
+	it("renders live and partial freshness states", () => {
+		const { rerender } = renderWithProviders(
+			<DataFreshnessStrip state={freshState} />,
+		);
+
+		expect(screen.getByText("Up to date")).toBeInTheDocument();
+		expect(screen.getByText(/last updated 12:00 pm/i)).toBeInTheDocument();
+
+		rerender(<DataFreshnessStrip state={partialFreshState} />);
+
+		expect(screen.getByText("Partial data")).toBeInTheDocument();
+		expect(screen.getByText("Processing unavailable")).toBeInTheDocument();
+	});
+});
+
+describe("ReplayIntelligencePanel", () => {
+	it("renders selected rep details and sticking-point context", () => {
+		renderWithProviders(
+			<ReplayIntelligencePanel
+				intelligence={replayIntelligence}
+				currentRepIndex={1}
+			/>,
+		);
+
+		expect(screen.getByText("Replay Intelligence")).toBeInTheDocument();
+		expect(screen.getByText("35%")).toBeInTheDocument();
+		expect(screen.getByText("Rep 2")).toBeInTheDocument();
+		expect(screen.getByText(/sticking point/i)).toBeInTheDocument();
+	});
+
+	it("renders no-telemetry and partial states", () => {
+		const { rerender } = renderWithProviders(
+			<ReplayIntelligencePanel
+				intelligence={{ ...replayIntelligence, status: "empty", repCount: 0 }}
+				currentRepIndex={0}
+			/>,
+		);
+
+		expect(screen.getByText(/no telemetry intelligence/i)).toBeInTheDocument();
+
+		rerender(
+			<ReplayIntelligencePanel
+				intelligence={{
+					...replayIntelligence,
+					status: "partial",
+					partialReason: "Using rep summaries.",
+				}}
+				currentRepIndex={0}
+			/>,
+		);
+
+		expect(screen.getByText(/using rep summaries/i)).toBeInTheDocument();
+	});
+});
+
+describe("CommunityPercentileAtlas", () => {
+	it("renders populated, loading, and empty states", () => {
+		const { rerender } = renderWithProviders(
+			<CommunityPercentileAtlas
+				rankings={percentileRankings}
+				loading={false}
+				error={false}
+			/>,
+		);
+
+		expect(screen.getByText("Community Percentile Atlas")).toBeInTheDocument();
+		expect(screen.getByText("Top 8%")).toBeInTheDocument();
+		expect(screen.getByTestId("distribution-chart")).toBeInTheDocument();
+
+		rerender(
+			<CommunityPercentileAtlas rankings={[]} loading={true} error={false} />,
+		);
+		expect(screen.getByText(/loading percentile atlas/i)).toBeInTheDocument();
+
+		rerender(
+			<CommunityPercentileAtlas rankings={[]} loading={false} error={false} />,
+		);
+		expect(screen.getByText(/no percentile data/i)).toBeInTheDocument();
+	});
+});
+
+describe("ProgressionWorkbench", () => {
+	it("renders the selected exercise and lets users switch exercises", async () => {
+		const user = userEvent.setup();
+		const onSelect = vi.fn();
+
+		renderWithProviders(
+			<ProgressionWorkbench
+				model={progressionModel}
+				unit="kg"
+				onSelectExercise={onSelect}
+			/>,
+		);
+
+		expect(screen.getByText("Progression Workbench")).toBeInTheDocument();
+		expect(screen.getAllByText("Squat").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getByText("Add 2.5 kg")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("button", { name: /bench press/i }));
+		expect(onSelect).toHaveBeenCalledWith("Bench Press");
+	});
+
+	it("renders no-history state", () => {
+		renderWithProviders(
+			<ProgressionWorkbench
+				model={{
+					exercises: [],
+					selectedExercise: null,
+					emptyReason: "No exercise progress history is available yet.",
+				}}
+				unit="kg"
+				onSelectExercise={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/no exercise progress history/i),
+		).toBeInTheDocument();
+	});
+});

--- a/src/app/components/__tests__/VisualizationV1Components.test.tsx
+++ b/src/app/components/__tests__/VisualizationV1Components.test.tsx
@@ -5,6 +5,7 @@ import { CommunityPercentileAtlas } from "@/app/components/analytics/CommunityPe
 import { DataFreshnessStrip } from "@/app/components/analytics/DataFreshnessStrip";
 import { ProgressionWorkbench } from "@/app/components/analytics/ProgressionWorkbench";
 import type { RankingItem } from "@/app/components/CommunityRankings";
+import { ReplayAnnotationOverlay } from "@/app/components/session-replay/ReplayAnnotationOverlay";
 import { ReplayIntelligencePanel } from "@/app/components/session-replay/ReplayIntelligencePanel";
 import type { FreshnessState } from "@/lib/freshness";
 import type { ProgressionWorkbenchModel } from "@/lib/progression-workbench";
@@ -213,6 +214,39 @@ describe("ReplayIntelligencePanel", () => {
 		);
 
 		expect(screen.getByText(/using rep summaries/i)).toBeInTheDocument();
+	});
+});
+
+describe("ReplayAnnotationOverlay", () => {
+	it("clamps rep and sticking-point annotations to the plot width", () => {
+		const { container } = renderWithProviders(
+			<ReplayAnnotationOverlay
+				intelligence={{
+					...replayIntelligence,
+					durationMs: 1000,
+					repInsights: [
+						{
+							...replayIntelligence.repInsights[0],
+							startMs: 0,
+							endMs: 2000,
+						},
+					],
+					stickingPoints: [
+						{
+							...replayIntelligence.stickingPoints[0],
+							timestampMs: 2000,
+						},
+					],
+				}}
+				currentRepIndex={0}
+				width={200}
+				height={120}
+			/>,
+		);
+
+		expect(container.querySelector("rect")?.getAttribute("width")).toBe("130");
+		expect(container.querySelector("line")?.getAttribute("x1")).toBe("180");
+		expect(container.querySelector("circle")?.getAttribute("cx")).toBe("180");
 	});
 });
 

--- a/src/app/components/analytics/CommunityPercentileAtlas.tsx
+++ b/src/app/components/analytics/CommunityPercentileAtlas.tsx
@@ -1,0 +1,59 @@
+import { AlertCircle, BarChart3 } from "lucide-react";
+import {
+	CommunityRankings,
+	type RankingItem,
+} from "@/app/components/CommunityRankings";
+import { Skeleton } from "@/app/components/ui/skeleton";
+
+interface CommunityPercentileAtlasProps {
+	rankings: RankingItem[];
+	loading: boolean;
+	error: boolean;
+}
+
+export function CommunityPercentileAtlas({
+	rankings,
+	loading,
+	error,
+}: CommunityPercentileAtlasProps) {
+	return (
+		<section className="space-y-4">
+			<div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+				<div>
+					<h3 className="text-xl text-white">Community Percentile Atlas</h3>
+					<p className="text-sm text-muted-foreground">
+						Top-percentile context from participating Phoenix users.
+					</p>
+				</div>
+				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					<BarChart3 className="size-4" aria-hidden="true" />
+					<span>Daily aggregate</span>
+				</div>
+			</div>
+
+			{loading ? (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					<p className="sr-only">Loading percentile atlas</p>
+					{Array.from({ length: 4 }).map((_, index) => (
+						<Skeleton
+							// biome-ignore lint/suspicious/noArrayIndexKey: static loading placeholders
+							key={index}
+							className="h-36 rounded-lg"
+						/>
+					))}
+				</div>
+			) : error ? (
+				<div className="flex items-center gap-2 rounded-lg border border-warning/30 bg-warning/5 p-4 text-sm text-warning">
+					<AlertCircle className="size-4" aria-hidden="true" />
+					<span>Percentile atlas is unavailable right now.</span>
+				</div>
+			) : rankings.length === 0 ? (
+				<div className="rounded-lg border border-secondary bg-muted/10 p-4 text-sm text-muted-foreground">
+					No percentile data is available for your account yet.
+				</div>
+			) : (
+				<CommunityRankings rankings={rankings} loading={false} />
+			)}
+		</section>
+	);
+}

--- a/src/app/components/analytics/DataFreshnessStrip.tsx
+++ b/src/app/components/analytics/DataFreshnessStrip.tsx
@@ -1,0 +1,82 @@
+import {
+	AlertTriangle,
+	CheckCircle2,
+	Clock,
+	RefreshCw,
+	WifiOff,
+} from "lucide-react";
+import type { FreshnessState, FreshnessStatus } from "@/lib/freshness";
+
+interface DataFreshnessStripProps {
+	state: FreshnessState;
+	className?: string;
+}
+
+const STATUS_STYLES: Record<
+	FreshnessStatus,
+	{ className: string; icon: typeof CheckCircle2 }
+> = {
+	live: {
+		className: "border-success/30 bg-success/5 text-success",
+		icon: CheckCircle2,
+	},
+	refreshing: {
+		className: "border-primary/30 bg-primary/5 text-primary",
+		icon: RefreshCw,
+	},
+	stale: {
+		className: "border-warning/30 bg-warning/5 text-warning",
+		icon: Clock,
+	},
+	reconnecting: {
+		className: "border-warning/30 bg-warning/5 text-warning",
+		icon: WifiOff,
+	},
+	partial: {
+		className: "border-warning/30 bg-warning/5 text-warning",
+		icon: AlertTriangle,
+	},
+	unavailable: {
+		className: "border-secondary bg-muted/10 text-muted-foreground",
+		icon: Clock,
+	},
+};
+
+export function DataFreshnessStrip({
+	state,
+	className,
+}: DataFreshnessStripProps) {
+	const status = STATUS_STYLES[state.status];
+	const Icon = status.icon;
+
+	return (
+		<div
+			className={[
+				"flex flex-col gap-2 rounded-lg border px-3 py-2 text-xs sm:flex-row sm:items-center sm:justify-between",
+				status.className,
+				className ?? "",
+			].join(" ")}
+			role={state.status === "live" ? "status" : "alert"}
+		>
+			<div className="flex min-w-0 items-start gap-2 sm:items-center">
+				<Icon className="mt-0.5 size-4 shrink-0 sm:mt-0" aria-hidden="true" />
+				<div className="min-w-0">
+					<div className="font-semibold">{state.label}</div>
+					<div className="text-muted-foreground">{state.description}</div>
+				</div>
+			</div>
+			{state.flags.length > 0 && (
+				<div className="flex flex-wrap gap-1 sm:justify-end">
+					{state.flags.map((flag) => (
+						<span
+							key={flag}
+							className="rounded-full border border-current/20 px-2 py-0.5 text-[11px]"
+						>
+							{flag}
+						</span>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/app/components/analytics/MobilePerformanceTab.tsx
+++ b/src/app/components/analytics/MobilePerformanceTab.tsx
@@ -1,13 +1,92 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { CommunityPercentileAtlas } from "@/app/components/analytics/CommunityPercentileAtlas";
 import { BiomechanicsContent } from "@/app/components/Biomechanics";
 import { SubscriptionGate } from "@/app/components/SubscriptionGate";
+import {
+	buildCommunityPercentileRankings,
+	buildEstimatedCommunityPercentileRankings,
+} from "@/lib/community-atlas";
+import type { WeightUnit } from "@/lib/units";
+import { communityBenchmarksOptions } from "@/queries/benchmarks";
+import { userRankingOptions } from "@/queries/leaderboard";
+import { gamificationStatsOptions } from "@/queries/profile";
 
-export default function MobilePerformanceTab() {
+interface MobilePerformanceTabProps {
+	userId: string;
+	unit: WeightUnit;
+}
+
+export default function MobilePerformanceTab({
+	userId,
+	unit,
+}: MobilePerformanceTabProps) {
+	const {
+		data: benchmarks,
+		isPending: benchmarksPending,
+		error: benchmarksError,
+	} = useQuery(communityBenchmarksOptions());
+	const {
+		data: userRankings,
+		isPending: rankingsPending,
+		error: rankingsError,
+	} = useQuery({
+		...userRankingOptions(userId),
+		enabled: !!userId,
+	});
+	const {
+		data: gamificationStats,
+		isPending: statsPending,
+		error: statsError,
+	} = useQuery({
+		...gamificationStatsOptions(userId),
+		enabled: !!userId,
+	});
+	const exactPercentileRankings = useMemo(
+		() =>
+			buildCommunityPercentileRankings({
+				benchmarks: benchmarks ?? [],
+				userRankings: userRankings ?? [],
+				unit,
+			}),
+		[benchmarks, userRankings, unit],
+	);
+	const estimatedPercentileRankings = useMemo(
+		() =>
+			buildEstimatedCommunityPercentileRankings({
+				benchmarks: benchmarks ?? [],
+				userStats: gamificationStats,
+				unit,
+			}),
+		[benchmarks, gamificationStats, unit],
+	);
+	const percentileRankings =
+		exactPercentileRankings.length > 0
+			? exactPercentileRankings
+			: estimatedPercentileRankings;
+	const atlasLoading =
+		benchmarksPending ||
+		((rankingsPending || statsPending) && percentileRankings.length === 0);
+	const atlasError =
+		benchmarksError != null ||
+		(rankingsError != null &&
+			statsError != null &&
+			percentileRankings.length === 0);
+
 	return (
-		<SubscriptionGate
-			requiredTier="INFERNO"
-			featureName="Performance Analytics"
-		>
-			<BiomechanicsContent view="performance" />
-		</SubscriptionGate>
+		<div className="space-y-4">
+			<CommunityPercentileAtlas
+				rankings={percentileRankings}
+				loading={atlasLoading}
+				error={atlasError}
+			/>
+
+			<SubscriptionGate
+				requiredTier="INFERNO"
+				featureName="Performance Analytics"
+			>
+				<BiomechanicsContent view="performance" />
+			</SubscriptionGate>
+		</div>
 	);
 }

--- a/src/app/components/analytics/MobileProgressTab.tsx
+++ b/src/app/components/analytics/MobileProgressTab.tsx
@@ -13,11 +13,13 @@ import { MobileChartCard } from "@/app/components/analytics/MobileChartCard";
 import { RechartsTooltip } from "@/app/components/charts/shared/RechartsTooltip";
 import { Button } from "@/app/components/ui/button";
 import { PHOENIX } from "@/lib/colors";
+import type { ProgressionWorkbenchModel } from "@/lib/progression-workbench";
 import type { WeightUnit } from "@/lib/units";
 import {
 	WORKOUT_PHASE_FILTERS,
 	type WorkoutPhaseFilter,
 } from "@/lib/workout-phases";
+import { ProgressionWorkbench } from "./ProgressionWorkbench";
 import type { PhaseMetricSummary } from "./phaseStatisticsTransforms";
 
 export interface MobileProgressTabProps {
@@ -33,6 +35,8 @@ export interface MobileProgressTabProps {
 	phaseFilter: WorkoutPhaseFilter;
 	onPhaseFilterChange: (phase: WorkoutPhaseFilter) => void;
 	phaseMetricSummary: PhaseMetricSummary;
+	progressionModel: ProgressionWorkbenchModel;
+	onSelectProgressionExercise: (exerciseName: string) => void;
 }
 
 function formatMetric(value: number, decimals = 1): string {
@@ -48,6 +52,8 @@ export default function MobileProgressTab({
 	phaseFilter,
 	onPhaseFilterChange,
 	phaseMetricSummary,
+	progressionModel,
+	onSelectProgressionExercise,
 }: MobileProgressTabProps) {
 	const titlePhase =
 		phaseFilter === "all" ? "PHASE" : phaseFilter.toUpperCase();
@@ -117,6 +123,12 @@ export default function MobileProgressTab({
 					</div>
 				)}
 			</MobileChartCard>
+
+			<ProgressionWorkbench
+				model={progressionModel}
+				unit={unit}
+				onSelectExercise={onSelectProgressionExercise}
+			/>
 
 			<MobileChartCard
 				title={`TOP LIFTS (${titlePhase} - ${unit.toUpperCase()})`}

--- a/src/app/components/analytics/PerformanceTab.tsx
+++ b/src/app/components/analytics/PerformanceTab.tsx
@@ -1,8 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { CommunityPercentileAtlas } from "@/app/components/analytics/CommunityPercentileAtlas";
 import { BiomechanicsContent } from "@/app/components/Biomechanics";
-import { CommunityRankings } from "@/app/components/CommunityRankings";
 import { SubscriptionGate } from "@/app/components/SubscriptionGate";
 import { Card } from "@/app/components/ui/card";
+import {
+	buildCommunityPercentileRankings,
+	buildEstimatedCommunityPercentileRankings,
+} from "@/lib/community-atlas";
 import { convertWeight, type WeightUnit } from "@/lib/units";
+import { communityBenchmarksOptions } from "@/queries/benchmarks";
+import { userRankingOptions } from "@/queries/leaderboard";
+import { gamificationStatsOptions } from "@/queries/profile";
 
 interface VolumeComparisonData {
 	current: Array<{
@@ -20,27 +29,78 @@ interface VolumeComparisonData {
 export interface PerformanceTabProps {
 	volumeComparison: VolumeComparisonData | undefined;
 	unit: WeightUnit;
+	userId: string;
 }
 
 export default function PerformanceTab({
 	volumeComparison,
 	unit,
+	userId,
 }: PerformanceTabProps) {
-	return (
-		<SubscriptionGate
-			requiredTier="INFERNO"
-			featureName="Performance Analytics"
-		>
-			{/* Community Rankings -- populated once benchmark Edge Function is scheduled */}
-			<div className="space-y-6">
-				<Card className="p-6 bg-surface-2 border-secondary">
-					<h3 className="text-xl text-white mb-4">Community Rankings</h3>
-					<p className="text-sm text-muted-foreground mb-4">
-						Rankings update daily based on all participating Phoenix users.
-					</p>
-					<CommunityRankings rankings={[]} loading={false} />
-				</Card>
+	const {
+		data: benchmarks,
+		isPending: benchmarksPending,
+		error: benchmarksError,
+	} = useQuery(communityBenchmarksOptions());
+	const {
+		data: userRankings,
+		isPending: rankingsPending,
+		error: rankingsError,
+	} = useQuery({
+		...userRankingOptions(userId),
+		enabled: !!userId,
+	});
+	const {
+		data: gamificationStats,
+		isPending: statsPending,
+		error: statsError,
+	} = useQuery({
+		...gamificationStatsOptions(userId),
+		enabled: !!userId,
+	});
+	const exactPercentileRankings = useMemo(
+		() =>
+			buildCommunityPercentileRankings({
+				benchmarks: benchmarks ?? [],
+				userRankings: userRankings ?? [],
+				unit,
+			}),
+		[benchmarks, userRankings, unit],
+	);
+	const estimatedPercentileRankings = useMemo(
+		() =>
+			buildEstimatedCommunityPercentileRankings({
+				benchmarks: benchmarks ?? [],
+				userStats: gamificationStats,
+				unit,
+			}),
+		[benchmarks, gamificationStats, unit],
+	);
+	const percentileRankings =
+		exactPercentileRankings.length > 0
+			? exactPercentileRankings
+			: estimatedPercentileRankings;
+	const atlasLoading =
+		benchmarksPending ||
+		((rankingsPending || statsPending) && percentileRankings.length === 0);
+	const atlasError =
+		benchmarksError != null ||
+		(rankingsError != null &&
+			statsError != null &&
+			percentileRankings.length === 0);
 
+	return (
+		<div className="space-y-6">
+			<CommunityPercentileAtlas
+				rankings={percentileRankings}
+				loading={atlasLoading}
+				error={atlasError}
+			/>
+
+			<SubscriptionGate
+				requiredTier="INFERNO"
+				featureName="Performance Analytics"
+			>
 				{/* Performance Metrics (Velocity, Power, TUT) */}
 				<BiomechanicsContent view="performance" />
 
@@ -90,7 +150,7 @@ export default function PerformanceTab({
 						</div>
 					</div>
 				</Card>
-			</div>
-		</SubscriptionGate>
+			</SubscriptionGate>
+		</div>
 	);
 }

--- a/src/app/components/analytics/ProgressTab.tsx
+++ b/src/app/components/analytics/ProgressTab.tsx
@@ -3,11 +3,13 @@ import { Clock } from "lucide-react";
 import { EChartsWrapper } from "@/app/components/charts/shared/EChartsWrapper";
 import { Button } from "@/app/components/ui/button";
 import { Card } from "@/app/components/ui/card";
+import type { ProgressionWorkbenchModel } from "@/lib/progression-workbench";
 import type { WeightUnit } from "@/lib/units";
 import {
 	WORKOUT_PHASE_FILTERS,
 	type WorkoutPhaseFilter,
 } from "@/lib/workout-phases";
+import { ProgressionWorkbench } from "./ProgressionWorkbench";
 import type {
 	PhaseMetricPair,
 	PhaseMetricSummary,
@@ -33,6 +35,8 @@ export interface ProgressTabProps {
 	phaseFilter: WorkoutPhaseFilter;
 	onPhaseFilterChange: (phase: WorkoutPhaseFilter) => void;
 	phaseMetricSummary: PhaseMetricSummary;
+	progressionModel: ProgressionWorkbenchModel;
+	onSelectProgressionExercise: (exerciseName: string) => void;
 }
 
 function formatMetric(value: number, decimals = 1): string {
@@ -92,6 +96,8 @@ export default function ProgressTab({
 	phaseFilter,
 	onPhaseFilterChange,
 	phaseMetricSummary,
+	progressionModel,
+	onSelectProgressionExercise,
 }: ProgressTabProps) {
 	return (
 		<>
@@ -148,6 +154,12 @@ export default function ProgressTab({
 					</div>
 				)}
 			</Card>
+
+			<ProgressionWorkbench
+				model={progressionModel}
+				unit={unit}
+				onSelectExercise={onSelectProgressionExercise}
+			/>
 
 			{/* 1RM Progression */}
 			<Card className="p-6 bg-surface-2 border-secondary">

--- a/src/app/components/analytics/ProgressionWorkbench.tsx
+++ b/src/app/components/analytics/ProgressionWorkbench.tsx
@@ -1,0 +1,186 @@
+import { AlertTriangle, ArrowUpRight, Dumbbell, Target } from "lucide-react";
+import { Button } from "@/app/components/ui/button";
+import { Card } from "@/app/components/ui/card";
+import type { ProgressionWorkbenchModel } from "@/lib/progression-workbench";
+import type { WeightUnit } from "@/lib/units";
+
+interface ProgressionWorkbenchProps {
+	model: ProgressionWorkbenchModel;
+	unit: WeightUnit;
+	onSelectExercise: (exerciseName: string) => void;
+}
+
+function TrendSvg({
+	points,
+}: {
+	points: NonNullable<ProgressionWorkbenchModel["selectedExercise"]>["points"];
+}) {
+	if (points.length < 2) {
+		return (
+			<div className="flex h-28 items-center justify-center text-sm text-muted-foreground">
+				Need more sessions for a trend.
+			</div>
+		);
+	}
+
+	const width = 360;
+	const height = 112;
+	const values = points.map((point) => point.oneRm);
+	const min = Math.min(...values);
+	const max = Math.max(...values);
+	const range = max - min || 1;
+	const step = width / Math.max(points.length - 1, 1);
+	const coordinates = points.map((point, index) => {
+		const x = index * step;
+		const y = height - ((point.oneRm - min) / range) * (height - 16) - 8;
+		return `${x},${y}`;
+	});
+
+	return (
+		<svg
+			viewBox={`0 0 ${width} ${height}`}
+			className="h-28 w-full overflow-visible"
+			role="img"
+			aria-label="Selected exercise one-rep max trend"
+		>
+			<polyline
+				points={coordinates.join(" ")}
+				fill="none"
+				stroke="#FF6B35"
+				strokeWidth="3"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			{coordinates.map((coordinate, index) => {
+				const [x, y] = coordinate.split(",").map(Number);
+				return (
+					<circle
+						// biome-ignore lint/suspicious/noArrayIndexKey: point order is chronological and stable
+						key={index}
+						cx={x}
+						cy={y}
+						r="4"
+						fill="#FF6B35"
+					/>
+				);
+			})}
+		</svg>
+	);
+}
+
+export function ProgressionWorkbench({
+	model,
+	unit,
+	onSelectExercise,
+}: ProgressionWorkbenchProps) {
+	const selected = model.selectedExercise;
+
+	if (!selected) {
+		return (
+			<Card className="border-secondary bg-surface-2 p-6 text-sm text-muted-foreground">
+				{model.emptyReason ?? "No exercise progress history is available yet."}
+			</Card>
+		);
+	}
+
+	const riskClass =
+		selected.plateauRisk === "high"
+			? "text-warning"
+			: selected.plateauRisk === "medium"
+				? "text-primary"
+				: "text-success";
+
+	return (
+		<Card className="border-secondary bg-surface-2 p-6">
+			<div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<h3 className="text-xl text-white">Progression Workbench</h3>
+					<p className="text-sm text-muted-foreground">
+						1RM trend, phase-aware PRs, plateau risk, and next progression.
+					</p>
+				</div>
+				<div className={`flex items-center gap-1.5 text-sm ${riskClass}`}>
+					{selected.plateauRisk === "high" ? (
+						<AlertTriangle className="size-4" aria-hidden="true" />
+					) : (
+						<ArrowUpRight className="size-4" aria-hidden="true" />
+					)}
+					<span className="capitalize">{selected.plateauRisk} risk</span>
+				</div>
+			</div>
+
+			<div className="grid gap-5 lg:grid-cols-[220px_1fr]">
+				<div className="flex gap-2 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible">
+					{model.exercises.map((exercise) => (
+						<Button
+							key={exercise.exerciseName}
+							type="button"
+							variant={
+								exercise.exerciseName === selected.exerciseName
+									? "default"
+									: "outline"
+							}
+							className="justify-start whitespace-nowrap lg:w-full"
+							onClick={() => onSelectExercise(exercise.exerciseName)}
+						>
+							{exercise.exerciseName}
+						</Button>
+					))}
+				</div>
+
+				<div className="min-w-0 space-y-4">
+					<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+						<div>
+							<h4 className="text-lg font-semibold text-white">
+								{selected.exerciseName}
+							</h4>
+							<p className="text-sm text-muted-foreground">
+								{selected.points.length} progress points
+							</p>
+						</div>
+						<div className="text-right">
+							<div className="text-2xl font-semibold text-white">
+								{selected.currentOneRm} {unit}
+							</div>
+							<div className="text-xs text-muted-foreground">current 1RM</div>
+						</div>
+					</div>
+
+					<div className="rounded-lg border border-secondary bg-background/50 p-3">
+						<TrendSvg points={selected.points} />
+					</div>
+
+					<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+						<div className="rounded-lg border border-secondary bg-muted/10 p-3">
+							<div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+								<ArrowUpRight className="size-3.5" aria-hidden="true" />
+								<span>Gain rate</span>
+							</div>
+							<div className="text-lg font-semibold text-white">
+								{selected.gainRatePctPer30Days}%
+							</div>
+						</div>
+						<div className="rounded-lg border border-secondary bg-muted/10 p-3">
+							<div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+								<Target className="size-3.5" aria-hidden="true" />
+								<span>Phase PRs</span>
+							</div>
+							<div className="text-lg font-semibold text-white">
+								{selected.phasePrCount}
+							</div>
+						</div>
+						<div className="col-span-2 rounded-lg border border-primary/30 bg-primary/5 p-3">
+							<div className="mb-1 flex items-center gap-1.5 text-xs text-primary">
+								<Dumbbell className="size-3.5" aria-hidden="true" />
+								<span>{selected.recommendation.label}</span>
+							</div>
+							<div className="text-sm text-muted-foreground">
+								{selected.recommendation.description}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/src/app/components/session-replay/ReplayAnnotationOverlay.tsx
+++ b/src/app/components/session-replay/ReplayAnnotationOverlay.tsx
@@ -16,7 +16,8 @@ function xForTime(
 ): number {
 	if (durationMs <= 0) return MARGIN.left;
 	const plotWidth = Math.max(1, width - MARGIN.left - MARGIN.right);
-	return MARGIN.left + (timestampMs / durationMs) * plotWidth;
+	const clampedTime = Math.max(0, Math.min(timestampMs, durationMs));
+	return MARGIN.left + (clampedTime / durationMs) * plotWidth;
 }
 
 export function ReplayAnnotationOverlay({

--- a/src/app/components/session-replay/ReplayAnnotationOverlay.tsx
+++ b/src/app/components/session-replay/ReplayAnnotationOverlay.tsx
@@ -1,0 +1,85 @@
+import type { ReplayIntelligence } from "@/lib/replay-intelligence";
+
+interface ReplayAnnotationOverlayProps {
+	intelligence: ReplayIntelligence;
+	currentRepIndex: number;
+	width: number;
+	height: number;
+}
+
+const MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
+
+function xForTime(
+	timestampMs: number,
+	durationMs: number,
+	width: number,
+): number {
+	if (durationMs <= 0) return MARGIN.left;
+	const plotWidth = Math.max(1, width - MARGIN.left - MARGIN.right);
+	return MARGIN.left + (timestampMs / durationMs) * plotWidth;
+}
+
+export function ReplayAnnotationOverlay({
+	intelligence,
+	currentRepIndex,
+	width,
+	height,
+}: ReplayAnnotationOverlayProps) {
+	if (intelligence.status === "empty" || intelligence.durationMs <= 0) {
+		return null;
+	}
+
+	const selectedRep = intelligence.repInsights[currentRepIndex];
+	const plotHeight = Math.max(1, height - MARGIN.top - MARGIN.bottom);
+
+	return (
+		<svg
+			className="pointer-events-none absolute inset-0 rounded-lg"
+			viewBox={`0 0 ${width} ${height}`}
+			role="img"
+			aria-label="Replay annotations for selected reps and sticking points"
+		>
+			{selectedRep && (
+				<rect
+					x={xForTime(selectedRep.startMs, intelligence.durationMs, width)}
+					y={MARGIN.top}
+					width={Math.max(
+						2,
+						xForTime(selectedRep.endMs, intelligence.durationMs, width) -
+							xForTime(selectedRep.startMs, intelligence.durationMs, width),
+					)}
+					height={plotHeight}
+					fill="rgba(245, 158, 11, 0.08)"
+					stroke="rgba(245, 158, 11, 0.65)"
+					strokeDasharray="4 4"
+				/>
+			)}
+
+			{intelligence.stickingPoints.map((point) => {
+				const x = xForTime(point.timestampMs, intelligence.durationMs, width);
+				return (
+					<g key={`${point.repNumber}-${point.timestampMs}`}>
+						<line
+							x1={x}
+							x2={x}
+							y1={MARGIN.top}
+							y2={MARGIN.top + plotHeight}
+							stroke="rgba(245, 158, 11, 0.8)"
+							strokeWidth="1.5"
+						/>
+						<circle cx={x} cy={MARGIN.top + 12} r="4" fill="#F59E0B" />
+						<text
+							x={Math.min(width - 44, x + 6)}
+							y={MARGIN.top + 16}
+							fill="#F59E0B"
+							fontSize="10"
+							fontWeight="700"
+						>
+							Rep {point.repNumber}
+						</text>
+					</g>
+				);
+			})}
+		</svg>
+	);
+}

--- a/src/app/components/session-replay/ReplayCanvas.tsx
+++ b/src/app/components/session-replay/ReplayCanvas.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { ReplayIntelligence } from "@/lib/replay-intelligence";
 import { renderForceCurve, renderVelocityBars } from "@/lib/replay-renderer";
 import type { TelemetryPointRow } from "@/schemas/telemetry";
 import { useReplayStore } from "@/stores/useReplayStore";
@@ -8,6 +9,7 @@ interface ReplayCanvasProps {
 	repBoundaries: number[];
 	width: number;
 	height: number;
+	intelligence?: ReplayIntelligence | null;
 }
 
 export function ReplayCanvas({
@@ -15,6 +17,7 @@ export function ReplayCanvas({
 	repBoundaries,
 	width,
 	height,
+	intelligence,
 }: ReplayCanvasProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const currentTimeMs = useReplayStore((state) => state.currentTimeMs);
@@ -40,6 +43,7 @@ export function ReplayCanvas({
 			data,
 			currentTimeMs,
 			repBoundaries,
+			intelligence,
 		};
 
 		if (activeChart === "force") {
@@ -47,7 +51,15 @@ export function ReplayCanvas({
 		} else {
 			renderVelocityBars(ctx, renderOptions);
 		}
-	}, [data, currentTimeMs, width, height, activeChart, repBoundaries]);
+	}, [
+		data,
+		currentTimeMs,
+		width,
+		height,
+		activeChart,
+		repBoundaries,
+		intelligence,
+	]);
 
 	return (
 		<canvas

--- a/src/app/components/session-replay/ReplayIntelligencePanel.tsx
+++ b/src/app/components/session-replay/ReplayIntelligencePanel.tsx
@@ -1,0 +1,113 @@
+import { AlertTriangle, Gauge, Target, Zap } from "lucide-react";
+import { Card } from "@/app/components/ui/card";
+import type { ReplayIntelligence } from "@/lib/replay-intelligence";
+
+interface ReplayIntelligencePanelProps {
+	intelligence: ReplayIntelligence;
+	currentRepIndex: number;
+}
+
+function MetricTile({
+	label,
+	value,
+	icon: Icon,
+}: {
+	label: string;
+	value: string;
+	icon: typeof Gauge;
+}) {
+	return (
+		<div className="rounded-lg border border-secondary bg-muted/10 p-3">
+			<div className="mb-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+				<Icon className="size-3.5" aria-hidden="true" />
+				<span>{label}</span>
+			</div>
+			<div className="text-xl font-semibold text-white">{value}</div>
+		</div>
+	);
+}
+
+export function ReplayIntelligencePanel({
+	intelligence,
+	currentRepIndex,
+}: ReplayIntelligencePanelProps) {
+	if (intelligence.status === "empty") {
+		return (
+			<Card className="border-secondary bg-surface-2 p-4 text-sm text-muted-foreground">
+				No telemetry intelligence is available for this set.
+			</Card>
+		);
+	}
+
+	const selectedRep =
+		intelligence.repInsights[currentRepIndex] ?? intelligence.repInsights[0];
+
+	return (
+		<Card className="space-y-4 border-secondary bg-surface-2 p-4">
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<h2 className="text-lg font-semibold text-white">
+						Replay Intelligence
+					</h2>
+					<p className="text-sm text-muted-foreground">
+						Client-derived from rep summaries and telemetry samples.
+					</p>
+				</div>
+				{intelligence.status === "partial" && intelligence.partialReason && (
+					<div className="flex items-center gap-1.5 rounded-full border border-warning/30 bg-warning/10 px-3 py-1 text-xs text-warning">
+						<AlertTriangle className="size-3.5" aria-hidden="true" />
+						<span>{intelligence.partialReason}</span>
+					</div>
+				)}
+			</div>
+
+			<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+				<MetricTile
+					label="Velocity loss"
+					value={`${Math.round(intelligence.velocityLossPct)}%`}
+					icon={Zap}
+				/>
+				<MetricTile
+					label="Fatigue slope"
+					value={`${intelligence.fatigueSlopePctPerRep}%/rep`}
+					icon={Gauge}
+				/>
+				<MetricTile
+					label="Rep consistency"
+					value={`${Math.round(intelligence.repConsistencyPct)}%`}
+					icon={Target}
+				/>
+				<MetricTile
+					label="Peak force"
+					value={`${Math.round(intelligence.forcePeakN)} N`}
+					icon={Gauge}
+				/>
+			</div>
+
+			{selectedRep && (
+				<div className="rounded-lg border border-secondary bg-background/50 p-3">
+					<div className="mb-2 flex items-center justify-between gap-3">
+						<div className="font-semibold text-white">
+							Rep {selectedRep.repNumber}
+						</div>
+						<div className="text-xs text-muted-foreground">
+							{selectedRep.meanVelocityMps.toFixed(2)} m/s avg
+						</div>
+					</div>
+					<div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground sm:grid-cols-4">
+						<span>Loss {Math.round(selectedRep.velocityLossPct)}%</span>
+						<span>Peak {Math.round(selectedRep.peakForceN)} N</span>
+						<span>{selectedRep.peakVelocityMps.toFixed(2)} m/s peak</span>
+						<span>{selectedRep.endMs - selectedRep.startMs} ms window</span>
+					</div>
+					{selectedRep.stickingPoint && (
+						<div className="mt-3 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+							Sticking point at {selectedRep.stickingPoint.positionMm} mm with{" "}
+							{selectedRep.stickingPoint.velocityMps.toFixed(2)} m/s velocity.
+						</div>
+					)}
+				</div>
+			)}
+		</Card>
+	);
+}

--- a/src/app/components/session-replay/SessionReplay.tsx
+++ b/src/app/components/session-replay/SessionReplay.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
+import { DataFreshnessStrip } from "@/app/components/analytics/DataFreshnessStrip";
 import { SubscriptionGate } from "@/app/components/SubscriptionGate";
 import { Button } from "@/app/components/ui/button";
 import { Skeleton } from "@/app/components/ui/skeleton";
@@ -11,14 +12,18 @@ import { usePlayback } from "@/hooks/usePlayback";
 import { useSubscription } from "@/hooks/useSubscription";
 import { displayExerciseName } from "@/lib/exercise-display";
 import { detectFatigue } from "@/lib/fatigue-detection";
+import { buildFreshnessState } from "@/lib/freshness";
 import { calculateRepQualityScore } from "@/lib/rep-quality";
+import { buildReplayIntelligence } from "@/lib/replay-intelligence";
 import { replaySessionOptions, replayTelemetryOptions } from "@/queries/replay";
 import type { RepSummary, TelemetryPointRow } from "@/schemas/telemetry";
 import { useReplayStore } from "@/stores/useReplayStore";
 import { FatigueSummary } from "./FatigueSummary";
 import { PlaybackControls } from "./PlaybackControls";
 import { QualityBadge } from "./QualityBadge";
+import { ReplayAnnotationOverlay } from "./ReplayAnnotationOverlay";
 import { ReplayCanvas } from "./ReplayCanvas";
+import { ReplayIntelligencePanel } from "./ReplayIntelligencePanel";
 import { SetNavigation } from "./SetNavigation";
 import { TimelineBar } from "./TimelineBar";
 
@@ -94,6 +99,11 @@ export function SessionReplay() {
 
 		// Detect fatigue
 		const fatigue = detectFatigue(repSummaries);
+		const intelligence = buildReplayIntelligence({
+			telemetry,
+			repSummaries,
+			repBoundaries,
+		});
 
 		return {
 			telemetry,
@@ -101,6 +111,7 @@ export function SessionReplay() {
 			durationMs,
 			repBoundaries,
 			fatigue,
+			intelligence,
 		};
 	}, [telemetryQuery.data]);
 
@@ -124,6 +135,28 @@ export function SessionReplay() {
 
 	// Playback hook
 	usePlayback(telemetryData?.durationMs ?? 0);
+
+	const replayFreshness = useMemo(
+		() =>
+			buildFreshnessState({
+				dataUpdatedAt:
+					Math.max(sessionQuery.dataUpdatedAt, telemetryQuery.dataUpdatedAt) ||
+					null,
+				staleAfterMs: 15 * 60 * 1000,
+				isFetching: sessionQuery.isFetching || telemetryQuery.isFetching,
+				hasError: sessionQuery.error != null || telemetryQuery.error != null,
+				partialTelemetry: telemetryData?.intelligence.status === "partial",
+			}),
+		[
+			sessionQuery.dataUpdatedAt,
+			sessionQuery.error,
+			sessionQuery.isFetching,
+			telemetryData?.intelligence.status,
+			telemetryQuery.dataUpdatedAt,
+			telemetryQuery.error,
+			telemetryQuery.isFetching,
+		],
+	);
 
 	// Responsive canvas dimensions via resize observer
 	const canvasContainerRef = useRef<HTMLDivElement>(null);
@@ -180,6 +213,8 @@ export function SessionReplay() {
 					</div>
 				</div>
 
+				<DataFreshnessStrip state={replayFreshness} />
+
 				{/* Loading state */}
 				{(sessionQuery.isLoading || telemetryQuery.isLoading) && (
 					<div className="space-y-4">
@@ -202,6 +237,11 @@ export function SessionReplay() {
 						{/* Fatigue summary */}
 						<FatigueSummary fatigue={telemetryData.fatigue} />
 
+						<ReplayIntelligencePanel
+							intelligence={telemetryData.intelligence}
+							currentRepIndex={currentRepIndex}
+						/>
+
 						{/* Chart type toggle */}
 						<Tabs
 							value={activeChart}
@@ -218,6 +258,13 @@ export function SessionReplay() {
 							<ReplayCanvas
 								data={telemetryData.telemetry}
 								repBoundaries={telemetryData.repBoundaries}
+								width={canvasWidth}
+								height={canvasHeight}
+								intelligence={telemetryData.intelligence}
+							/>
+							<ReplayAnnotationOverlay
+								intelligence={telemetryData.intelligence}
+								currentRepIndex={currentRepIndex}
 								width={canvasWidth}
 								height={canvasHeight}
 							/>
@@ -276,14 +323,37 @@ export function SessionReplay() {
 					</>
 				)}
 
+				{/* Rep-summary fallback for sets that synced summaries before dense telemetry */}
+				{telemetryData &&
+					telemetryData.telemetry.length === 0 &&
+					telemetryData.repSummaries.length > 0 && (
+						<div className="space-y-4">
+							<FatigueSummary fatigue={telemetryData.fatigue} />
+							<ReplayIntelligencePanel
+								intelligence={telemetryData.intelligence}
+								currentRepIndex={currentRepIndex}
+							/>
+							<div className="rounded-lg border border-secondary bg-surface-2 p-4 text-sm text-muted-foreground">
+								Dense telemetry is not available for this set yet. Showing
+								rep-summary intelligence until the next sync completes.
+							</div>
+							<SetNavigation
+								currentSetIndex={currentSetIndex}
+								totalSets={allSets.length}
+							/>
+						</div>
+					)}
+
 				{/* Empty state */}
-				{telemetryData && telemetryData.telemetry.length === 0 && (
-					<div className="p-8 text-center">
-						<p className="text-muted-foreground">
-							No telemetry data available for this set
-						</p>
-					</div>
-				)}
+				{telemetryData &&
+					telemetryData.telemetry.length === 0 &&
+					telemetryData.repSummaries.length === 0 && (
+						<div className="p-8 text-center">
+							<p className="text-muted-foreground">
+								No telemetry data available for this set
+							</p>
+						</div>
+					)}
 			</div>
 		</SubscriptionGate>
 	);

--- a/src/lib/__tests__/community-atlas.test.ts
+++ b/src/lib/__tests__/community-atlas.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCommunityPercentileRankings,
+	buildEstimatedCommunityPercentileRankings,
+	type CommunityBenchmarkRow,
+} from "@/lib/community-atlas";
+import type { UserRanking } from "@/queries/leaderboard";
+
+const benchmarks: CommunityBenchmarkRow[] = [
+	{
+		id: "bench-volume",
+		metric_type: "leaderboard",
+		metric_key: "total_volume_kg",
+		percentile_values: { p10: 1000, p50: 8000, p90: 20000 },
+		total_users: 50,
+		updated_at: "2026-06-01T00:00:00Z",
+	},
+	{
+		id: "bench-workouts",
+		metric_type: "leaderboard",
+		metric_key: "workout_count",
+		percentile_values: { "10": 2, "50": 12, "90": 35 },
+		total_users: 48,
+		updated_at: "2026-06-01T00:00:00Z",
+	},
+	{
+		id: "bench-bad",
+		metric_type: "leaderboard",
+		metric_key: "malformed",
+		percentile_values: { p50: "not-a-number" },
+		total_users: 48,
+		updated_at: "2026-06-01T00:00:00Z",
+	},
+];
+
+const rankings: UserRanking[] = [
+	{
+		metric: "totalVolume",
+		rank: 4,
+		value: 18_500,
+		percentile: 92,
+		totalUsers: 50,
+	},
+	{
+		metric: "workoutCount",
+		rank: 10,
+		value: 28,
+		percentile: 81,
+		totalUsers: 48,
+	},
+];
+
+describe("buildCommunityPercentileRankings", () => {
+	it("maps benchmark rows and user rankings into Top X% cards", () => {
+		const cards = buildCommunityPercentileRankings({
+			benchmarks,
+			userRankings: rankings,
+			unit: "kg",
+		});
+
+		expect(cards).toHaveLength(2);
+		expect(cards[0]).toMatchObject({
+			label: "Total Volume",
+			percentile: 8,
+			value: 18500,
+			unit: "kg",
+			rank: 4,
+			totalUsers: 50,
+			percentiles: { p10: 1000, p50: 8000, p90: 20000 },
+		});
+		expect(cards[1]).toMatchObject({
+			label: "Workout Count",
+			percentile: 19,
+			unit: "sessions",
+		});
+	});
+
+	it("skips malformed benchmark payloads without dropping valid rankings", () => {
+		const cards = buildCommunityPercentileRankings({
+			benchmarks,
+			userRankings: [
+				...rankings,
+				{
+					metric: "malformed",
+					rank: 1,
+					value: 1,
+					percentile: 99,
+					totalUsers: 48,
+				},
+			],
+			unit: "kg",
+		});
+
+		expect(cards.map((card) => card.label)).toEqual([
+			"Total Volume",
+			"Workout Count",
+		]);
+	});
+});
+
+describe("buildEstimatedCommunityPercentileRankings", () => {
+	it("estimates Top X% cards from benchmark cutoffs and owner stats", () => {
+		const cards = buildEstimatedCommunityPercentileRankings({
+			benchmarks,
+			userStats: {
+				total_volume_kg: 18_500,
+				total_workouts: 28,
+				longest_streak: null,
+				current_streak: null,
+			},
+			unit: "kg",
+		});
+
+		expect(cards).toHaveLength(2);
+		expect(cards[0]).toMatchObject({
+			label: "Total Volume",
+			estimated: true,
+			unit: "kg",
+			value: 18500,
+			totalUsers: 50,
+		});
+		expect(cards[0].percentile).toBeGreaterThan(1);
+		expect(cards[0].percentile).toBeLessThan(20);
+		expect(cards[1]).toMatchObject({
+			label: "Workout Count",
+			estimated: true,
+			unit: "sessions",
+		});
+	});
+});

--- a/src/lib/__tests__/freshness.test.ts
+++ b/src/lib/__tests__/freshness.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildFreshnessState } from "@/lib/freshness";
+
+describe("buildFreshnessState", () => {
+	it("reports live state when data is recent", () => {
+		const state = buildFreshnessState({
+			dataUpdatedAt: Date.parse("2026-06-05T12:00:00Z"),
+			nowMs: Date.parse("2026-06-05T12:01:00Z"),
+			staleAfterMs: 5 * 60 * 1000,
+			isFetching: false,
+			hasError: false,
+		});
+
+		expect(state.status).toBe("live");
+		expect(state.label).toBe("Up to date");
+	});
+
+	it("preserves stale data while marking it stale", () => {
+		const state = buildFreshnessState({
+			dataUpdatedAt: Date.parse("2026-06-05T11:00:00Z"),
+			nowMs: Date.parse("2026-06-05T12:00:00Z"),
+			staleAfterMs: 30 * 60 * 1000,
+			isFetching: false,
+			hasError: false,
+		});
+
+		expect(state.status).toBe("stale");
+		expect(state.label).toContain("Stale");
+		expect(state.description).toContain("Last updated");
+	});
+
+	it("surfaces reconnecting, partial telemetry, and processing unavailable states", () => {
+		const reconnecting = buildFreshnessState({
+			dataUpdatedAt: Date.parse("2026-06-05T12:00:00Z"),
+			nowMs: Date.parse("2026-06-05T12:01:00Z"),
+			staleAfterMs: 5 * 60 * 1000,
+			isFetching: true,
+			hasError: true,
+		});
+		const partial = buildFreshnessState({
+			nowMs: Date.parse("2026-06-05T12:01:00Z"),
+			isFetching: false,
+			hasError: false,
+			partialTelemetry: true,
+			processingAvailable: false,
+		});
+
+		expect(reconnecting.status).toBe("reconnecting");
+		expect(partial.status).toBe("partial");
+		expect(partial.flags).toContain("Processing unavailable");
+	});
+});

--- a/src/lib/__tests__/progression-workbench.test.ts
+++ b/src/lib/__tests__/progression-workbench.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildProgressionWorkbenchModel,
+	type ProgressionProgressRow,
+	type ProgressionRecordRow,
+} from "@/lib/progression-workbench";
+
+const progressRows: ProgressionProgressRow[] = [
+	{
+		id: "p1",
+		user_id: "u1",
+		exercise_name: "Bench Press",
+		session_id: "s1",
+		recorded_at: new Date("2026-03-01T00:00:00Z"),
+		max_weight_kg: 80,
+		total_volume_kg: 2000,
+		estimated_1rm_kg: 100,
+		max_reps: 8,
+		set_count: 4,
+	},
+	{
+		id: "p2",
+		user_id: "u1",
+		exercise_name: "Bench Press",
+		session_id: "s2",
+		recorded_at: new Date("2026-04-15T00:00:00Z"),
+		max_weight_kg: 82,
+		total_volume_kg: 2100,
+		estimated_1rm_kg: 101,
+		max_reps: 8,
+		set_count: 4,
+	},
+	{
+		id: "p3",
+		user_id: "u1",
+		exercise_name: "Bench Press",
+		session_id: "s3",
+		recorded_at: new Date("2026-05-20T00:00:00Z"),
+		max_weight_kg: 81,
+		total_volume_kg: 2050,
+		estimated_1rm_kg: 100.5,
+		max_reps: 8,
+		set_count: 4,
+	},
+	{
+		id: "p4",
+		user_id: "u1",
+		exercise_name: "Squat",
+		session_id: "s4",
+		recorded_at: new Date("2026-05-25T00:00:00Z"),
+		max_weight_kg: 120,
+		total_volume_kg: 3000,
+		estimated_1rm_kg: 150,
+		max_reps: 6,
+		set_count: 5,
+	},
+	{
+		id: "p5",
+		user_id: "u1",
+		exercise_name: "Squat",
+		session_id: "s5",
+		recorded_at: new Date("2026-06-05T00:00:00Z"),
+		max_weight_kg: 128,
+		total_volume_kg: 3400,
+		estimated_1rm_kg: 162,
+		max_reps: 6,
+		set_count: 5,
+	},
+];
+
+const records: ProgressionRecordRow[] = [
+	{
+		id: "r1",
+		exercise_name: "Bench Press",
+		exercise_id: null,
+		record_type: "1RM",
+		workout_phase: "CONCENTRIC",
+		value: 101,
+		unit: "kg",
+		achieved_at: new Date("2026-04-15T00:00:00Z"),
+	},
+	{
+		id: "r2",
+		exercise_name: "Bench Press",
+		exercise_id: null,
+		record_type: "1RM",
+		workout_phase: "ECCENTRIC",
+		value: 104,
+		unit: "kg",
+		achieved_at: new Date("2026-05-20T00:00:00Z"),
+	},
+	{
+		id: "r3",
+		exercise_name: "Squat",
+		exercise_id: null,
+		record_type: "1RM",
+		workout_phase: "CONCENTRIC",
+		value: 162,
+		unit: "kg",
+		achieved_at: new Date("2026-06-05T00:00:00Z"),
+	},
+];
+
+describe("buildProgressionWorkbenchModel", () => {
+	it("detects plateau risk and phase-filtered PR counts for the selected exercise", () => {
+		const model = buildProgressionWorkbenchModel({
+			progressRows,
+			records,
+			selectedExercise: "Bench Press",
+			phaseFilter: "concentric",
+			unit: "kg",
+			now: new Date("2026-06-05T00:00:00Z"),
+		});
+
+		expect(model.selectedExercise?.exerciseName).toBe("Bench Press");
+		expect(model.selectedExercise?.plateauRisk).toBe("high");
+		expect(model.selectedExercise?.phasePrCount).toBe(1);
+		expect(model.selectedExercise?.recommendation.kind).toBe("variation");
+	});
+
+	it("prioritizes recent improving exercises and converts display values to lbs", () => {
+		const model = buildProgressionWorkbenchModel({
+			progressRows,
+			records,
+			phaseFilter: "all",
+			unit: "lbs",
+			now: new Date("2026-06-05T00:00:00Z"),
+		});
+
+		expect(model.exercises[0].exerciseName).toBe("Squat");
+		expect(model.selectedExercise?.plateauRisk).toBe("low");
+		expect(model.selectedExercise?.currentOneRm).toBeCloseTo(357.1, 1);
+		expect(model.selectedExercise?.gainRatePctPer30Days).toBeGreaterThan(10);
+		expect(model.selectedExercise?.recommendation.kind).toBe("load");
+	});
+
+	it("returns an empty state when no progress history exists", () => {
+		const model = buildProgressionWorkbenchModel({
+			progressRows: [],
+			records: [],
+			phaseFilter: "all",
+			unit: "kg",
+			now: new Date("2026-06-05T00:00:00Z"),
+		});
+
+		expect(model.exercises).toEqual([]);
+		expect(model.selectedExercise).toBeNull();
+		expect(model.emptyReason).toContain("No exercise progress");
+	});
+});

--- a/src/lib/__tests__/progression-workbench.test.ts
+++ b/src/lib/__tests__/progression-workbench.test.ts
@@ -147,4 +147,31 @@ describe("buildProgressionWorkbenchModel", () => {
 		expect(model.selectedExercise).toBeNull();
 		expect(model.emptyReason).toContain("No exercise progress");
 	});
+
+	it("keeps single-session exercises at low plateau risk", () => {
+		const model = buildProgressionWorkbenchModel({
+			progressRows: [
+				{
+					id: "p6",
+					user_id: "u1",
+					exercise_name: "Deadlift",
+					session_id: "s6",
+					recorded_at: new Date("2026-04-01T00:00:00Z"),
+					max_weight_kg: 140,
+					total_volume_kg: 2800,
+					estimated_1rm_kg: 170,
+					max_reps: 5,
+					set_count: 4,
+				},
+			],
+			records: [],
+			selectedExercise: "Deadlift",
+			phaseFilter: "all",
+			unit: "kg",
+			now: new Date("2026-06-05T00:00:00Z"),
+		});
+
+		expect(model.selectedExercise?.plateauRisk).toBe("low");
+		expect(model.selectedExercise?.recommendation.kind).toBe("load");
+	});
 });

--- a/src/lib/__tests__/replay-intelligence.test.ts
+++ b/src/lib/__tests__/replay-intelligence.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildReplayIntelligence,
+	type ReplayIntelligenceInput,
+} from "@/lib/replay-intelligence";
+
+const repSummaries: ReplayIntelligenceInput["repSummaries"] = [
+	{
+		id: "rep-1",
+		set_id: "set-1",
+		rep_number: 1,
+		mean_velocity_mps: 0.6,
+		peak_velocity_mps: 0.82,
+		mean_force_n: 840,
+		peak_force_n: 960,
+		power_watts: 410,
+		rom_mm: 420,
+		tut_ms: 1200,
+		left_force_avg: 420,
+		right_force_avg: 420,
+		asymmetry_pct: 0,
+		vbt_zone: "speed-strength",
+	},
+	{
+		id: "rep-2",
+		set_id: "set-1",
+		rep_number: 2,
+		mean_velocity_mps: 0.55,
+		peak_velocity_mps: 0.75,
+		mean_force_n: 860,
+		peak_force_n: 980,
+		power_watts: 390,
+		rom_mm: 418,
+		tut_ms: 1250,
+		left_force_avg: 430,
+		right_force_avg: 430,
+		asymmetry_pct: 0,
+		vbt_zone: "speed-strength",
+	},
+	{
+		id: "rep-3",
+		set_id: "set-1",
+		rep_number: 3,
+		mean_velocity_mps: 0.48,
+		peak_velocity_mps: 0.66,
+		mean_force_n: 890,
+		peak_force_n: 1030,
+		power_watts: 360,
+		rom_mm: 415,
+		tut_ms: 1300,
+		left_force_avg: 455,
+		right_force_avg: 435,
+		asymmetry_pct: 4,
+		vbt_zone: "strength-speed",
+	},
+	{
+		id: "rep-4",
+		set_id: "set-1",
+		rep_number: 4,
+		mean_velocity_mps: 0.39,
+		peak_velocity_mps: 0.54,
+		mean_force_n: 900,
+		peak_force_n: 1010,
+		power_watts: 300,
+		rom_mm: 405,
+		tut_ms: 1500,
+		left_force_avg: 470,
+		right_force_avg: 430,
+		asymmetry_pct: 8,
+		vbt_zone: "strength-speed",
+	},
+];
+
+const telemetry: ReplayIntelligenceInput["telemetry"] = [
+	{
+		timestamp_ms: 0,
+		force_n: 620,
+		velocity_mps: 0.3,
+		position_mm: 0,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 400,
+		force_n: 960,
+		velocity_mps: 0.78,
+		position_mm: 180,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 1200,
+		force_n: 780,
+		velocity_mps: 0.38,
+		position_mm: 420,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 1500,
+		force_n: 640,
+		velocity_mps: 0.28,
+		position_mm: 0,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 2000,
+		force_n: 980,
+		velocity_mps: 0.7,
+		position_mm: 170,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 2800,
+		force_n: 800,
+		velocity_mps: 0.35,
+		position_mm: 418,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 3000,
+		force_n: 700,
+		velocity_mps: 0.24,
+		position_mm: 0,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 3520,
+		force_n: 1030,
+		velocity_mps: 0.18,
+		position_mm: 185,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 4300,
+		force_n: 820,
+		velocity_mps: 0.31,
+		position_mm: 415,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 4500,
+		force_n: 720,
+		velocity_mps: 0.2,
+		position_mm: 0,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 5000,
+		force_n: 1010,
+		velocity_mps: 0.16,
+		position_mm: 175,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 5900,
+		force_n: 810,
+		velocity_mps: 0.29,
+		position_mm: 405,
+		cable: "A",
+	},
+];
+
+describe("buildReplayIntelligence", () => {
+	it("summarizes velocity loss, fatigue slope, consistency, and force peak", () => {
+		const result = buildReplayIntelligence({
+			telemetry,
+			repSummaries,
+			repBoundaries: [0, 1500, 3000, 4500],
+		});
+
+		expect(result.status).toBe("ready");
+		expect(result.repCount).toBe(4);
+		expect(result.velocityLossPct).toBeCloseTo(35, 0);
+		expect(result.fatigueSlopePctPerRep).toBeLessThan(-10);
+		expect(result.repConsistencyPct).toBeGreaterThan(75);
+		expect(result.repConsistencyPct).toBeLessThan(95);
+		expect(result.forcePeakN).toBe(1030);
+	});
+
+	it("marks sticking points when high force coincides with unusually low velocity", () => {
+		const result = buildReplayIntelligence({
+			telemetry,
+			repSummaries,
+			repBoundaries: [0, 1500, 3000, 4500],
+		});
+
+		expect(result.stickingPoints).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					repNumber: 3,
+					timestampMs: 3520,
+					positionMm: 185,
+				}),
+			]),
+		);
+	});
+
+	it("reports partial telemetry when summaries exist without enough samples", () => {
+		const result = buildReplayIntelligence({
+			telemetry: [],
+			repSummaries,
+			repBoundaries: [0, 1500, 3000, 4500],
+		});
+
+		expect(result.status).toBe("partial");
+		expect(result.partialReason).toContain("rep summaries");
+		expect(result.repInsights).toHaveLength(4);
+	});
+});

--- a/src/lib/__tests__/replay-intelligence.test.ts
+++ b/src/lib/__tests__/replay-intelligence.test.ts
@@ -204,4 +204,30 @@ describe("buildReplayIntelligence", () => {
 		expect(result.partialReason).toContain("rep summaries");
 		expect(result.repInsights).toHaveLength(4);
 	});
+
+	it("does not extend missing intermediate rep windows to the full telemetry duration", () => {
+		const result = buildReplayIntelligence({
+			telemetry: [
+				...telemetry,
+				{
+					timestamp_ms: 10_000,
+					force_n: 500,
+					velocity_mps: 0.2,
+					position_mm: 10,
+					cable: "A",
+				},
+			],
+			repSummaries: repSummaries.slice(0, 2),
+			repBoundaries: [0],
+		});
+
+		expect(result.repInsights[0]).toMatchObject({
+			startMs: 0,
+			endMs: 1700,
+		});
+		expect(result.repInsights[1]).toMatchObject({
+			startMs: 1700,
+			endMs: 10_000,
+		});
+	});
 });

--- a/src/lib/__tests__/replay-renderer.test.ts
+++ b/src/lib/__tests__/replay-renderer.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplayIntelligence } from "@/lib/replay-intelligence";
+import { renderForceCurve } from "@/lib/replay-renderer";
+import type { TelemetryPointRow } from "@/schemas/telemetry";
+
+function createRecordingContext() {
+	const fillRects: Array<[number, number, number, number]> = [];
+	const arcs: Array<[number, number, number, number, number]> = [];
+	const context = {
+		beginPath: vi.fn(),
+		closePath: vi.fn(),
+		createLinearGradient: vi.fn().mockReturnValue({
+			addColorStop: vi.fn(),
+		}),
+		fill: vi.fn(),
+		fillRect: vi.fn((x: number, y: number, width: number, height: number) => {
+			fillRects.push([x, y, width, height]);
+		}),
+		lineTo: vi.fn(),
+		moveTo: vi.fn(),
+		stroke: vi.fn(),
+		setLineDash: vi.fn(),
+		arc: vi.fn(
+			(x: number, y: number, radius: number, start: number, end: number) => {
+				arcs.push([x, y, radius, start, end]);
+			},
+		),
+		fillStyle: "",
+		lineWidth: 1,
+		strokeStyle: "",
+	};
+
+	return {
+		context: context as unknown as CanvasRenderingContext2D,
+		fillRects,
+		arcs,
+	};
+}
+
+const data: TelemetryPointRow[] = [
+	{
+		timestamp_ms: 0,
+		force_n: 100,
+		velocity_mps: 0.4,
+		position_mm: 0,
+		cable: "A",
+	},
+	{
+		timestamp_ms: 1000,
+		force_n: 200,
+		velocity_mps: 0.5,
+		position_mm: 300,
+		cable: "A",
+	},
+];
+
+const intelligence: ReplayIntelligence = {
+	status: "ready",
+	partialReason: null,
+	repCount: 1,
+	repInsights: [
+		{
+			repNumber: 1,
+			startMs: 0,
+			endMs: 2000,
+			meanVelocityMps: 0.4,
+			peakVelocityMps: 0.5,
+			peakForceN: 200,
+			velocityLossPct: 20,
+			consistencyPct: 90,
+			stickingPoint: null,
+		},
+	],
+	stickingPoints: [
+		{
+			repNumber: 1,
+			timestampMs: 2000,
+			positionMm: 200,
+			velocityMps: 0.1,
+			forceN: 200,
+		},
+	],
+	velocityLossPct: 20,
+	fatigueSlopePctPerRep: 0,
+	repConsistencyPct: 90,
+	forcePeakN: 200,
+	durationMs: 2000,
+};
+
+describe("renderForceCurve", () => {
+	it("clamps replay intelligence highlights to the plot width", () => {
+		const { context, fillRects, arcs } = createRecordingContext();
+
+		renderForceCurve(context, {
+			width: 200,
+			height: 120,
+			data,
+			currentTimeMs: 2000,
+			repBoundaries: [],
+			intelligence,
+		});
+
+		expect(fillRects[1]).toEqual([50, 20, 130, 60]);
+		expect(arcs[0]?.[0]).toBe(180);
+	});
+});

--- a/src/lib/community-atlas.ts
+++ b/src/lib/community-atlas.ts
@@ -1,0 +1,274 @@
+import type { RankingItem } from "@/app/components/CommunityRankings";
+import { PHOENIX } from "@/lib/colors";
+import { convertWeight, type WeightUnit } from "@/lib/units";
+import type { UserRanking } from "@/queries/leaderboard";
+
+export interface CommunityBenchmarkRow {
+	id: string;
+	metric_type: string;
+	metric_key: string | null;
+	percentile_values: unknown;
+	total_users: number;
+	updated_at: string | null;
+}
+
+interface BuildCommunityPercentileRankingsInput {
+	benchmarks: CommunityBenchmarkRow[];
+	userRankings: UserRanking[];
+	unit: WeightUnit;
+}
+
+export interface CommunityAtlasUserStats {
+	total_volume_kg: number | null;
+	total_workouts: number | null;
+	longest_streak: number | null;
+	current_streak: number | null;
+}
+
+const METRIC_META: Record<
+	string,
+	{
+		label: string;
+		unit: string;
+		color: string;
+		aliases: string[];
+		convertWeight?: boolean;
+	}
+> = {
+	totalVolume: {
+		label: "Total Volume",
+		unit: "kg",
+		color: PHOENIX.ember,
+		aliases: ["totalvolume", "total_volume", "total_volume_kg", "volume"],
+		convertWeight: true,
+	},
+	workoutCount: {
+		label: "Workout Count",
+		unit: "sessions",
+		color: PHOENIX.gold,
+		aliases: ["workoutcount", "workout_count", "total_workouts", "workouts"],
+	},
+	longestStreak: {
+		label: "Longest Streak",
+		unit: "days",
+		color: PHOENIX.flameRed,
+		aliases: ["longeststreak", "longest_streak", "best_streak"],
+	},
+	currentStreak: {
+		label: "Current Streak",
+		unit: "days",
+		color: PHOENIX.forgeGreen,
+		aliases: ["currentstreak", "current_streak"],
+	},
+	prCount: {
+		label: "Phase PRs",
+		unit: "PRs",
+		color: PHOENIX.ashGray,
+		aliases: ["prcount", "pr_count", "personal_records", "prs"],
+	},
+	exerciseMastery: {
+		label: "Exercise Mastery",
+		unit: "exercises",
+		color: PHOENIX.flameYellow,
+		aliases: ["exercisemastery", "exercise_mastery", "mastered_count"],
+	},
+};
+
+const STAT_FIELD_BY_METRIC: Partial<
+	Record<keyof typeof METRIC_META, keyof CommunityAtlasUserStats>
+> = {
+	totalVolume: "total_volume_kg",
+	workoutCount: "total_workouts",
+	longestStreak: "longest_streak",
+	currentStreak: "current_streak",
+};
+
+function normalizeKey(value: string | null | undefined): string {
+	return (value ?? "").replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function normalizePercentiles(value: unknown): Record<string, number> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+	const normalized: Record<string, number> = {};
+	for (const [rawKey, rawValue] of Object.entries(value)) {
+		const percentileMatch = rawKey.match(/^p?(\d{1,2})$/i);
+		const numericValue =
+			typeof rawValue === "number"
+				? rawValue
+				: typeof rawValue === "string" && rawValue.trim() !== ""
+					? Number(rawValue)
+					: Number.NaN;
+		if (!percentileMatch || !Number.isFinite(numericValue)) continue;
+		normalized[`p${percentileMatch[1]}`] = numericValue;
+	}
+
+	return Object.keys(normalized).length >= 2 ? normalized : null;
+}
+
+function findBenchmarkForMetric(
+	benchmarks: CommunityBenchmarkRow[],
+	metric: string,
+): CommunityBenchmarkRow | undefined {
+	const meta = METRIC_META[metric];
+	const aliases = new Set([
+		normalizeKey(metric),
+		...(meta?.aliases ?? []).map(normalizeKey),
+	]);
+
+	return benchmarks.find((benchmark) => {
+		const key = normalizeKey(benchmark.metric_key);
+		const type = normalizeKey(benchmark.metric_type);
+		return aliases.has(key) || aliases.has(type);
+	});
+}
+
+function toTopPercent(percentile: number): number {
+	if (!Number.isFinite(percentile)) return 100;
+	return Math.max(1, Math.min(100, Math.round(100 - percentile)));
+}
+
+function estimatePercentileFromCutoffs(
+	percentiles: Record<string, number>,
+	value: number,
+): number {
+	const points = Object.entries(percentiles)
+		.map(([key, cutoff]) => ({
+			percentile: Number(key.replace(/^p/i, "")),
+			cutoff,
+		}))
+		.filter(
+			(point) =>
+				Number.isFinite(point.percentile) && Number.isFinite(point.cutoff),
+		)
+		.sort((a, b) => a.cutoff - b.cutoff);
+
+	if (points.length === 0) return 0;
+	if (value <= points[0].cutoff) return points[0].percentile;
+	const last = points[points.length - 1];
+	if (value >= last.cutoff) return last.percentile;
+
+	for (let index = 1; index < points.length; index += 1) {
+		const lower = points[index - 1];
+		const upper = points[index];
+		if (value > upper.cutoff) continue;
+		const range = upper.cutoff - lower.cutoff;
+		if (range <= 0) return upper.percentile;
+		const ratio = (value - lower.cutoff) / range;
+		return lower.percentile + ratio * (upper.percentile - lower.percentile);
+	}
+
+	return last.percentile;
+}
+
+function convertPercentiles(
+	percentiles: Record<string, number>,
+	unit: WeightUnit,
+	shouldConvert: boolean,
+): Record<string, number> {
+	if (!shouldConvert) return percentiles;
+	return Object.fromEntries(
+		Object.entries(percentiles).map(([key, value]) => [
+			key,
+			Math.round(convertWeight(value, unit) * 10) / 10,
+		]),
+	);
+}
+
+export function buildCommunityPercentileRankings({
+	benchmarks,
+	userRankings,
+	unit,
+}: BuildCommunityPercentileRankingsInput): RankingItem[] {
+	return userRankings
+		.map((ranking): RankingItem | null => {
+			const meta = METRIC_META[ranking.metric];
+			if (!meta) return null;
+
+			const benchmark = findBenchmarkForMetric(benchmarks, ranking.metric);
+			if (!benchmark) return null;
+
+			const normalizedPercentiles = normalizePercentiles(
+				benchmark.percentile_values,
+			);
+			if (!normalizedPercentiles) return null;
+
+			const shouldConvert = meta.convertWeight === true;
+			const displayValue = shouldConvert
+				? Math.round(convertWeight(ranking.value, unit) * 10) / 10
+				: ranking.value;
+
+			return {
+				label: meta.label,
+				percentile: toTopPercent(ranking.percentile),
+				value: displayValue,
+				unit: shouldConvert ? unit : meta.unit,
+				rank: ranking.rank,
+				totalUsers: ranking.totalUsers || benchmark.total_users,
+				color: meta.color,
+				percentiles: convertPercentiles(
+					normalizedPercentiles,
+					unit,
+					shouldConvert,
+				),
+			};
+		})
+		.filter((item): item is RankingItem => item !== null);
+}
+
+export function buildEstimatedCommunityPercentileRankings({
+	benchmarks,
+	userStats,
+	unit,
+}: {
+	benchmarks: CommunityBenchmarkRow[];
+	userStats: CommunityAtlasUserStats | null | undefined;
+	unit: WeightUnit;
+}): RankingItem[] {
+	if (!userStats) return [];
+
+	return Object.entries(STAT_FIELD_BY_METRIC)
+		.map(([metric, statField]): RankingItem | null => {
+			const meta = METRIC_META[metric];
+			if (!meta) return null;
+
+			const rawValue = userStats[statField];
+			if (rawValue == null || !Number.isFinite(rawValue)) return null;
+
+			const benchmark = findBenchmarkForMetric(benchmarks, metric);
+			if (!benchmark) return null;
+
+			const normalizedPercentiles = normalizePercentiles(
+				benchmark.percentile_values,
+			);
+			if (!normalizedPercentiles) return null;
+
+			const estimatedPercentile = estimatePercentileFromCutoffs(
+				normalizedPercentiles,
+				rawValue,
+			);
+			const topPercent = toTopPercent(estimatedPercentile);
+			const shouldConvert = meta.convertWeight === true;
+			const displayValue = shouldConvert
+				? Math.round(convertWeight(rawValue, unit) * 10) / 10
+				: rawValue;
+			const totalUsers = benchmark.total_users;
+
+			return {
+				label: meta.label,
+				percentile: topPercent,
+				value: displayValue,
+				unit: shouldConvert ? unit : meta.unit,
+				rank: Math.max(1, Math.round((topPercent / 100) * totalUsers)),
+				totalUsers,
+				color: meta.color,
+				percentiles: convertPercentiles(
+					normalizedPercentiles,
+					unit,
+					shouldConvert,
+				),
+				estimated: true,
+			};
+		})
+		.filter((item): item is RankingItem => item !== null);
+}

--- a/src/lib/freshness.ts
+++ b/src/lib/freshness.ts
@@ -1,0 +1,132 @@
+export type FreshnessStatus =
+	| "live"
+	| "refreshing"
+	| "stale"
+	| "reconnecting"
+	| "partial"
+	| "unavailable";
+
+export interface FreshnessInput {
+	dataUpdatedAt?: number | null;
+	nowMs?: number;
+	staleAfterMs?: number;
+	isFetching: boolean;
+	hasError: boolean;
+	partialTelemetry?: boolean;
+	processingAvailable?: boolean;
+}
+
+export interface FreshnessState {
+	status: FreshnessStatus;
+	label: string;
+	description: string;
+	flags: string[];
+	lastUpdatedLabel: string | null;
+}
+
+function formatLastUpdated(
+	timestamp: number | null | undefined,
+): string | null {
+	if (!timestamp) return null;
+	return new Date(timestamp).toLocaleTimeString("en-US", {
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+export function buildFreshnessState({
+	dataUpdatedAt,
+	nowMs = Date.now(),
+	staleAfterMs = 10 * 60 * 1000,
+	isFetching,
+	hasError,
+	partialTelemetry = false,
+	processingAvailable = true,
+}: FreshnessInput): FreshnessState {
+	const lastUpdatedLabel = formatLastUpdated(dataUpdatedAt);
+	const ageMs = dataUpdatedAt ? nowMs - dataUpdatedAt : null;
+	const flags: string[] = [];
+
+	if (!processingAvailable) {
+		flags.push("Processing unavailable");
+	}
+
+	if (partialTelemetry) {
+		flags.push("Partial telemetry");
+		return {
+			status: "partial",
+			label: "Partial data",
+			description: lastUpdatedLabel
+				? `Last updated ${lastUpdatedLabel}. Some telemetry is missing.`
+				: "Some telemetry is missing.",
+			flags,
+			lastUpdatedLabel,
+		};
+	}
+
+	if (hasError && isFetching) {
+		flags.push("Reconnecting");
+		return {
+			status: "reconnecting",
+			label: "Reconnecting",
+			description: lastUpdatedLabel
+				? `Keeping last update from ${lastUpdatedLabel} visible while reconnecting.`
+				: "Reconnecting to refresh the latest data.",
+			flags,
+			lastUpdatedLabel,
+		};
+	}
+
+	if (hasError) {
+		flags.push("Refresh failed");
+		return {
+			status: "stale",
+			label: "Stale data",
+			description: lastUpdatedLabel
+				? `Last updated ${lastUpdatedLabel}. Refresh failed.`
+				: "Refresh failed before any data was loaded.",
+			flags,
+			lastUpdatedLabel,
+		};
+	}
+
+	if (!dataUpdatedAt) {
+		return {
+			status: "unavailable",
+			label: "No data yet",
+			description: "Waiting for the first successful sync.",
+			flags,
+			lastUpdatedLabel: null,
+		};
+	}
+
+	if (isFetching) {
+		flags.push("Refreshing");
+		return {
+			status: "refreshing",
+			label: "Refreshing",
+			description: `Last updated ${lastUpdatedLabel}. Pulling the newest sync.`,
+			flags,
+			lastUpdatedLabel,
+		};
+	}
+
+	if (ageMs != null && ageMs > staleAfterMs) {
+		flags.push("Stale");
+		return {
+			status: "stale",
+			label: "Stale data",
+			description: `Last updated ${lastUpdatedLabel}. Waiting for the next sync_complete refresh.`,
+			flags,
+			lastUpdatedLabel,
+		};
+	}
+
+	return {
+		status: "live",
+		label: "Up to date",
+		description: `Last updated ${lastUpdatedLabel}.`,
+		flags,
+		lastUpdatedLabel,
+	};
+}

--- a/src/lib/progression-workbench.ts
+++ b/src/lib/progression-workbench.ts
@@ -114,6 +114,10 @@ function detectPlateauRisk({
 	lastPrAt: Date | null;
 	now: Date;
 }): "low" | "medium" | "high" {
+	if (rows.length < 2) {
+		return "low";
+	}
+
 	const lastThree = rows.slice(-3).map((row) => row.estimated_1rm_kg);
 	const lastThreeRangePct =
 		lastThree.length >= 3

--- a/src/lib/progression-workbench.ts
+++ b/src/lib/progression-workbench.ts
@@ -1,0 +1,290 @@
+import { convertWeight, type WeightUnit } from "@/lib/units";
+import { normalizeWorkoutPhase } from "@/lib/workout-phases";
+
+export interface ProgressionProgressRow {
+	id: string;
+	user_id: string;
+	exercise_name: string;
+	session_id: string;
+	recorded_at: Date;
+	max_weight_kg: number;
+	total_volume_kg: number;
+	estimated_1rm_kg: number;
+	max_reps: number;
+	set_count: number;
+}
+
+export interface ProgressionRecordRow {
+	id: string;
+	exercise_name: string;
+	exercise_id: string | null;
+	record_type: string;
+	workout_phase: string | null;
+	value: number;
+	unit: string;
+	achieved_at: Date;
+}
+
+export interface ProgressionRecommendation {
+	kind: "load" | "reps" | "variation";
+	label: string;
+	description: string;
+}
+
+export interface ProgressionExerciseSummary {
+	exerciseName: string;
+	currentOneRm: number;
+	currentOneRmKg: number;
+	gainRatePctPer30Days: number;
+	plateauRisk: "low" | "medium" | "high";
+	phasePrCount: number;
+	lastProgressAt: Date;
+	lastPrAt: Date | null;
+	recommendation: ProgressionRecommendation;
+	points: Array<{
+		date: string;
+		oneRm: number;
+		oneRmKg: number;
+		volume: number;
+		maxWeight: number;
+	}>;
+}
+
+export interface ProgressionWorkbenchModel {
+	exercises: ProgressionExerciseSummary[];
+	selectedExercise: ProgressionExerciseSummary | null;
+	emptyReason: string | null;
+}
+
+interface BuildProgressionWorkbenchModelInput {
+	progressRows: ProgressionProgressRow[];
+	records: ProgressionRecordRow[];
+	selectedExercise?: string | null;
+	phaseFilter: string;
+	unit: WeightUnit;
+	now?: Date;
+}
+
+function round(value: number, digits = 1): number {
+	const factor = 10 ** digits;
+	return Math.round(value * factor) / factor;
+}
+
+function pctChange(first: number, last: number): number {
+	if (first <= 0) return 0;
+	return ((last - first) / first) * 100;
+}
+
+function daysBetween(first: Date, last: Date): number {
+	const ms = last.getTime() - first.getTime();
+	return Math.max(1, ms / (1000 * 60 * 60 * 24));
+}
+
+function matchesPhase(
+	record: ProgressionRecordRow,
+	phaseFilter: string,
+): boolean {
+	if (phaseFilter === "all") return true;
+	return (
+		normalizeWorkoutPhase(record.workout_phase) ===
+		normalizeWorkoutPhase(phaseFilter)
+	);
+}
+
+function phaseRecordsForExercise(
+	records: ProgressionRecordRow[],
+	exerciseName: string,
+	phaseFilter: string,
+): ProgressionRecordRow[] {
+	return records.filter(
+		(record) =>
+			record.exercise_name.toLowerCase() === exerciseName.toLowerCase() &&
+			matchesPhase(record, phaseFilter),
+	);
+}
+
+function detectPlateauRisk({
+	rows,
+	gainRatePctPer30Days,
+	lastPrAt,
+	now,
+}: {
+	rows: ProgressionProgressRow[];
+	gainRatePctPer30Days: number;
+	lastPrAt: Date | null;
+	now: Date;
+}): "low" | "medium" | "high" {
+	const lastThree = rows.slice(-3).map((row) => row.estimated_1rm_kg);
+	const lastThreeRangePct =
+		lastThree.length >= 3
+			? pctChange(Math.min(...lastThree), Math.max(...lastThree))
+			: null;
+	const daysSincePr = lastPrAt
+		? daysBetween(lastPrAt, now)
+		: Number.POSITIVE_INFINITY;
+
+	if (lastThreeRangePct != null && lastThreeRangePct <= 2 && daysSincePr > 42) {
+		return "high";
+	}
+
+	if (gainRatePctPer30Days < 1 || daysSincePr > 30) {
+		return "medium";
+	}
+
+	return "low";
+}
+
+function buildRecommendation(
+	risk: ProgressionExerciseSummary["plateauRisk"],
+	latest: ProgressionProgressRow,
+	unit: WeightUnit,
+): ProgressionRecommendation {
+	if (risk === "high") {
+		return {
+			kind: "variation",
+			label: "Rotate stimulus",
+			description:
+				"Progress has flattened. Try a variation, rep-range change, or short deload before chasing load.",
+		};
+	}
+
+	if (risk === "medium") {
+		return {
+			kind: "reps",
+			label: "Earn the jump",
+			description:
+				"Hold load steady and add clean reps before the next weight increase.",
+		};
+	}
+
+	const nextLoad = convertWeight(latest.max_weight_kg + 2.5, unit);
+	return {
+		kind: "load",
+		label: `Add ${unit === "lbs" ? "5 lb" : "2.5 kg"}`,
+		description: `Recent trend supports testing about ${round(nextLoad, unit === "lbs" ? 0 : 1)} ${unit} next time.`,
+	};
+}
+
+function buildExerciseSummary({
+	exerciseName,
+	rows,
+	records,
+	phaseFilter,
+	unit,
+	now,
+}: {
+	exerciseName: string;
+	rows: ProgressionProgressRow[];
+	records: ProgressionRecordRow[];
+	phaseFilter: string;
+	unit: WeightUnit;
+	now: Date;
+}): ProgressionExerciseSummary {
+	const sortedRows = [...rows].sort(
+		(a, b) => a.recorded_at.getTime() - b.recorded_at.getTime(),
+	);
+	const first = sortedRows[0];
+	const latest = sortedRows[sortedRows.length - 1];
+	const elapsedDays = daysBetween(first.recorded_at, latest.recorded_at);
+	const totalGainPct = pctChange(
+		first.estimated_1rm_kg,
+		latest.estimated_1rm_kg,
+	);
+	const gainRatePctPer30Days = (totalGainPct / elapsedDays) * 30;
+	const phasePrs = phaseRecordsForExercise(records, exerciseName, phaseFilter);
+	const lastPrAt =
+		phasePrs.length > 0
+			? [...phasePrs].sort(
+					(a, b) => b.achieved_at.getTime() - a.achieved_at.getTime(),
+				)[0].achieved_at
+			: null;
+	const plateauRisk = detectPlateauRisk({
+		rows: sortedRows,
+		gainRatePctPer30Days,
+		lastPrAt,
+		now,
+	});
+
+	const placeholder = {
+		plateauRisk,
+	} as ProgressionExerciseSummary;
+	const recommendation = buildRecommendation(
+		placeholder.plateauRisk,
+		latest,
+		unit,
+	);
+
+	return {
+		exerciseName,
+		currentOneRm: round(convertWeight(latest.estimated_1rm_kg, unit), 1),
+		currentOneRmKg: latest.estimated_1rm_kg,
+		gainRatePctPer30Days: round(gainRatePctPer30Days, 1),
+		plateauRisk,
+		phasePrCount: phasePrs.length,
+		lastProgressAt: latest.recorded_at,
+		lastPrAt,
+		recommendation,
+		points: sortedRows.map((row) => ({
+			date: row.recorded_at.toLocaleDateString("en-US", {
+				month: "short",
+				day: "numeric",
+			}),
+			oneRm: round(convertWeight(row.estimated_1rm_kg, unit), 1),
+			oneRmKg: row.estimated_1rm_kg,
+			volume: round(convertWeight(row.total_volume_kg, unit), 1),
+			maxWeight: round(convertWeight(row.max_weight_kg, unit), 1),
+		})),
+	};
+}
+
+export function buildProgressionWorkbenchModel({
+	progressRows,
+	records,
+	selectedExercise,
+	phaseFilter,
+	unit,
+	now = new Date(),
+}: BuildProgressionWorkbenchModelInput): ProgressionWorkbenchModel {
+	if (progressRows.length === 0) {
+		return {
+			exercises: [],
+			selectedExercise: null,
+			emptyReason: "No exercise progress history is available yet.",
+		};
+	}
+
+	const grouped = new Map<string, ProgressionProgressRow[]>();
+	for (const row of progressRows) {
+		const existing = grouped.get(row.exercise_name) ?? [];
+		existing.push(row);
+		grouped.set(row.exercise_name, existing);
+	}
+
+	const exercises = [...grouped.entries()]
+		.map(([exerciseName, rows]) =>
+			buildExerciseSummary({
+				exerciseName,
+				rows,
+				records,
+				phaseFilter,
+				unit,
+				now,
+			}),
+		)
+		.sort((a, b) => {
+			const dateDelta = b.lastProgressAt.getTime() - a.lastProgressAt.getTime();
+			if (dateDelta !== 0) return dateDelta;
+			return b.currentOneRmKg - a.currentOneRmKg;
+		});
+
+	const selected =
+		exercises.find((exercise) => exercise.exerciseName === selectedExercise) ??
+		exercises[0] ??
+		null;
+
+	return {
+		exercises,
+		selectedExercise: selected,
+		emptyReason: null,
+	};
+}

--- a/src/lib/replay-intelligence.ts
+++ b/src/lib/replay-intelligence.ts
@@ -1,0 +1,215 @@
+import type { RepSummary, TelemetryPointRow } from "@/schemas/telemetry";
+
+export interface ReplayStickingPoint {
+	repNumber: number;
+	timestampMs: number;
+	positionMm: number;
+	velocityMps: number;
+	forceN: number;
+}
+
+export interface ReplayRepInsight {
+	repNumber: number;
+	startMs: number;
+	endMs: number;
+	meanVelocityMps: number;
+	peakVelocityMps: number;
+	peakForceN: number;
+	velocityLossPct: number;
+	consistencyPct: number;
+	stickingPoint: ReplayStickingPoint | null;
+}
+
+export interface ReplayIntelligenceInput {
+	telemetry: TelemetryPointRow[];
+	repSummaries: RepSummary[];
+	repBoundaries: number[];
+}
+
+export interface ReplayIntelligence {
+	status: "empty" | "partial" | "ready";
+	partialReason: string | null;
+	repCount: number;
+	repInsights: ReplayRepInsight[];
+	stickingPoints: ReplayStickingPoint[];
+	velocityLossPct: number;
+	fatigueSlopePctPerRep: number;
+	repConsistencyPct: number;
+	forcePeakN: number;
+	durationMs: number;
+}
+
+function round(value: number, digits = 1): number {
+	const factor = 10 ** digits;
+	return Math.round(value * factor) / factor;
+}
+
+function mean(values: number[]): number {
+	if (values.length === 0) return 0;
+	return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function standardDeviation(values: number[]): number {
+	if (values.length < 2) return 0;
+	const avg = mean(values);
+	const variance = mean(values.map((value) => (value - avg) ** 2));
+	return Math.sqrt(variance);
+}
+
+function getRepWindow(
+	index: number,
+	repBoundaries: number[],
+	telemetry: TelemetryPointRow[],
+	repSummaries: RepSummary[],
+): { startMs: number; endMs: number } {
+	const startMs =
+		repBoundaries[index] ??
+		repSummaries
+			.slice(0, index)
+			.reduce((sum, rep) => sum + rep.tut_ms + 500, 0);
+	const maxTelemetryMs =
+		telemetry.length > 0
+			? Math.max(...telemetry.map((point) => point.timestamp_ms))
+			: startMs + (repSummaries[index]?.tut_ms ?? 0);
+	const endMs =
+		repBoundaries[index + 1] ??
+		Math.max(startMs + (repSummaries[index]?.tut_ms ?? 0), maxTelemetryMs);
+	return { startMs, endMs };
+}
+
+function findStickingPoint(
+	rep: RepSummary,
+	points: TelemetryPointRow[],
+): ReplayStickingPoint | null {
+	if (points.length === 0 || rep.mean_velocity_mps <= 0) return null;
+
+	const velocityThreshold = rep.mean_velocity_mps * 0.45;
+	const forceThreshold = rep.peak_force_n * 0.9;
+	const candidates = points.filter(
+		(point) =>
+			point.velocity_mps <= velocityThreshold &&
+			point.force_n >= forceThreshold,
+	);
+
+	if (candidates.length === 0) return null;
+
+	const point = [...candidates].sort((a, b) => {
+		const forceDelta = b.force_n - a.force_n;
+		if (forceDelta !== 0) return forceDelta;
+		return a.velocity_mps - b.velocity_mps;
+	})[0];
+
+	return {
+		repNumber: rep.rep_number,
+		timestampMs: point.timestamp_ms,
+		positionMm: point.position_mm,
+		velocityMps: point.velocity_mps,
+		forceN: point.force_n,
+	};
+}
+
+export function buildReplayIntelligence({
+	telemetry,
+	repSummaries,
+	repBoundaries,
+}: ReplayIntelligenceInput): ReplayIntelligence {
+	if (repSummaries.length === 0 && telemetry.length === 0) {
+		return {
+			status: "empty",
+			partialReason: null,
+			repCount: 0,
+			repInsights: [],
+			stickingPoints: [],
+			velocityLossPct: 0,
+			fatigueSlopePctPerRep: 0,
+			repConsistencyPct: 0,
+			forcePeakN: 0,
+			durationMs: 0,
+		};
+	}
+
+	const velocities = repSummaries.map((rep) => rep.mean_velocity_mps);
+	const firstVelocity = velocities[0] ?? 0;
+	const lastVelocity = velocities[velocities.length - 1] ?? firstVelocity;
+	const velocityLossPct =
+		firstVelocity > 0
+			? ((firstVelocity - lastVelocity) / firstVelocity) * 100
+			: 0;
+	const fatigueSlopePctPerRep =
+		firstVelocity > 0 && velocities.length > 1
+			? ((lastVelocity - firstVelocity) /
+					(velocities.length - 1) /
+					firstVelocity) *
+				100
+			: 0;
+	const avgVelocity = mean(velocities);
+	const repConsistencyPct =
+		avgVelocity > 0
+			? Math.max(
+					0,
+					Math.min(
+						100,
+						100 - (standardDeviation(velocities) / avgVelocity) * 100,
+					),
+				)
+			: 0;
+	const forcePeakN = Math.max(
+		0,
+		...repSummaries.map((rep) => rep.peak_force_n),
+		...telemetry.map((point) => point.force_n),
+	);
+	const durationMs =
+		telemetry.length > 0
+			? Math.max(...telemetry.map((point) => point.timestamp_ms))
+			: repSummaries.reduce((sum, rep) => sum + rep.tut_ms, 0);
+
+	const repInsights = repSummaries.map((rep, index): ReplayRepInsight => {
+		const { startMs, endMs } = getRepWindow(
+			index,
+			repBoundaries,
+			telemetry,
+			repSummaries,
+		);
+		const points = telemetry.filter(
+			(point) => point.timestamp_ms >= startMs && point.timestamp_ms < endMs,
+		);
+		const stickingPoint = findStickingPoint(rep, points);
+		const lossFromFirst =
+			firstVelocity > 0
+				? ((firstVelocity - rep.mean_velocity_mps) / firstVelocity) * 100
+				: 0;
+
+		return {
+			repNumber: rep.rep_number,
+			startMs,
+			endMs,
+			meanVelocityMps: rep.mean_velocity_mps,
+			peakVelocityMps: rep.peak_velocity_mps,
+			peakForceN: rep.peak_force_n,
+			velocityLossPct: round(Math.max(0, lossFromFirst), 1),
+			consistencyPct: round(repConsistencyPct, 1),
+			stickingPoint,
+		};
+	});
+
+	const stickingPoints = repInsights
+		.map((rep) => rep.stickingPoint)
+		.filter((point): point is ReplayStickingPoint => point !== null);
+	const hasSummariesWithoutTelemetry =
+		repSummaries.length > 0 && telemetry.length < repSummaries.length * 2;
+
+	return {
+		status: hasSummariesWithoutTelemetry ? "partial" : "ready",
+		partialReason: hasSummariesWithoutTelemetry
+			? "Using rep summaries because telemetry samples are incomplete."
+			: null,
+		repCount: repSummaries.length,
+		repInsights,
+		stickingPoints,
+		velocityLossPct: round(Math.max(0, velocityLossPct), 1),
+		fatigueSlopePctPerRep: round(fatigueSlopePctPerRep, 1),
+		repConsistencyPct: round(repConsistencyPct, 1),
+		forcePeakN,
+		durationMs,
+	};
+}

--- a/src/lib/replay-intelligence.ts
+++ b/src/lib/replay-intelligence.ts
@@ -73,7 +73,9 @@ function getRepWindow(
 			: startMs + (repSummaries[index]?.tut_ms ?? 0);
 	const endMs =
 		repBoundaries[index + 1] ??
-		Math.max(startMs + (repSummaries[index]?.tut_ms ?? 0), maxTelemetryMs);
+		(index < repSummaries.length - 1
+			? startMs + (repSummaries[index]?.tut_ms ?? 0) + 500
+			: Math.max(startMs + (repSummaries[index]?.tut_ms ?? 0), maxTelemetryMs));
 	return { startMs, endMs };
 }
 

--- a/src/lib/replay-renderer.ts
+++ b/src/lib/replay-renderer.ts
@@ -80,18 +80,21 @@ function drawReplayIntelligence(
 	if (!intelligence || intelligence.status === "empty" || maxTime === 0) return;
 
 	const xScale = plotArea.width / maxTime;
+	const clampTime = (timestampMs: number) =>
+		Math.max(0, Math.min(timestampMs, maxTime));
 
 	for (const rep of intelligence.repInsights) {
 		if (rep.velocityLossPct < 20) continue;
-		const startX = plotArea.x + rep.startMs * xScale;
-		const endX = plotArea.x + rep.endMs * xScale;
+		const startX = plotArea.x + clampTime(rep.startMs) * xScale;
+		const endX = plotArea.x + clampTime(rep.endMs) * xScale;
+		if (endX <= startX) continue;
 		ctx.fillStyle = VELOCITY_LOSS_COLOR;
 		ctx.fillRect(startX, plotArea.y, endX - startX, plotArea.height);
 	}
 
 	for (const point of intelligence.stickingPoints) {
 		if (point.timestampMs > currentTimeMs) continue;
-		const x = plotArea.x + point.timestampMs * xScale;
+		const x = plotArea.x + clampTime(point.timestampMs) * xScale;
 		ctx.fillStyle = STICKING_POINT_COLOR;
 		ctx.beginPath();
 		ctx.arc(x, plotArea.y + 12, 4, 0, Math.PI * 2);

--- a/src/lib/replay-renderer.ts
+++ b/src/lib/replay-renderer.ts
@@ -1,4 +1,5 @@
 import type { TelemetryPointRow } from "@/schemas/telemetry";
+import type { ReplayIntelligence } from "./replay-intelligence";
 
 interface RenderOptions {
 	width: number;
@@ -6,6 +7,7 @@ interface RenderOptions {
 	data: TelemetryPointRow[];
 	currentTimeMs: number;
 	repBoundaries: number[];
+	intelligence?: ReplayIntelligence | null;
 }
 
 const MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
@@ -13,6 +15,8 @@ const BACKGROUND_COLOR = "#0D0D0D";
 const EMBER_COLOR = "#FF6B35";
 const REP_BAND_COLOR = "rgba(255, 107, 53, 0.08)";
 const PLAYHEAD_COLOR = "rgba(255, 255, 255, 0.7)";
+const VELOCITY_LOSS_COLOR = "rgba(220, 38, 38, 0.08)";
+const STICKING_POINT_COLOR = "#F59E0B";
 
 function getPlotArea(width: number, height: number) {
 	return {
@@ -66,11 +70,41 @@ function drawPlayhead(
 	ctx.setLineDash([]);
 }
 
+function drawReplayIntelligence(
+	ctx: CanvasRenderingContext2D,
+	plotArea: ReturnType<typeof getPlotArea>,
+	intelligence: ReplayIntelligence | null | undefined,
+	maxTime: number,
+	currentTimeMs: number,
+) {
+	if (!intelligence || intelligence.status === "empty" || maxTime === 0) return;
+
+	const xScale = plotArea.width / maxTime;
+
+	for (const rep of intelligence.repInsights) {
+		if (rep.velocityLossPct < 20) continue;
+		const startX = plotArea.x + rep.startMs * xScale;
+		const endX = plotArea.x + rep.endMs * xScale;
+		ctx.fillStyle = VELOCITY_LOSS_COLOR;
+		ctx.fillRect(startX, plotArea.y, endX - startX, plotArea.height);
+	}
+
+	for (const point of intelligence.stickingPoints) {
+		if (point.timestampMs > currentTimeMs) continue;
+		const x = plotArea.x + point.timestampMs * xScale;
+		ctx.fillStyle = STICKING_POINT_COLOR;
+		ctx.beginPath();
+		ctx.arc(x, plotArea.y + 12, 4, 0, Math.PI * 2);
+		ctx.fill();
+	}
+}
+
 export function renderForceCurve(
 	ctx: CanvasRenderingContext2D,
 	options: RenderOptions,
 ): void {
-	const { width, height, data, currentTimeMs, repBoundaries } = options;
+	const { width, height, data, currentTimeMs, repBoundaries, intelligence } =
+		options;
 	const plotArea = getPlotArea(width, height);
 
 	// Clear canvas with dark background
@@ -90,6 +124,7 @@ export function renderForceCurve(
 
 	// Draw rep background bands
 	drawRepBands(ctx, plotArea, repBoundaries, maxTime);
+	drawReplayIntelligence(ctx, plotArea, intelligence, maxTime, currentTimeMs);
 
 	// Filter data up to currentTimeMs
 	const visibleData = data.filter((d) => d.timestamp_ms <= currentTimeMs);
@@ -143,7 +178,8 @@ export function renderVelocityBars(
 	ctx: CanvasRenderingContext2D,
 	options: RenderOptions,
 ): void {
-	const { width, height, data, currentTimeMs, repBoundaries } = options;
+	const { width, height, data, currentTimeMs, repBoundaries, intelligence } =
+		options;
 	const plotArea = getPlotArea(width, height);
 
 	// Clear canvas with dark background
@@ -163,6 +199,7 @@ export function renderVelocityBars(
 
 	// Draw rep background bands
 	drawRepBands(ctx, plotArea, repBoundaries, maxTime);
+	drawReplayIntelligence(ctx, plotArea, intelligence, maxTime, currentTimeMs);
 
 	// Filter data up to currentTimeMs
 	const visibleData = data.filter((d) => d.timestamp_ms <= currentTimeMs);

--- a/src/queries/__tests__/benchmarks.test.ts
+++ b/src/queries/__tests__/benchmarks.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/queries/keys";
+
+function buildChain(terminal: { data: unknown; error: unknown }) {
+	const self: Record<string, ReturnType<typeof vi.fn>> = {};
+	for (const method of ["select", "eq", "order"]) {
+		self[method] = vi.fn();
+	}
+	for (const method of Object.keys(self)) {
+		self[method].mockReturnValue({ ...self, ...terminal });
+	}
+	return self;
+}
+
+let chain: ReturnType<typeof buildChain>;
+const fromFn = vi.fn(() => chain);
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: { from: (...args: unknown[]) => fromFn(...args) },
+}));
+
+describe("communityBenchmarksOptions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("fetches all benchmark rows with a stable query key", async () => {
+		const rows = [
+			{
+				id: "b1",
+				metric_type: "leaderboard",
+				metric_key: "total_volume_kg",
+				percentile_values: { p50: 1000, p90: 2000 },
+				total_users: 12,
+				updated_at: "2026-06-01T00:00:00Z",
+			},
+		];
+		chain = buildChain({ data: rows, error: null });
+
+		const { communityBenchmarksOptions } = await import("../benchmarks");
+		const opts = communityBenchmarksOptions();
+		const result = await opts.queryFn?.({} as never);
+
+		expect(opts.queryKey).toEqual(queryKeys.benchmarks.all);
+		expect(fromFn).toHaveBeenCalledWith("community_benchmarks");
+		expect(chain.select).toHaveBeenCalledWith("*");
+		expect(result).toEqual(rows);
+	});
+});

--- a/src/queries/__tests__/freshness.test.ts
+++ b/src/queries/__tests__/freshness.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/queries/keys";
+
+function buildChain(terminal: { data: unknown; error: unknown }) {
+	const self: Record<string, ReturnType<typeof vi.fn>> = {};
+	for (const method of ["select", "eq", "order", "limit"]) {
+		self[method] = vi.fn();
+	}
+	for (const method of Object.keys(self)) {
+		self[method].mockReturnValue({ ...self, ...terminal });
+	}
+	return self;
+}
+
+let chain: ReturnType<typeof buildChain>;
+const fromFn = vi.fn(() => chain);
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: { from: (...args: unknown[]) => fromFn(...args) },
+}));
+
+describe("dashboardFreshnessOptions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns the latest workout update for the active profile", async () => {
+		chain = buildChain({
+			data: [
+				{
+					updated_at: "2026-06-05T12:00:00Z",
+					started_at: "2026-06-05T11:00:00Z",
+				},
+			],
+			error: null,
+		});
+
+		const { dashboardFreshnessOptions } = await import("../freshness");
+		const opts = dashboardFreshnessOptions("user-1", "profile-1");
+		const result = await opts.queryFn?.({} as never);
+
+		expect(opts.queryKey).toEqual(
+			queryKeys.analytics.summary("user-1", "freshness", "profile-1"),
+		);
+		expect(fromFn).toHaveBeenCalledWith("workout_sessions");
+		expect(chain.eq).toHaveBeenCalledWith("user_id", "user-1");
+		expect(chain.eq).toHaveBeenCalledWith("local_profile_id", "profile-1");
+		expect(result).toEqual({
+			lastWorkoutUpdatedAt: "2026-06-05T12:00:00Z",
+			lastWorkoutStartedAt: "2026-06-05T11:00:00Z",
+			hasSyncedWorkouts: true,
+		});
+	});
+});

--- a/src/queries/__tests__/progress.test.ts
+++ b/src/queries/__tests__/progress.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/queries/keys";
+
+function buildChain(terminal: { data: unknown; error: unknown }) {
+	const self: Record<string, ReturnType<typeof vi.fn>> = {};
+	for (const method of ["select", "eq", "order"]) {
+		self[method] = vi.fn();
+	}
+	for (const method of Object.keys(self)) {
+		self[method].mockReturnValue({ ...self, ...terminal });
+	}
+	return self;
+}
+
+let chain: ReturnType<typeof buildChain>;
+const fromFn = vi.fn(() => chain);
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: { from: (...args: unknown[]) => fromFn(...args) },
+}));
+
+describe("progressionWorkbenchOptions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		fromFn.mockImplementation(() => chain);
+	});
+
+	it("fetches all exercise progress and personal records for the active profile", async () => {
+		const progressChain = buildChain({
+			data: [
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					user_id: "22222222-2222-4222-8222-222222222222",
+					exercise_name: "Bench Press",
+					session_id: "33333333-3333-4333-8333-333333333333",
+					recorded_at: "2026-06-05T00:00:00Z",
+					max_weight_kg: 50,
+					total_volume_kg: 1000,
+					estimated_1rm_kg: 60,
+					max_reps: 8,
+					set_count: 4,
+				},
+			],
+			error: null,
+		});
+		const recordsChain = buildChain({ data: [], error: null });
+		let callCount = 0;
+		fromFn.mockImplementation(() => {
+			callCount++;
+			return callCount === 1 ? progressChain : recordsChain;
+		});
+
+		const { progressionWorkbenchOptions } = await import("../progress");
+		const opts = progressionWorkbenchOptions("user-1", "profile-1");
+		const result = await opts.queryFn?.({} as never);
+
+		expect(opts.queryKey).toEqual(
+			queryKeys.progress.summary("user-1", "workbench", "profile-1"),
+		);
+		expect(fromFn).toHaveBeenCalledWith("exercise_progress");
+		expect(fromFn).toHaveBeenCalledWith("personal_records");
+		expect(progressChain.eq).toHaveBeenCalledWith("user_id", "user-1");
+		expect(progressChain.eq).toHaveBeenCalledWith(
+			"local_profile_id",
+			"profile-1",
+		);
+		expect(result.progressRows).toHaveLength(1);
+		expect(result.records).toEqual([]);
+	});
+});

--- a/src/queries/benchmarks.ts
+++ b/src/queries/benchmarks.ts
@@ -2,6 +2,21 @@ import { queryOptions } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { queryKeys } from "./keys";
 
+export function communityBenchmarksOptions() {
+	return queryOptions({
+		queryKey: queryKeys.benchmarks.all,
+		queryFn: async () => {
+			const { data, error } = await supabase
+				.from("community_benchmarks")
+				.select("*")
+				.order("metric_type");
+			if (error) throw error;
+			return data ?? [];
+		},
+		staleTime: 10 * 60 * 1000,
+	});
+}
+
 export function benchmarkOptions(metricType: string, metricKey?: string) {
 	return queryOptions({
 		queryKey: queryKeys.benchmarks.distribution(metricType, metricKey),

--- a/src/queries/freshness.ts
+++ b/src/queries/freshness.ts
@@ -1,0 +1,41 @@
+import { queryOptions } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { queryKeys } from "./keys";
+
+export interface DashboardFreshness {
+	lastWorkoutUpdatedAt: string | null;
+	lastWorkoutStartedAt: string | null;
+	hasSyncedWorkouts: boolean;
+}
+
+export function dashboardFreshnessOptions(
+	userId: string,
+	profileId?: string | null,
+) {
+	return queryOptions({
+		queryKey: queryKeys.analytics.summary(userId, "freshness", profileId),
+		queryFn: async (): Promise<DashboardFreshness> => {
+			let query = supabase
+				.from("workout_sessions")
+				.select("updated_at, started_at")
+				.eq("user_id", userId);
+
+			if (profileId) {
+				query = query.eq("local_profile_id", profileId);
+			}
+
+			const { data, error } = await query
+				.order("updated_at", { ascending: false })
+				.limit(1);
+			if (error) throw error;
+
+			const latest = data?.[0];
+			return {
+				lastWorkoutUpdatedAt: latest?.updated_at ?? null,
+				lastWorkoutStartedAt: latest?.started_at ?? null,
+				hasSyncedWorkouts: latest != null,
+			};
+		},
+		staleTime: 60 * 1000,
+	});
+}

--- a/src/queries/progress.ts
+++ b/src/queries/progress.ts
@@ -2,6 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { z } from "zod";
 import { supabase } from "@/lib/supabase";
 import { exerciseProgressSchema } from "@/schemas/telemetry";
+import { personalRecordListSchema } from "@/schemas/transforms";
 import { queryKeys } from "./keys";
 
 /** Fetch distinct exercise names for the user */
@@ -51,6 +52,45 @@ export function exerciseProgressOptions(
 			if (error) throw error;
 			return z.array(exerciseProgressSchema).parse(data);
 		},
+	});
+}
+
+/** Fetch the read-only data needed for the customer progression workbench. */
+export function progressionWorkbenchOptions(
+	userId: string,
+	profileId?: string | null,
+) {
+	return queryOptions({
+		queryKey: queryKeys.progress.summary(userId, "workbench", profileId),
+		queryFn: async () => {
+			let progressQuery = supabase
+				.from("exercise_progress")
+				.select("*")
+				.eq("user_id", userId);
+			let recordsQuery = supabase
+				.from("personal_records")
+				.select("*")
+				.eq("user_id", userId);
+
+			if (profileId) {
+				progressQuery = progressQuery.eq("local_profile_id", profileId);
+				recordsQuery = recordsQuery.eq("local_profile_id", profileId);
+			}
+
+			const [progressRes, recordsRes] = await Promise.all([
+				progressQuery.order("recorded_at", { ascending: true }),
+				recordsQuery.order("achieved_at", { ascending: true }),
+			]);
+
+			if (progressRes.error) throw progressRes.error;
+			if (recordsRes.error) throw recordsRes.error;
+
+			return {
+				progressRows: z.array(exerciseProgressSchema).parse(progressRes.data),
+				records: personalRecordListSchema.parse(recordsRes.data),
+			};
+		},
+		staleTime: 5 * 60 * 1000,
 	});
 }
 


### PR DESCRIPTION
## Summary
- Adds replay intelligence overlays, freshness status strips, a progression workbench, and a live community percentile atlas.
- Wires analytics and replay pages to typed read-only query helpers and derived client-side transforms.
- Fallbacks keep percentile and replay insights visible from populated live data instead of waiting on future pipeline tables.

## Testing
- Unit tests added for telemetry summaries, percentile mapping, freshness states, and progression recommendations.
- Component tests added for the new analytics and replay visualization states.
- Local browser smoke testing verified authenticated dashboard, analytics, performance, history, and replay routes without console errors.