### PR TITLE
fix: guard personal record profile sync

### DIFF
--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -4,6 +4,7 @@ import {
 	buildPersonalRecordRows,
 	buildPersonalRecordRowsForPush,
 	personalRecordIdentityKey,
+	resolveDedicatedRecordLocalProfileId,
 } from "../../../supabase/functions/_shared/personalRecordRow.ts";
 
 /**
@@ -389,5 +390,272 @@ describe("personalRecordIdentityKey", () => {
 				exercise_name: "id:curl",
 			}),
 		);
+	});
+});
+
+describe("Issue #507: per-record localProfileId validation", () => {
+	// These tests lock in the fix for Cloud Sync personal_records upsert
+	// failing the `fk_personal_records_profile` foreign key when a dedicated
+	// personalRecord carries a stale/invalid per-record `localProfileId` that
+	// bypasses the handler-sanitized top-level `localProfileId`.
+
+	const VALID_IDS = new Set(["default", "secondary"]);
+
+	it("preserves a per-record localProfileId that is in the valid set", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Bench Press",
+					muscleGroup: "Chest",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					weightKg: 125,
+					reps: 3,
+					workoutPhase: "CONCENTRIC",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					localProfileId: "secondary",
+				},
+			],
+			USER_ID,
+			PROFILE_ID, // sanitized handler fallback = "default"
+			VALID_IDS,
+		);
+
+		expect(out).toHaveLength(1);
+		expect(out[0]?.local_profile_id).toBe("secondary");
+	});
+
+	it("falls back to the sanitized handler localProfileId when the per-record ID is invalid and the handler has one", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Squat",
+					muscleGroup: "Legs",
+					recordType: "MAX_WEIGHT",
+					value: 200,
+					weightKg: 200,
+					reps: 1,
+					workoutPhase: "COMBINED",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					// Stale/invalid ID not present in the current push's valid set.
+					localProfileId: "deleted-profile-uuid",
+				},
+			],
+			USER_ID,
+			PROFILE_ID, // sanitized handler fallback = "default"
+			VALID_IDS,
+		);
+
+		expect(out).toHaveLength(1);
+		expect(out[0]?.local_profile_id).toBe("default");
+	});
+
+	it("nulls the per-record localProfileId when it is invalid and the sanitized handler fallback is null", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Deadlift",
+					muscleGroup: "Back",
+					recordType: "MAX_WEIGHT",
+					value: 250,
+					weightKg: 250,
+					reps: 1,
+					workoutPhase: "COMBINED",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					localProfileId: "stale-profile-uuid",
+				},
+			],
+			USER_ID,
+			null, // sanitized handler fallback = null (pre-multi-profile clients)
+			VALID_IDS,
+		);
+
+		expect(out).toHaveLength(1);
+		expect(out[0]?.local_profile_id).toBeNull();
+	});
+
+	it("uses the sanitized handler fallback when the per-record localProfileId is undefined", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Overhead Press",
+					muscleGroup: "Shoulders",
+					recordType: "MAX_WEIGHT",
+					value: 80,
+					weightKg: 80,
+					reps: 5,
+					workoutPhase: "CONCENTRIC",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					// localProfileId deliberately omitted (undefined).
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+			VALID_IDS,
+		);
+
+		expect(out).toHaveLength(1);
+		expect(out[0]?.local_profile_id).toBe("default");
+	});
+
+	it("preserves the historical behavior when no valid set is supplied", () => {
+		// Call sites that don't yet know about the current push's profile
+		// set should keep the old semantics: any defined string ID is
+		// trusted. This guarantees the new parameter is opt-in.
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Bench Press",
+					muscleGroup: "Chest",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					weightKg: 125,
+					reps: 3,
+					workoutPhase: "CONCENTRIC",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					localProfileId: "any-stale-id",
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+			null, // no valid set supplied
+		);
+
+		expect(out).toHaveLength(1);
+		expect(out[0]?.local_profile_id).toBe("any-stale-id");
+	});
+
+	it("normalizes a mix of valid and invalid per-record IDs in the same batch", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					exerciseName: "Squat",
+					recordType: "MAX_WEIGHT",
+					value: 200,
+					weightKg: 200,
+					reps: 1,
+					workoutPhase: "COMBINED",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					localProfileId: "default", // valid
+				},
+				{
+					exerciseName: "Bench Press",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					weightKg: 125,
+					reps: 3,
+					workoutPhase: "COMBINED",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					localProfileId: "stale-id", // invalid
+				},
+				{
+					exerciseName: "Deadlift",
+					recordType: "MAX_WEIGHT",
+					value: 250,
+					weightKg: 250,
+					reps: 1,
+					workoutPhase: "COMBINED",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					// undefined -> fallback
+				},
+			],
+			USER_ID,
+			"secondary", // sanitized handler fallback
+			new Set(["default", "secondary"]),
+		);
+
+		expect(out.map((r) => r.local_profile_id)).toEqual([
+			"default",
+			"secondary",
+			"secondary",
+		]);
+	});
+
+	it("propagates the valid set through buildPersonalRecordRowsForPush for dedicated records", () => {
+		const rows = buildPersonalRecordRowsForPush(
+			[baseSession({ prType: "MAX_VOLUME", prPhase: "CONCENTRIC" })], // ignored when dedicated present
+			[
+				{
+					exerciseName: "Bench Press",
+					muscleGroup: "Chest",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					weightKg: 125,
+					reps: 3,
+					workoutPhase: "CONCENTRIC",
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					localProfileId: "stale-id", // invalid
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+			VALID_IDS,
+		);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.local_profile_id).toBe("default");
+	});
+
+	it("propagates the valid set through buildPersonalRecordRowsForPush for set-derived records when no dedicated records are present", () => {
+		// Set-derived path uses the handler fallback directly, not
+		// per-record IDs, so the valid-set parameter is irrelevant here.
+		// The set is still accepted (and ignored) to keep the signature
+		// uniform across both branches.
+		const rows = buildPersonalRecordRowsForPush(
+			[baseSession()],
+			[],
+			USER_ID,
+			PROFILE_ID,
+			VALID_IDS,
+		);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.local_profile_id).toBe("default");
+	});
+});
+
+describe("resolveDedicatedRecordLocalProfileId", () => {
+	const VALID_IDS = new Set(["default", "secondary"]);
+
+	it("returns the handler fallback for undefined per-record ID", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId(undefined, "default", VALID_IDS),
+		).toBe("default");
+	});
+
+	it("returns null for undefined per-record ID when handler fallback is null", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId(undefined, null, VALID_IDS),
+		).toBeNull();
+	});
+
+	it("preserves an explicit null per-record ID as null", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId(null, "default", VALID_IDS),
+		).toBeNull();
+	});
+
+	it("preserves a per-record ID that is in the valid set", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId("secondary", "default", VALID_IDS),
+		).toBe("secondary");
+	});
+
+	it("falls back to the handler fallback for a per-record ID absent from the valid set", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId("stale-uuid", "default", VALID_IDS),
+		).toBe("default");
+	});
+
+	it("falls back to null when the per-record ID is invalid and the handler fallback is null", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId("stale-uuid", null, VALID_IDS),
+		).toBeNull();
+	});
+
+	it("preserves the historical behavior when the valid set is null", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId("any-id", "default", null),
+		).toBe("any-id");
 	});
 });

--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -629,6 +629,16 @@ describe("resolveDedicatedRecordLocalProfileId", () => {
 		).toBeNull();
 	});
 
+	it("returns null for undefined per-record ID when handler fallback is absent from the valid set", () => {
+		expect(
+			resolveDedicatedRecordLocalProfileId(
+				undefined,
+				"stale-handler-id",
+				VALID_IDS,
+			),
+		).toBeNull();
+	});
+
 	it("preserves an explicit null per-record ID as null", () => {
 		expect(
 			resolveDedicatedRecordLocalProfileId(null, "default", VALID_IDS),

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -151,7 +151,12 @@ export function resolveDedicatedRecordLocalProfileId(
 	validLocalProfileIds: ReadonlySet<string> | null,
 ): string | null {
 	if (recordLocalProfileId === undefined) {
-		return handlerLocalProfileId;
+		if (validLocalProfileIds === null || handlerLocalProfileId === null) {
+			return handlerLocalProfileId;
+		}
+		return validLocalProfileIds.has(handlerLocalProfileId)
+			? handlerLocalProfileId
+			: null;
 	}
 	if (recordLocalProfileId === null) {
 		return null;

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -121,19 +121,71 @@ function valueForDedicatedRecord(
 	return record.weightKg ?? 0;
 }
 
+/**
+ * Resolve a per-record `localProfileId` against a caller-supplied set of
+ * valid local profile IDs for the current push.
+ *
+ * Background (Issue #507): mobile-sync-push sanitizes the top-level
+ * `localProfileId` when a local profile upsert fails, but dedicated
+ * `personalRecords` can carry their own `record.localProfileId`. A stale
+ * or invalid per-record ID bypasses the sanitized handler fallback and
+ * trips the `fk_personal_records_profile` foreign key on upsert.
+ *
+ * Rules:
+ *  - `undefined` → fall back to the handler-sanitized `localProfileId`.
+ *  - Explicit `null` → preserved as `null` (caller intentionally has no
+ *    profile; the FK is satisfied when `local_profile_id` is nullable).
+ *  - String ID present in `validLocalProfileIds` → preserved.
+ *  - String ID absent from `validLocalProfileIds` → fall back to the
+ *    handler-sanitized `localProfileId` when that fallback is also valid,
+ *    otherwise null it out. This is the FK-safe behavior.
+ *
+ * When `validLocalProfileIds` is `null` the helper preserves the
+ * historical behavior: any defined string ID is trusted. This keeps
+ * call sites that don't yet know about the current push's profile set
+ * working unchanged.
+ */
+export function resolveDedicatedRecordLocalProfileId(
+	recordLocalProfileId: string | null | undefined,
+	handlerLocalProfileId: string | null,
+	validLocalProfileIds: ReadonlySet<string> | null,
+): string | null {
+	if (recordLocalProfileId === undefined) {
+		return handlerLocalProfileId;
+	}
+	if (recordLocalProfileId === null) {
+		return null;
+	}
+	if (validLocalProfileIds === null) {
+		return recordLocalProfileId;
+	}
+	if (validLocalProfileIds.has(recordLocalProfileId)) {
+		return recordLocalProfileId;
+	}
+	if (
+		handlerLocalProfileId !== null &&
+		validLocalProfileIds.has(handlerLocalProfileId)
+	) {
+		return handlerLocalProfileId;
+	}
+	return null;
+}
+
 export function buildDedicatedPersonalRecordRows(
 	records: DedicatedPersonalRecordInput[],
 	userId: string,
 	localProfileId: string | null,
+	validLocalProfileIds: ReadonlySet<string> | null = null,
 ): PersonalRecordRow[] {
 	return records.map((record) => {
 		const recordType = record.recordType ?? "1RM";
 		const row: PersonalRecordRow = {
 			user_id: userId,
-			local_profile_id:
-				record.localProfileId === undefined
-					? localProfileId
-					: record.localProfileId,
+			local_profile_id: resolveDedicatedRecordLocalProfileId(
+				record.localProfileId,
+				localProfileId,
+				validLocalProfileIds,
+			),
 			exercise_name: record.exerciseName,
 			exercise_id: record.exerciseId ?? null,
 			muscle_group: record.muscleGroup ?? "General",
@@ -158,12 +210,14 @@ export function buildPersonalRecordRowsForPush(
 	personalRecords: DedicatedPersonalRecordInput[],
 	userId: string,
 	localProfileId: string | null,
+	validLocalProfileIds: ReadonlySet<string> | null = null,
 ): PersonalRecordRow[] {
 	if (personalRecords.length > 0) {
 		return buildDedicatedPersonalRecordRows(
 			personalRecords,
 			userId,
 			localProfileId,
+			validLocalProfileIds,
 		);
 	}
 

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -812,6 +812,11 @@ Deno.serve(async (req) => {
     // Use `let` so we can clear it to null if the profile upsert fails.
     let localProfileId: string | null = payload.profileId ?? null;
     const allProfiles: LocalProfileDto[] | null = payload.allProfiles ?? null;
+    // Tracks profile IDs that are safe to reference in FK-protected rows for
+    // this push. Dedicated personalRecords can carry their own localProfileId;
+    // validating against this set prevents stale per-record IDs from bypassing
+    // the sanitized handler-level fallback (Issue #507).
+    const validLocalProfileIdsForPush = new Set<string>();
 
     if (allProfiles && allProfiles.length > 0) {
       // Schema already validated each allProfiles[].id is "default" or a UUID
@@ -839,8 +844,14 @@ Deno.serve(async (req) => {
           localProfileId = null;
         }
       } else {
-        // Delete profiles that no longer exist on the device (from this device only)
         const activeIds = allProfiles.map((p) => p.id);
+        for (const id of activeIds) validLocalProfileIdsForPush.add(id);
+        if (localProfileId && !validLocalProfileIdsForPush.has(localProfileId)) {
+          console.warn('Clearing localProfileId because it is absent from allProfiles');
+          localProfileId = null;
+        }
+
+        // Delete profiles that no longer exist on the device (from this device only)
         const { error: deleteError } = await supabase
           .from('local_profiles')
           .delete()
@@ -882,6 +893,8 @@ Deno.serve(async (req) => {
         console.warn('Failed to upsert local profile:', profileError.message);
         console.warn('Clearing localProfileId to avoid FK violation on session insert');
         localProfileId = null;
+      } else if (localProfileId) {
+        validLocalProfileIdsForPush.add(localProfileId);
       }
     }
 
@@ -1461,6 +1474,7 @@ Deno.serve(async (req) => {
       payload.personalRecords ?? [],
       userId,
       localProfileId,
+      validLocalProfileIdsForPush,
     );
 
     if (prRows.length > 0) {

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -815,7 +815,11 @@ Deno.serve(async (req) => {
     // Tracks profile IDs that are safe to reference in FK-protected rows for
     // this push. Dedicated personalRecords can carry their own localProfileId;
     // validating against this set prevents stale per-record IDs from bypassing
-    // the sanitized handler-level fallback (Issue #507).
+    // the sanitized handler-level fallback (Issue #507). Keep validation
+    // opt-out for legacy payloads that provide only per-record profile IDs and
+    // no top-level/allProfiles data to validate against.
+    const shouldValidatePersonalRecordProfileIds =
+      (allProfiles && allProfiles.length > 0) || localProfileId !== null;
     const validLocalProfileIdsForPush = new Set<string>();
 
     if (allProfiles && allProfiles.length > 0) {
@@ -1474,7 +1478,7 @@ Deno.serve(async (req) => {
       payload.personalRecords ?? [],
       userId,
       localProfileId,
-      validLocalProfileIdsForPush,
+      shouldValidatePersonalRecordProfileIds ? validLocalProfileIdsForPush : null,
     );
 
     if (prRows.length > 0) {


### PR DESCRIPTION
## Summary

Fixes the Cloud Sync `personal_records` FK failure diagnosed in the RCA for Project Phoenix Mobile issue 9thLevelSoftware/phoenix-portal#72.

Root cause: `mobile-sync-push` sanitized the handler-level `localProfileId` after local profile upsert failures, but dedicated `personalRecords` could still carry their own per-record `localProfileId`. The personal record row builder preferred that per-record value, so stale/missing profile IDs bypassed the fallback and could violate `fk_personal_records_profile`.

## Implementation

- Added `resolveDedicatedRecordLocalProfileId()` to normalize dedicated PR profile IDs against the set of profile IDs known valid for the current push.
- Populated `validLocalProfileIdsForPush` after local profile validation/upsert, and passed it into the PR row builder at runtime.
- Invalid per-record PR profile IDs now fall back to the sanitized active profile ID only when that fallback is valid; otherwise they are nulled so the row is unscoped and FK-safe.
- Preserved historical behavior for legacy payloads that provide only per-record profile IDs and no top-level/allProfiles data to validate against.
- Added regression coverage for valid IDs, stale IDs, undefined/null IDs, mixed batches, and the `buildPersonalRecordRowsForPush()` propagation path.

## Tests run

- `npx vitest run src/lib/__tests__/sync-personal-records.test.ts` — 35/35 passed
- `npx tsc --noEmit` — passed
- `npm test` — 118 files, 1235 passed, 16 skipped
- `npm run lint` — passed
- `npm run build` — passed

Fixes 9thLevelSoftware/phoenix-portal#72

User retains final merge approval; this automation will not merge.
