### PR TITLE
fix: remove CSS override that hid active underline tab text

### DIFF
--- a/src/app/components/ui/tabs.tsx
+++ b/src/app/components/ui/tabs.tsx
@@ -63,13 +63,6 @@ const tabsTriggerVariants = cva(
 				default:
 					"flex-1 h-[calc(100%-1px)] rounded-md border border-transparent px-2 py-1 text-secondary-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground",
 				underline:
-					// Active state: use `text-foreground` (theme's light-on-dark
-					// token, #e0e0e8) rather than `text-white` which in this
-					// codebase was rendering invisible on the dark background
-					// — the Leaderboard tab group was reported with black-on-black
-					// selected text. `font-semibold` on active gives an extra
-					// visual cue so the tab reads as selected even for users who
-					// can't see the thin orange underline.
 					"flex-1 rounded-none border-b-2 border-transparent px-4 py-3 text-muted-foreground data-[state=active]:border-primary data-[state=active]:text-foreground data-[state=active]:font-semibold",
 			},
 		},

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -298,8 +298,7 @@
 
   /* Keep filled primary controls above WCAG AA contrast thresholds. */
   [data-slot="button"].bg-primary,
-  [data-slot="avatar-fallback"].bg-primary,
-  [data-slot="tabs-trigger"][data-state="active"] {
+  [data-slot="avatar-fallback"].bg-primary {
     color: var(--primary-foreground) !important;
   }
 


### PR DESCRIPTION
## Summary

- **Root cause:** A CSS rule in `theme.css` (`[data-slot="tabs-trigger"][data-state="active"]`) forced `color: var(--primary-foreground) !important` (#06060a, near-black) on **all** active tab triggers. This was intended for the `default` variant (which has an orange `bg-primary` fill), but it also hit the `underline` variant — which has no background fill — rendering the selected tab text invisible (black on black).
- Removed the `[data-slot="tabs-trigger"][data-state="active"]` selector from the WCAG contrast rule. Both tab variants already set the correct active text color via their Tailwind utility classes (`text-primary-foreground` for default, `text-foreground` for underline).
- Cleaned up a stale 7-line comment in `tabs.tsx` that described a prior misdiagnosis.

## Test plan

- [ ] On mobile viewport, navigate to Community → verify "Routines" and "Cycles" tab labels remain visible when selected
- [ ] Navigate to Social → Leaderboard → verify "All-Time Rankings", "Weekly Challenge", "My Rankings" tabs are readable when active
- [ ] Navigate to Challenges → verify "Active", "Past", "Discover" tabs display correctly
- [ ] On desktop, verify default (filled) tab variants still show correct contrast (dark text on orange bg)
- [ ] Verify buttons with `bg-primary` and avatar fallbacks still get the `!important` foreground override

Fixes #62

https://claude.ai/code/session_011EC4LANhrTRKHjSDZ1hpet


---
_Generated by [Claude Code](https://claude.ai/code/session_011EC4LANhrTRKHjSDZ1hpet)_