### PR TITLE
fix(comparison): render em-dash and show session dates in header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
   e2e:
     name: Playwright E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -80,7 +84,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
       - run: npm run test:e2e
         env:
           CI: true

--- a/src/app/components/ComparisonView.tsx
+++ b/src/app/components/ComparisonView.tsx
@@ -534,6 +534,7 @@ export function ComparisonView() {
 								<time
 									dateTime={summaryA.startedAt.toISOString()}
 									className="text-muted-foreground/80"
+									suppressHydrationWarning
 								>
 									{formatSessionDate(summaryA.startedAt)}
 								</time>
@@ -545,6 +546,7 @@ export function ComparisonView() {
 								<time
 									dateTime={summaryB.startedAt.toISOString()}
 									className="text-muted-foreground/80"
+									suppressHydrationWarning
 								>
 									{formatSessionDate(summaryB.startedAt)}
 								</time>

--- a/src/app/components/ComparisonView.tsx
+++ b/src/app/components/ComparisonView.tsx
@@ -66,6 +66,14 @@ function formatVelocity(v: number): string {
 	return `${v.toFixed(2)} m/s`;
 }
 
+function formatSessionDate(d: Date): string {
+	return d.toLocaleDateString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
 function SessionSummaryCard({
 	summary,
 	label,
@@ -178,14 +186,14 @@ function ExerciseBreakdownTable({ result }: { result: ComparisonResult }) {
 								<td className="py-3 text-white font-medium">{ex.name}</td>
 								<td className="py-3 text-right text-secondary-foreground">
 									{ex.onlyInB ? (
-										<span className="text-muted-foreground">\u2014</span>
+										<span className="text-muted-foreground">—</span>
 									) : (
 										`${ex.volumeA.toLocaleString()} kg`
 									)}
 								</td>
 								<td className="py-3 text-right text-secondary-foreground">
 									{ex.onlyInA ? (
-										<span className="text-muted-foreground">\u2014</span>
+										<span className="text-muted-foreground">—</span>
 									) : (
 										`${ex.volumeB.toLocaleString()} kg`
 									)}
@@ -205,23 +213,23 @@ function ExerciseBreakdownTable({ result }: { result: ComparisonResult }) {
 								</td>
 								<td className="py-3 text-right text-secondary-foreground">
 									{ex.onlyInB ? (
-										<span className="text-muted-foreground">\u2014</span>
+										<span className="text-muted-foreground">—</span>
 									) : (
 										formatVelocity(ex.velocityA)
 									)}
 								</td>
 								<td className="py-3 text-right text-secondary-foreground">
 									{ex.onlyInA ? (
-										<span className="text-muted-foreground">\u2014</span>
+										<span className="text-muted-foreground">—</span>
 									) : (
 										formatVelocity(ex.velocityB)
 									)}
 								</td>
 								<td className="py-3 text-right">
 									{ex.onlyInA || ex.onlyInB ? (
-										<span className="text-muted-foreground">\u2014</span>
+										<span className="text-muted-foreground">—</span>
 									) : ex.velocityA === 0 && ex.velocityB === 0 ? (
-										<span className="text-muted-foreground">\u2014</span>
+										<span className="text-muted-foreground">—</span>
 									) : (
 										<DeltaIndicator value={ex.velocityDeltaPct} />
 									)}
@@ -519,10 +527,28 @@ export function ComparisonView() {
 								Session Comparison
 							</h1>
 						</FeatureHint>
-						<div className="flex items-center gap-3">
-							<p className="text-muted-foreground">
-								{summaryA.name} vs {summaryB.name}
-							</p>
+						<div className="flex items-center gap-3 flex-wrap text-sm">
+							<span className="text-muted-foreground">
+								<span className="font-medium text-white">A</span> ·{" "}
+								{summaryA.name} ·{" "}
+								<time
+									dateTime={summaryA.startedAt.toISOString()}
+									className="text-muted-foreground/80"
+								>
+									{formatSessionDate(summaryA.startedAt)}
+								</time>
+							</span>
+							<span className="text-muted-foreground/60">vs</span>
+							<span className="text-muted-foreground">
+								<span className="font-medium text-white">B</span> ·{" "}
+								{summaryB.name} ·{" "}
+								<time
+									dateTime={summaryB.startedAt.toISOString()}
+									className="text-muted-foreground/80"
+								>
+									{formatSessionDate(summaryB.startedAt)}
+								</time>
+							</span>
 							<Button
 								variant="outline"
 								size="sm"


### PR DESCRIPTION
Two related bugs in the Session Comparison view (issue #65):

1. Six JSX text nodes used the literal escape '\u2014' as text content. JSX does not interpret backslash escapes, so the user saw the 6-character string '\u2014' instead of an em-dash where an exercise was missing from one session or both velocities were zero. Replaced with the actual em-dash character.

2. The comparison header rendered only the two session names ('{nameA} vs {nameB}') with no dates. When both sessions share a name (e.g. '1.Anchor.DL/BP' vs '1.Anchor.DL/BP'), the volume / duration delta sign is uninterpretable without knowing which side is newer, forcing the user to click Swap to disambiguate. Added per-side date display and explicit A/B labels wrapped in a semantic <time> element.

The one remaining '\u2014' literal (formatVelocity) is inside a TypeScript string literal and is correctly interpreted as em-dash by the JS engine; left untouched.

Closes #65