### PR TITLE
fix: eliminate dark-on-dark text across tabs, buttons, and nav menu

### DIFF
--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -13,10 +13,10 @@ const buttonVariants = cva(
 				destructive:
 					"bg-destructive/60 text-white hover:bg-destructive/90 focus-visible:ring-destructive/40",
 				outline:
-					"border border-input bg-input/30 text-foreground hover:bg-input/50 hover:text-accent-foreground",
+					"border border-input bg-input/30 text-foreground hover:bg-input/50 hover:text-foreground",
 				secondary:
 					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
-				ghost: "hover:bg-accent/50 hover:text-accent-foreground",
+				ghost: "hover:bg-accent/10 hover:text-foreground",
 				link: "text-primary underline-offset-4 hover:underline",
 				cta: "bg-primary hover:bg-primary/90 text-primary-foreground border-0 font-medium",
 				success:

--- a/src/app/components/ui/navigation-menu.tsx
+++ b/src/app/components/ui/navigation-menu.tsx
@@ -129,7 +129,7 @@ function NavigationMenuLink({
 		<NavigationMenuPrimitive.Link
 			data-slot="navigation-menu-link"
 			className={cn(
-				"data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
+				"data-[active=true]:focus:bg-accent/50 data-[active=true]:hover:bg-accent/50 data-[active=true]:bg-accent/10 data-[active=true]:text-foreground hover:bg-accent/10 hover:text-foreground focus:bg-accent/10 focus:text-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}

--- a/src/app/components/ui/tabs.tsx
+++ b/src/app/components/ui/tabs.tsx
@@ -63,13 +63,6 @@ const tabsTriggerVariants = cva(
 				default:
 					"flex-1 h-[calc(100%-1px)] rounded-md border border-transparent px-2 py-1 text-secondary-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground",
 				underline:
-					// Active state: use `text-foreground` (theme's light-on-dark
-					// token, #e0e0e8) rather than `text-white` which in this
-					// codebase was rendering invisible on the dark background
-					// — the Leaderboard tab group was reported with black-on-black
-					// selected text. `font-semibold` on active gives an extra
-					// visual cue so the tab reads as selected even for users who
-					// can't see the thin orange underline.
 					"flex-1 rounded-none border-b-2 border-transparent px-4 py-3 text-muted-foreground data-[state=active]:border-primary data-[state=active]:text-foreground data-[state=active]:font-semibold",
 			},
 		},

--- a/src/app/components/ui/tabs.tsx
+++ b/src/app/components/ui/tabs.tsx
@@ -81,6 +81,7 @@ function TabsTrigger({
 	return (
 		<TabsPrimitive.Trigger
 			data-slot="tabs-trigger"
+			data-variant={variant ?? "default"}
 			className={cn(tabsTriggerVariants({ variant }), className)}
 			{...props}
 		/>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -298,8 +298,7 @@
 
   /* Keep filled primary controls above WCAG AA contrast thresholds. */
   [data-slot="button"].bg-primary,
-  [data-slot="avatar-fallback"].bg-primary,
-  [data-slot="tabs-trigger"][data-state="active"] {
+  [data-slot="avatar-fallback"].bg-primary {
     color: var(--primary-foreground) !important;
   }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -519,6 +519,12 @@
   }
 }
 
+/* Underline tabs: guarantee light active text on transparent background.
+   Unlayered so it beats any @layer utilities cascade edge case. */
+[data-slot="tabs-trigger"][data-variant="underline"][data-state="active"] {
+  color: var(--foreground);
+}
+
 /* ---- Reduced motion: respect user preference for ALL CSS animations ---- */
 @media (prefers-reduced-motion: reduce) {
   .animate-signal-pulse {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -298,7 +298,8 @@
 
   /* Keep filled primary controls above WCAG AA contrast thresholds. */
   [data-slot="button"].bg-primary,
-  [data-slot="avatar-fallback"].bg-primary {
+  [data-slot="avatar-fallback"].bg-primary,
+  [data-slot="tabs-trigger"][data-variant="default"][data-state="active"] {
     color: var(--primary-foreground) !important;
   }
 


### PR DESCRIPTION
## Summary

Multiple UI components applied near-black text colors (`text-accent-foreground` = `#06060a`, `text-primary-foreground` = `#06060a`) in states where the background was transparent or semi-transparent — rendering text invisible on the `#06060a` dark theme.

- **tabs.tsx**: Added `data-variant` attribute to `TabsTrigger` so CSS can reliably target underline vs default tabs
- **theme.css**: Added an **unlayered** CSS rule for `[data-variant="underline"][data-state="active"]` that guarantees `color: var(--foreground)` — this beats any `@layer utilities` cascade edge case, which is why the previous Tailwind-only fix (`data-[state=active]:text-foreground`) wasn't consistently applying across all pages
- **button.tsx**: Fixed `ghost` variant hover (`bg-accent/50` + dark text → `bg-accent/10` + light text) and `outline` variant hover (`text-accent-foreground` → `text-foreground`)
- **navigation-menu.tsx**: Fixed link active/hover/focus states from opaque `bg-accent` + dark text to `bg-accent/10` + light text

### Why the Tailwind-only fix wasn't enough

The underline tab variant correctly had `data-[state=active]:text-foreground` in its class list. However, in Tailwind v4's layered CSS architecture, all utility classes are in `@layer utilities`. Some pages were inconsistently rendering the active color — likely due to CSS cascade ordering within the layer or service worker caching. The new unlayered CSS rule sits **outside** all `@layer` blocks, giving it the highest cascade priority by spec, making it immune to layer-internal ordering issues.

## Test plan

- [ ] Leaderboard: verify "All-Time Rankings" / "Weekly Challenge" / "My Rankings" tab labels visible when selected
- [ ] Community (mobile): verify "Routines" / "Cycles" tab labels visible when selected
- [ ] Challenges (mobile): verify "Active" / "Past" / "Discover" tab labels visible when selected
- [ ] Ghost buttons: hover over "..." menus, filter buttons — text stays readable
- [ ] Outline buttons: hover over bordered buttons — text stays readable
- [ ] Desktop navigation menu: active link text visible, hover text visible
- [ ] Default (filled) tab variants still work: dark text on orange bg (Profile, Analytics, etc.)

Fixes #62

https://claude.ai/code/session_011EC4LANhrTRKHjSDZ1hpet


---
_Generated by [Claude Code](https://claude.ai/code/session_011EC4LANhrTRKHjSDZ1hpet)_