### PR TITLE
Normalize weight displays to the user’s preferred unit

### DIFF
--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -303,7 +303,7 @@ function mapServerInsight(
 			: description;
 
 	return {
-		id: (item.id as string) ?? `${title}-${description}`,
+		id: (item.id as string) ?? `${title}-${normalizedDescription}`,
 		type: normalizeInsightType(item.insight_type ?? item.type),
 		title,
 		description: normalizedDescription,

--- a/src/app/components/Analytics.tsx
+++ b/src/app/components/Analytics.tsx
@@ -59,7 +59,13 @@ import {
 import type { MuscleRecovery } from "@/lib/sra-recovery";
 import { computeSraStatus } from "@/lib/sra-recovery";
 import { calculateRTL, classifyTrainingLoad } from "@/lib/training-load";
-import { convertWeight, formatVolume, type WeightUnit } from "@/lib/units";
+import {
+	convertWeight,
+	convertWeightFromUnit,
+	formatVolume,
+	isWeightUnit,
+	type WeightUnit,
+} from "@/lib/units";
 import type { ExerciseSessionData } from "@/lib/volume-landmarks";
 import { computeWeeklyVolume } from "@/lib/volume-landmarks";
 import {
@@ -226,6 +232,84 @@ function convertStrengthSeriesPoint(
 			key === "date" ? value : convertWeight(Number(value), unit),
 		]),
 	) as Record<string, string | number>;
+}
+
+function toNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value)
+		? value
+		: undefined;
+}
+
+function roundDisplayMetric(value: number, unit: string): number {
+	if (isWeightUnit(unit)) {
+		return Number(value.toFixed(unit === "lbs" ? 1 : 0));
+	}
+	return value;
+}
+
+function formatMetricText(value: number, unit: string): string {
+	if (isWeightUnit(unit)) {
+		return `${roundDisplayMetric(value, unit).toLocaleString()} ${unit}`;
+	}
+	return `${value.toLocaleString()}${unit}`;
+}
+
+function normalizeInsightType(value: unknown): InsightItem["type"] {
+	return value === "success" ||
+		value === "warning" ||
+		value === "info" ||
+		value === "achievement"
+		? value
+		: "info";
+}
+
+function mapServerInsight(
+	item: Record<string, unknown>,
+	unit: WeightUnit,
+): InsightItem {
+	const sourceUnit = item.metric_unit;
+	const rawValue = toNumber(item.metric_value);
+	const rawDelta = toNumber(item.metric_delta);
+	const metricName = item.metric_name;
+	const metric =
+		typeof metricName === "string" && rawValue !== undefined
+			? {
+					name: metricName,
+					value: isWeightUnit(sourceUnit)
+						? roundDisplayMetric(
+								convertWeightFromUnit(rawValue, sourceUnit, unit),
+								unit,
+							)
+						: rawValue,
+					unit: isWeightUnit(sourceUnit) ? unit : String(sourceUnit ?? ""),
+					delta:
+						rawDelta !== undefined
+							? isWeightUnit(sourceUnit)
+								? roundDisplayMetric(
+										convertWeightFromUnit(rawDelta, sourceUnit, unit),
+										unit,
+									)
+								: rawDelta
+							: undefined,
+				}
+			: undefined;
+	const title = (item.title as string) ?? "";
+	const description = (item.description as string) ?? "";
+	const normalizedDescription =
+		metric && isWeightUnit(metric.unit) && title.startsWith("New PR:")
+			? metric.delta !== undefined
+				? `You set a personal record on ${metric.name} -- ${formatMetricText(metric.value, metric.unit)} (up ${formatMetricText(metric.delta, metric.unit)} from ${formatMetricText(metric.value - metric.delta, metric.unit)}).`
+				: `You set a personal record on ${metric.name} -- ${formatMetricText(metric.value, metric.unit)}.`
+			: description;
+
+	return {
+		id: (item.id as string) ?? `${title}-${description}`,
+		type: normalizeInsightType(item.insight_type ?? item.type),
+		title,
+		description: normalizedDescription,
+		recommendation: item.recommendation as string | undefined,
+		metric,
+	};
 }
 
 const EXERCISE_COLORS = [PHOENIX.ember, PHOENIX.flameRed, PHOENIX.gold];
@@ -1015,14 +1099,9 @@ export function Analytics() {
 			Array.isArray(insightsData) &&
 			insightsData.length > 0
 		) {
-			return insightsData.map((item: Record<string, unknown>) => ({
-				id: (item.id as string) ?? String(Math.random()),
-				type: ((item.type as string) ?? "info") as InsightItem["type"],
-				title: (item.title as string) ?? "",
-				description: (item.description as string) ?? "",
-				recommendation: item.recommendation as string | undefined,
-				metric: item.metric as InsightItem["metric"],
-			}));
+			return insightsData.map((item: Record<string, unknown>) =>
+				mapServerInsight(item, unit),
+			);
 		}
 		// Fallback: convert local insights to InsightsFeed format
 		return insights.map((i, idx) => ({
@@ -1036,7 +1115,7 @@ export function Analytics() {
 			title: i.title,
 			description: i.description,
 		}));
-	}, [insightsData, insights]);
+	}, [insightsData, insights, unit]);
 
 	// --- Muscle radar data ---
 	const muscleRadarData = useMemo(() => {

--- a/src/app/components/Biomechanics.tsx
+++ b/src/app/components/Biomechanics.tsx
@@ -36,6 +36,7 @@ import { Switch } from "@/app/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 
 import { useAuth } from "@/app/hooks/useAuth";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
 import { PHOENIX } from "@/lib/colors";
 import { repSummariesOptions, repTelemetryOptions } from "@/queries/telemetry";
 import { sessionDetailOptions, workoutListOptions } from "@/queries/workouts";
@@ -115,6 +116,7 @@ export function BiomechanicsContent({
 }: BiomechanicsContentProps) {
 	const { user } = useAuth();
 	const userId = user?.id ?? "";
+	const unit = usePreferredWeightUnit();
 	const showBiomechanics = view === "all" || view === "biomechanics";
 	const showPerformance = view === "all" || view === "performance";
 	const showExpandedSections = view === "all";
@@ -453,7 +455,7 @@ export function BiomechanicsContent({
 								</Section>
 
 								<Section title="Body Overview" icon={Activity}>
-									<MuscleHeatmap muscleVolumes={muscleVolumes} />
+									<MuscleHeatmap muscleVolumes={muscleVolumes} unit={unit} />
 								</Section>
 							</div>
 						</>
@@ -565,7 +567,7 @@ export function BiomechanicsContent({
 								icon={Activity}
 								className="col-span-full"
 							>
-								<SummaryReport userId={userId} />
+								<SummaryReport userId={userId} unit={unit} />
 							</Section>
 
 							<Section

--- a/src/app/components/Challenges.tsx
+++ b/src/app/components/Challenges.tsx
@@ -30,6 +30,8 @@ import {
 	TabsList,
 	TabsTrigger,
 } from "@/app/components/ui/tabs";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
+import { formatVolume, type WeightUnit } from "@/lib/units";
 import { useJoinChallenge, useLeaveChallenge } from "@/mutations/challenges";
 import { useAuth } from "@/providers/AuthProvider";
 import {
@@ -65,6 +67,18 @@ function getDaysRemaining(endDate: string) {
 	return Math.max(0, diff);
 }
 
+function formatChallengeValue(
+	value: number,
+	challengeType: string,
+	unit: WeightUnit,
+	targetUnit?: string | null,
+): string {
+	if (challengeType === "volume") {
+		return formatVolume(value, unit);
+	}
+	return `${value.toLocaleString()}${targetUnit ? ` ${targetUnit}` : ""}`;
+}
+
 // ---- Shared progress bar component ----
 
 function ChallengeProgressBar({
@@ -74,6 +88,7 @@ function ChallengeProgressBar({
 	targetValue,
 	startDate,
 	endDate,
+	unit,
 	compact = false,
 }: {
 	userId: string;
@@ -82,6 +97,7 @@ function ChallengeProgressBar({
 	targetValue: number;
 	startDate: string;
 	endDate: string;
+	unit: WeightUnit;
 	compact?: boolean;
 }) {
 	const { data: progress } = useQuery(
@@ -120,8 +136,8 @@ function ChallengeProgressBar({
 			<Progress value={percentage} className="h-3" />
 			{progress && (
 				<div className="text-xs text-muted-foreground mt-1 font-data">
-					{progress.current.toLocaleString()} /{" "}
-					{progress.target.toLocaleString()}
+					{formatChallengeValue(progress.current, challengeType, unit)} /{" "}
+					{formatChallengeValue(progress.target, challengeType, unit)}
 				</div>
 			)}
 		</div>
@@ -137,6 +153,7 @@ function ChallengeCard({
 	isExpanded,
 	daysRemaining: _daysRemaining,
 	userId,
+	unit,
 	onToggleExpand,
 	onJoin,
 	onLeave,
@@ -149,6 +166,7 @@ function ChallengeCard({
 	isExpanded: boolean;
 	daysRemaining: number;
 	userId: string;
+	unit: WeightUnit;
 	onToggleExpand: () => void;
 	onJoin: () => void;
 	onLeave: () => void;
@@ -199,6 +217,7 @@ function ChallengeCard({
 								targetValue={challenge.target_value}
 								startDate={challenge.start_date}
 								endDate={challenge.end_date}
+								unit={unit}
 							/>
 						)}
 
@@ -207,8 +226,12 @@ function ChallengeCard({
 							<div>
 								<div className="text-xs text-muted-foreground mb-1">Target</div>
 								<div className="text-xl text-white font-data">
-									{challenge.target_value.toLocaleString()}{" "}
-									{challenge.target_unit}
+									{formatChallengeValue(
+										challenge.target_value,
+										challenge.challenge_type,
+										unit,
+										challenge.target_unit,
+									)}
 								</div>
 							</div>
 							<div>
@@ -294,8 +317,12 @@ function ChallengeCard({
 							<div className="flex items-center gap-1">
 								<Target className="w-4 h-4" />
 								<span>
-									{challenge.target_value.toLocaleString()}{" "}
-									{challenge.target_unit}
+									{formatChallengeValue(
+										challenge.target_value,
+										challenge.challenge_type,
+										unit,
+										challenge.target_unit,
+									)}
 								</span>
 							</div>
 						</div>
@@ -395,10 +422,12 @@ function MobileChallengeCard({
 	challenge,
 	isJoined,
 	userId,
+	unit,
 }: {
 	challenge: Challenge;
 	isJoined: boolean;
 	userId: string;
+	unit: WeightUnit;
 }) {
 	return (
 		<Card className="p-4 bg-surface-2 border-secondary">
@@ -425,6 +454,7 @@ function MobileChallengeCard({
 							targetValue={challenge.target_value}
 							startDate={challenge.start_date}
 							endDate={challenge.end_date}
+							unit={unit}
 							compact
 						/>
 					)}
@@ -448,6 +478,7 @@ function MobileChallengeCard({
 
 export function Challenges() {
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 	const userId = user?.id ?? "";
 
 	const { data: challenges, isPending: challengesLoading } = useQuery(
@@ -580,6 +611,7 @@ export function Challenges() {
 													challenge={challenge}
 													isJoined={true}
 													userId={userId}
+													unit={unit}
 												/>
 											</SwipeableCard>
 											{mobileExpandedId === challenge.id && (
@@ -591,7 +623,15 @@ export function Challenges() {
 														<span className="capitalize">
 															{challenge.challenge_type}
 														</span>
-														<span>Target: {challenge.target_value}</span>
+														<span>
+															Target:{" "}
+															{formatChallengeValue(
+																challenge.target_value,
+																challenge.challenge_type,
+																unit,
+																challenge.target_unit,
+															)}
+														</span>
 														{challenge.prize && (
 															<span className="text-accent">
 																{challenge.prize}
@@ -759,6 +799,7 @@ export function Challenges() {
 										isExpanded={expandedId === challenge.id}
 										daysRemaining={getDaysRemaining(challenge.end_date)}
 										userId={userId}
+										unit={unit}
 										onToggleExpand={() =>
 											setExpandedId(
 												expandedId === challenge.id ? null : challenge.id,

--- a/src/app/components/Challenges.tsx
+++ b/src/app/components/Challenges.tsx
@@ -31,7 +31,8 @@ import {
 	TabsTrigger,
 } from "@/app/components/ui/tabs";
 import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
-import { formatVolume, type WeightUnit } from "@/lib/units";
+import { formatChallengeValue } from "@/lib/challenges";
+import type { WeightUnit } from "@/lib/units";
 import { useJoinChallenge, useLeaveChallenge } from "@/mutations/challenges";
 import { useAuth } from "@/providers/AuthProvider";
 import {
@@ -65,18 +66,6 @@ function getDaysRemaining(endDate: string) {
 		(end.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
 	);
 	return Math.max(0, diff);
-}
-
-function formatChallengeValue(
-	value: number,
-	challengeType: string,
-	unit: WeightUnit,
-	targetUnit?: string | null,
-): string {
-	if (challengeType === "volume") {
-		return formatVolume(value, unit);
-	}
-	return `${value.toLocaleString()}${targetUnit ? ` ${targetUnit}` : ""}`;
 }
 
 // ---- Shared progress bar component ----

--- a/src/app/components/ComparisonSessionPicker.tsx
+++ b/src/app/components/ComparisonSessionPicker.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/app/components/ui/dialog";
 import { Skeleton } from "@/app/components/ui/skeleton";
 import { useAuth } from "@/app/hooks/useAuth";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
+import { formatVolume } from "@/lib/units";
 import { workoutListOptions } from "@/queries/workouts";
 
 interface ComparisonSessionPickerProps {
@@ -27,6 +29,7 @@ export function ComparisonSessionPicker({
 	onSelect,
 }: ComparisonSessionPickerProps) {
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 	const { data: workouts, isPending } = useQuery(
 		workoutListOptions(user?.id ?? ""),
 	);
@@ -112,7 +115,7 @@ export function ComparisonSessionPicker({
 												<Clock className="w-3 h-3" />
 												{workout.duration_seconds}m
 											</span>
-											<span>{workout.total_volume.toLocaleString()} kg</span>
+											<span>{formatVolume(workout.total_volume, unit)}</span>
 										</div>
 									</div>
 								</div>

--- a/src/app/components/ComparisonView.tsx
+++ b/src/app/components/ComparisonView.tsx
@@ -22,12 +22,14 @@ import {
 	TabsTrigger,
 } from "@/app/components/ui/tabs";
 import { useIsMobile } from "@/app/hooks/useIsMobile";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
 import { useSubscription } from "@/hooks/useSubscription";
 import {
 	type ComparisonResult,
 	compareSessions,
 	type SessionSummary,
 } from "@/lib/comparison";
+import { formatVolume, type WeightUnit } from "@/lib/units";
 import { comparisonDetailOptions } from "@/queries/workouts";
 
 function DeltaIndicator({
@@ -77,9 +79,11 @@ function formatSessionDate(d: Date): string {
 function SessionSummaryCard({
 	summary,
 	label,
+	unit,
 }: {
 	summary: SessionSummary;
 	label: string;
+	unit: WeightUnit;
 }) {
 	return (
 		<Card className="bg-surface-2 border-secondary p-5">
@@ -99,7 +103,7 @@ function SessionSummaryCard({
 				<div>
 					<div className="text-muted-foreground">Volume</div>
 					<div className="text-white font-semibold font-data">
-						{summary.totalVolume.toLocaleString()} kg
+						{formatVolume(summary.totalVolume, unit)}
 					</div>
 				</div>
 				<div>
@@ -149,7 +153,13 @@ function OverallDeltas({ result }: { result: ComparisonResult }) {
 	);
 }
 
-function ExerciseBreakdownTable({ result }: { result: ComparisonResult }) {
+function ExerciseBreakdownTable({
+	result,
+	unit,
+}: {
+	result: ComparisonResult;
+	unit: WeightUnit;
+}) {
 	return (
 		<Card className="bg-surface-2 border-secondary p-5">
 			<h3 className="text-sm text-muted-foreground uppercase tracking-wider mb-4">
@@ -188,14 +198,14 @@ function ExerciseBreakdownTable({ result }: { result: ComparisonResult }) {
 									{ex.onlyInB ? (
 										<span className="text-muted-foreground">—</span>
 									) : (
-										`${ex.volumeA.toLocaleString()} kg`
+										formatVolume(ex.volumeA, unit)
 									)}
 								</td>
 								<td className="py-3 text-right text-secondary-foreground">
 									{ex.onlyInA ? (
 										<span className="text-muted-foreground">—</span>
 									) : (
-										`${ex.volumeB.toLocaleString()} kg`
+										formatVolume(ex.volumeB, unit)
 									)}
 								</td>
 								<td className="py-3 text-right">
@@ -243,7 +253,13 @@ function ExerciseBreakdownTable({ result }: { result: ComparisonResult }) {
 	);
 }
 
-function ExerciseBreakdownMobile({ result }: { result: ComparisonResult }) {
+function ExerciseBreakdownMobile({
+	result,
+	unit,
+}: {
+	result: ComparisonResult;
+	unit: WeightUnit;
+}) {
 	return (
 		<div className="space-y-3">
 			<h3 className="text-sm text-muted-foreground uppercase tracking-wider">
@@ -264,7 +280,8 @@ function ExerciseBreakdownMobile({ result }: { result: ComparisonResult }) {
 
 							<div className="text-secondary-foreground">Volume</div>
 							<div className="text-center text-secondary-foreground font-data">
-								{ex.volumeA.toLocaleString()} / {ex.volumeB.toLocaleString()}
+								{formatVolume(ex.volumeA, unit)} /{" "}
+								{formatVolume(ex.volumeB, unit)}
 							</div>
 							<div className="text-right">
 								<DeltaIndicator value={ex.deltaPct} />
@@ -294,6 +311,7 @@ export function ComparisonView() {
 	const [searchParams, setSearchParams] = useSearchParams();
 	const navigate = useNavigate();
 	const isMobile = useIsMobile();
+	const unit = usePreferredWeightUnit();
 	const { isPremium, isLoading: subLoading } = useSubscription();
 
 	const sessionAId = searchParams.get("a") ?? "";
@@ -597,10 +615,18 @@ export function ComparisonView() {
 								<TabsTrigger value="b">Session B</TabsTrigger>
 							</TabsList>
 							<TabsContent value="a">
-								<SessionSummaryCard summary={summaryA} label="Session A" />
+								<SessionSummaryCard
+									summary={summaryA}
+									label="Session A"
+									unit={unit}
+								/>
 							</TabsContent>
 							<TabsContent value="b">
-								<SessionSummaryCard summary={summaryB} label="Session B" />
+								<SessionSummaryCard
+									summary={summaryB}
+									label="Session B"
+									unit={unit}
+								/>
 							</TabsContent>
 						</Tabs>
 					</motion.div>
@@ -611,8 +637,16 @@ export function ComparisonView() {
 						transition={{ delay: 0.1 }}
 						className="grid grid-cols-2 gap-4"
 					>
-						<SessionSummaryCard summary={summaryA} label="Session A" />
-						<SessionSummaryCard summary={summaryB} label="Session B" />
+						<SessionSummaryCard
+							summary={summaryA}
+							label="Session A"
+							unit={unit}
+						/>
+						<SessionSummaryCard
+							summary={summaryB}
+							label="Session B"
+							unit={unit}
+						/>
 					</motion.div>
 				)}
 
@@ -632,9 +666,9 @@ export function ComparisonView() {
 					transition={{ delay: 0.3 }}
 				>
 					{isMobile ? (
-						<ExerciseBreakdownMobile result={result} />
+						<ExerciseBreakdownMobile result={result} unit={unit} />
 					) : (
-						<ExerciseBreakdownTable result={result} />
+						<ExerciseBreakdownTable result={result} unit={unit} />
 					)}
 				</motion.div>
 			</div>

--- a/src/app/components/CycleBuilder.tsx
+++ b/src/app/components/CycleBuilder.tsx
@@ -37,7 +37,14 @@ import { Switch } from "@/app/components/ui/switch";
 import { Textarea } from "@/app/components/ui/textarea";
 import { UnsavedChangesDialog } from "@/app/components/ui/unsaved-changes-dialog";
 import { useAuth } from "@/app/hooks/useAuth";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
 import type { Json } from "@/lib/database.types";
+import {
+	formatWeight,
+	type WeightUnit,
+	weightInputToKg,
+	weightInputValue,
+} from "@/lib/units";
 import { useSaveCycle, useUpdateCycle } from "@/mutations/cycles";
 import { cycleDetailOptions } from "@/queries/cycles";
 import { routineListOptions } from "@/queries/routines";
@@ -106,6 +113,7 @@ export function CycleBuilder() {
 
 	// Fetch real routines from Supabase
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 	const { data: routinesRaw } = useQuery({
 		...routineListOptions(user?.id ?? ""),
 		enabled: !!user?.id,
@@ -624,6 +632,7 @@ export function CycleBuilder() {
 							setDeloadVolume(v);
 							setHasUnsavedChanges(true);
 						}}
+						unit={unit}
 					/>
 				</motion.div>
 
@@ -728,6 +737,7 @@ export function CycleBuilder() {
 							}
 						: null,
 				}}
+				unit={unit}
 			/>
 
 			{/* Unsaved Changes Dialog */}
@@ -1072,6 +1082,7 @@ function ProgressionRules({
 	onDeloadIntensityChange,
 	deloadVolume,
 	onDeloadVolumeChange,
+	unit,
 }: {
 	progressionType: "percentage" | "fixed" | "manual";
 	onProgressionTypeChange: (v: "percentage" | "fixed" | "manual") => void;
@@ -1095,7 +1106,14 @@ function ProgressionRules({
 	onDeloadIntensityChange: (v: number) => void;
 	deloadVolume: number;
 	onDeloadVolumeChange: (v: number) => void;
+	unit: WeightUnit;
 }) {
+	const progressionAmountDisplay =
+		progressionType === "fixed"
+			? weightInputValue(progressionAmount, unit)
+			: progressionAmount;
+	const fixedStep = unit === "lbs" ? 0.5 : 0.25;
+
 	return (
 		<Card className="p-6 bg-surface-2 border-secondary">
 			<h2 className="text-xl font-semibold text-white mb-6 flex items-center gap-2">
@@ -1139,16 +1157,20 @@ function ProgressionRules({
 							<Label className="text-secondary-foreground mb-2">
 								{progressionType === "percentage"
 									? "Increase (%)"
-									: "Increase (kg)"}
+									: `Increase (${unit})`}
 							</Label>
 							<Input
 								type="number"
-								value={progressionAmount}
+								value={progressionAmountDisplay}
 								onChange={(e) =>
-									onProgressionAmountChange(parseFloat(e.target.value) || 0)
+									onProgressionAmountChange(
+										progressionType === "fixed"
+											? weightInputToKg(e.target.value, unit)
+											: parseFloat(e.target.value) || 0,
+									)
 								}
 								className="bg-background border-secondary"
-								step={progressionType === "percentage" ? 0.5 : 0.25}
+								step={progressionType === "percentage" ? 0.5 : fixedStep}
 								min={0}
 							/>
 						</div>
@@ -1206,31 +1228,35 @@ function ProgressionRules({
 				<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
 					<div>
 						<Label className="text-secondary-foreground mb-2">
-							Upper Body Increment (kg)
+							Upper Body Increment ({unit})
 						</Label>
 						<Input
 							type="number"
-							value={upperBodyIncrement}
+							value={weightInputValue(upperBodyIncrement, unit)}
 							onChange={(e) =>
-								onUpperBodyIncrementChange(parseFloat(e.target.value) || 0)
+								onUpperBodyIncrementChange(
+									weightInputToKg(e.target.value, unit),
+								)
 							}
 							className="bg-background border-secondary"
-							step={0.25}
+							step={fixedStep}
 							min={0}
 						/>
 					</div>
 					<div>
 						<Label className="text-secondary-foreground mb-2">
-							Lower Body Increment (kg)
+							Lower Body Increment ({unit})
 						</Label>
 						<Input
 							type="number"
-							value={lowerBodyIncrement}
+							value={weightInputValue(lowerBodyIncrement, unit)}
 							onChange={(e) =>
-								onLowerBodyIncrementChange(parseFloat(e.target.value) || 0)
+								onLowerBodyIncrementChange(
+									weightInputToKg(e.target.value, unit),
+								)
 							}
 							className="bg-background border-secondary"
-							step={0.5}
+							step={fixedStep}
 							min={0}
 						/>
 					</div>
@@ -1310,6 +1336,7 @@ function PreviewModal({
 	isOpen,
 	onClose,
 	cycle,
+	unit,
 }: {
 	isOpen: boolean;
 	onClose: () => void;
@@ -1326,6 +1353,7 @@ function PreviewModal({
 		};
 		deload: { frequency: number; intensity: number; volume: number } | null;
 	};
+	unit: WeightUnit;
 }) {
 	const workoutDays = cycle.days.filter((d) => d.type === "workout").length;
 	const restDays = cycle.days.filter((d) => d.type === "rest").length;
@@ -1417,8 +1445,9 @@ function PreviewModal({
 								<div className="text-sm text-white">
 									Amount:{" "}
 									<span className="text-primary">
-										{cycle.progression.amount}
-										{cycle.progression.type === "percentage" ? "%" : "kg"}
+										{cycle.progression.type === "percentage"
+											? `${cycle.progression.amount}%`
+											: formatWeight(cycle.progression.amount, unit)}
 									</span>
 								</div>
 							)}

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -36,6 +36,7 @@ import {
 import { useAuth } from "@/app/hooks/useAuth";
 import { useStreak } from "@/hooks/useStreak";
 import { fadeUp, hover, staggerContainer } from "@/lib/animations";
+import { formatChallengeValue } from "@/lib/challenges";
 import { PHOENIX } from "@/lib/colors";
 import {
 	convertWeight,
@@ -189,18 +190,6 @@ function MobileRecentActivityCard({
 			</div>
 		</Card>
 	);
-}
-
-function formatChallengeValue(
-	value: number,
-	challengeType: string,
-	unit: WeightUnit,
-	targetUnit?: string | null,
-): string {
-	if (challengeType === "volume") {
-		return formatVolume(value, unit);
-	}
-	return `${value.toLocaleString()}${targetUnit ? ` ${targetUnit}` : ""}`;
 }
 
 function ActiveChallengesSection({

--- a/src/app/components/Dashboard.tsx
+++ b/src/app/components/Dashboard.tsx
@@ -191,7 +191,25 @@ function MobileRecentActivityCard({
 	);
 }
 
-function ActiveChallengesSection({ userId }: { userId: string }) {
+function formatChallengeValue(
+	value: number,
+	challengeType: string,
+	unit: WeightUnit,
+	targetUnit?: string | null,
+): string {
+	if (challengeType === "volume") {
+		return formatVolume(value, unit);
+	}
+	return `${value.toLocaleString()}${targetUnit ? ` ${targetUnit}` : ""}`;
+}
+
+function ActiveChallengesSection({
+	userId,
+	unit,
+}: {
+	userId: string;
+	unit: WeightUnit;
+}) {
 	const {
 		data: userChallenges,
 		isPending,
@@ -289,8 +307,12 @@ function ActiveChallengesSection({ userId }: { userId: string }) {
 									{challenge.name}
 								</h4>
 								<p className="text-xs text-muted-foreground">
-									{challenge.target_value.toLocaleString()}
-									{challenge.target_unit ? ` ${challenge.target_unit}` : ""}{" "}
+									{formatChallengeValue(
+										challenge.target_value,
+										challenge.challenge_type,
+										unit,
+										challenge.target_unit,
+									)}{" "}
 									target
 								</p>
 							</div>
@@ -310,7 +332,15 @@ function ActiveChallengesSection({ userId }: { userId: string }) {
 						<Progress value={progress?.percentage ?? 0} className="h-2" />
 						<p className="mt-2 text-xs text-muted-foreground">
 							{progress
-								? `${Math.round(progress.current).toLocaleString()} / ${Math.round(progress.target).toLocaleString()}`
+								? `${formatChallengeValue(
+										Math.round(progress.current),
+										challenge.challenge_type,
+										unit,
+									)} / ${formatChallengeValue(
+										Math.round(progress.target),
+										challenge.challenge_type,
+										unit,
+									)}`
 								: "Calculating progress..."}
 						</p>
 					</div>
@@ -1363,7 +1393,10 @@ export function Dashboard() {
 							<motion.div variants={fadeUp}>
 								<Card className="p-5 signal-panel">
 									<h3 className="text-xl text-white mb-4">Active Challenges</h3>
-									<ActiveChallengesSection userId={user?.id ?? ""} />
+									<ActiveChallengesSection
+										userId={user?.id ?? ""}
+										unit={unit}
+									/>
 								</Card>
 							</motion.div>
 

--- a/src/app/components/GoalDashboardWidget.tsx
+++ b/src/app/components/GoalDashboardWidget.tsx
@@ -4,7 +4,9 @@ import { Link } from "react-router";
 import { Button } from "@/app/components/ui/button";
 import { Card } from "@/app/components/ui/card";
 import { useAuth } from "@/app/hooks/useAuth";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
 import { useSubscription } from "@/hooks/useSubscription";
+import { formatVolume, formatWeight, type WeightUnit } from "@/lib/units";
 import { goalsOptions } from "@/queries/goals";
 import { useProfileFilterStore } from "@/stores/useProfileFilterStore";
 import { GoalProgressRing } from "./GoalProgressRing";
@@ -12,6 +14,7 @@ import { useGoalProgress } from "./Goals";
 
 export function GoalDashboardWidget() {
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 	const { isPremium } = useSubscription();
 	const { data: goals } = useQuery({
 		...goalsOptions(user?.id ?? ""),
@@ -99,10 +102,10 @@ export function GoalDashboardWidget() {
 								/>
 								<div className="flex-1 min-w-0">
 									<p className="text-sm text-white truncate">
-										{getGoalLabel(goal)}
+										{getGoalLabel(goal, unit)}
 									</p>
 									<p className="text-xs text-muted-foreground">
-										{getGoalProgressText(goal, progress)}
+										{getGoalProgressText(goal, progress, unit)}
 									</p>
 								</div>
 							</div>
@@ -114,19 +117,22 @@ export function GoalDashboardWidget() {
 	);
 }
 
-function getGoalLabel(goal: {
-	goal_type: string;
-	target_value: number;
-	target_unit: string;
-	exercise_name: string | null;
-}): string {
+function getGoalLabel(
+	goal: {
+		goal_type: string;
+		target_value: number;
+		target_unit: string;
+		exercise_name: string | null;
+	},
+	unit: WeightUnit,
+): string {
 	switch (goal.goal_type) {
 		case "frequency":
 			return `${goal.target_value} workouts / ${goal.target_unit === "workouts/month" ? "month" : "week"}`;
 		case "volume":
-			return `${goal.target_value.toLocaleString()} kg / ${goal.target_unit === "kg/month" ? "month" : "week"}`;
+			return `${formatVolume(goal.target_value, unit)} / ${goal.target_unit === "kg/month" ? "month" : "week"}`;
 		case "pr":
-			return `${goal.exercise_name}: ${goal.target_value} kg PR`;
+			return `${goal.exercise_name}: ${formatWeight(goal.target_value, unit)} PR`;
 		default:
 			return "Goal";
 	}
@@ -135,13 +141,14 @@ function getGoalLabel(goal: {
 function getGoalProgressText(
 	goal: { goal_type: string; target_value: number },
 	progress: number,
+	unit: WeightUnit,
 ): string {
 	const achieved = Math.round((progress / 100) * goal.target_value);
 	if (goal.goal_type === "frequency") {
 		return `${achieved}/${goal.target_value} workouts`;
 	}
 	if (goal.goal_type === "volume") {
-		return `${achieved.toLocaleString()}/${goal.target_value.toLocaleString()} kg`;
+		return `${formatVolume(achieved, unit)}/${formatVolume(goal.target_value, unit)}`;
 	}
 	return `${progress >= 100 ? "Achieved" : `${Math.round(progress)}%`}`;
 }

--- a/src/app/components/Goals.tsx
+++ b/src/app/components/Goals.tsx
@@ -47,7 +47,15 @@ import {
 } from "@/app/components/ui/tabs";
 import { cn } from "@/app/components/ui/utils";
 import { useAuth } from "@/app/hooks/useAuth";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
 import { useSubscription } from "@/hooks/useSubscription";
+import {
+	formatVolume,
+	formatWeight,
+	type WeightUnit,
+	weightInputToKg,
+	weightInputValue,
+} from "@/lib/units";
 import {
 	useArchiveGoal,
 	useCreateGoal,
@@ -155,26 +163,30 @@ const goalTypeIcons = {
 	pr: Award,
 };
 
-function getGoalDescription(goal: Goal): string {
+function getGoalDescription(goal: Goal, unit: WeightUnit): string {
 	switch (goal.goal_type) {
 		case "frequency":
 			return `${goal.target_value} workouts per ${goal.period === "monthly" ? "month" : "week"}`;
 		case "volume":
-			return `${goal.target_value.toLocaleString()} kg per ${goal.period === "monthly" ? "month" : "week"}`;
+			return `${formatVolume(goal.target_value, unit)} per ${goal.period === "monthly" ? "month" : "week"}`;
 		case "pr":
-			return `${goal.exercise_name}: ${goal.target_value} kg`;
+			return `${goal.exercise_name}: ${formatWeight(goal.target_value, unit)}`;
 		default:
 			return "Goal";
 	}
 }
 
-function getProgressText(goal: Goal, progress: number): string {
+function getProgressText(
+	goal: Goal,
+	progress: number,
+	unit: WeightUnit,
+): string {
 	const achieved = Math.round((progress / 100) * goal.target_value);
 	switch (goal.goal_type) {
 		case "frequency":
 			return `${achieved}/${goal.target_value} workouts this ${goal.period === "monthly" ? "month" : "week"}`;
 		case "volume":
-			return `${achieved.toLocaleString()}/${goal.target_value.toLocaleString()} kg this ${goal.period === "monthly" ? "month" : "week"}`;
+			return `${formatVolume(achieved, unit)}/${formatVolume(goal.target_value, unit)} this ${goal.period === "monthly" ? "month" : "week"}`;
 		case "pr":
 			return progress >= 100
 				? "Target reached!"
@@ -275,6 +287,7 @@ function ExerciseNameCombobox({
 
 export function Goals() {
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 	const { isPremium, isInferno } = useSubscription();
 	const { activeProfileId } = useProfileFilterStore();
 	const { data: goals, isPending } = useQuery(goalsOptions(user?.id ?? ""));
@@ -508,11 +521,11 @@ export function Goals() {
 												<div className="flex items-center gap-2 mb-1">
 													<Icon className="w-4 h-4 text-primary" />
 													<h3 className="text-lg font-semibold text-white">
-														{getGoalDescription(goal)}
+														{getGoalDescription(goal, unit)}
 													</h3>
 												</div>
 												<p className="text-sm text-muted-foreground font-data">
-													{getProgressText(goal, progress)}
+													{getProgressText(goal, progress, unit)}
 												</p>
 												{goal.deadline && (
 													<p className="text-xs text-muted-foreground mt-1">
@@ -583,7 +596,7 @@ export function Goals() {
 											</div>
 											<div>
 												<p className="text-sm text-white">
-													{getGoalDescription(goal)}
+													{getGoalDescription(goal, unit)}
 												</p>
 												<p className="text-xs text-muted-foreground">
 													Completed{" "}
@@ -636,7 +649,7 @@ export function Goals() {
 												</div>
 												<div>
 													<p className="text-sm text-muted-foreground">
-														{getGoalDescription(goal)}
+														{getGoalDescription(goal, unit)}
 													</p>
 													<p className="text-xs text-muted-foreground mt-0.5">
 														Archived {goal.updated_at.toLocaleDateString()}
@@ -687,6 +700,7 @@ export function Goals() {
 				open={createOpen}
 				onOpenChange={setCreateOpen}
 				title="Create Goal"
+				unit={unit}
 				exerciseNames={knownExerciseNames}
 				onSubmit={(data) => {
 					createGoal.mutate({
@@ -706,6 +720,7 @@ export function Goals() {
 					}}
 					title="Edit Goal"
 					isEdit
+					unit={unit}
 					exerciseNames={knownExerciseNames}
 					defaultValues={{
 						goal_type: editGoal.goal_type,
@@ -742,6 +757,7 @@ interface GoalFormDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	title: string;
+	unit: WeightUnit;
 	/** When true, goal type tabs are hidden (type cannot change after creation). */
 	isEdit?: boolean;
 	/** Known exercise names for PR goal autocomplete. */
@@ -768,6 +784,7 @@ function GoalFormDialog({
 	open,
 	onOpenChange,
 	title,
+	unit,
 	isEdit = false,
 	exerciseNames = [],
 	defaultValues,
@@ -776,9 +793,11 @@ function GoalFormDialog({
 	const [goalType, setGoalType] = useState<"frequency" | "volume" | "pr">(
 		defaultValues?.goal_type ?? "frequency",
 	);
-	const [targetValue, setTargetValue] = useState(
-		defaultValues?.target_value?.toString() ?? "",
-	);
+	const initialTargetValue =
+		defaultValues?.goal_type === "volume" || defaultValues?.goal_type === "pr"
+			? weightInputValue(defaultValues.target_value, unit)
+			: (defaultValues?.target_value?.toString() ?? "");
+	const [targetValue, setTargetValue] = useState(initialTargetValue);
 	const [exerciseName, setExerciseName] = useState(
 		defaultValues?.exercise_name ?? "",
 	);
@@ -791,7 +810,12 @@ function GoalFormDialog({
 	useEffect(() => {
 		if (open) {
 			setGoalType(defaultValues?.goal_type ?? "frequency");
-			setTargetValue(defaultValues?.target_value?.toString() ?? "");
+			setTargetValue(
+				defaultValues?.goal_type === "volume" ||
+					defaultValues?.goal_type === "pr"
+					? weightInputValue(defaultValues.target_value, unit)
+					: (defaultValues?.target_value?.toString() ?? ""),
+			);
 			setExerciseName(defaultValues?.exercise_name ?? "");
 			setDeadline(defaultValues?.deadline ?? "");
 			setPeriod(defaultValues?.period ?? "weekly");
@@ -800,6 +824,7 @@ function GoalFormDialog({
 		open,
 		defaultValues?.goal_type,
 		defaultValues?.target_value,
+		unit,
 		defaultValues?.exercise_name,
 		defaultValues?.deadline,
 		defaultValues?.period,
@@ -817,7 +842,11 @@ function GoalFormDialog({
 	};
 
 	const handleSubmit = () => {
-		const value = parseFloat(targetValue);
+		const parsedValue = parseFloat(targetValue);
+		const value =
+			goalType === "volume" || goalType === "pr"
+				? weightInputToKg(targetValue, unit)
+				: parsedValue;
 		if (Number.isNaN(value) || value <= 0) return;
 		if (goalType === "pr" && !exerciseName.trim()) return;
 
@@ -933,14 +962,14 @@ function GoalFormDialog({
 						<TabsContent value="volume" className="space-y-4 mt-4">
 							<div>
 								<Label htmlFor="vol-target">
-									Target volume (kg) per{" "}
+									Target volume ({unit}) per{" "}
 									{period === "monthly" ? "month" : "week"}
 								</Label>
 								<Input
 									id="vol-target"
 									type="number"
 									min={1}
-									placeholder="e.g. 10000"
+									placeholder={unit === "lbs" ? "e.g. 22000" : "e.g. 10000"}
 									value={targetValue}
 									onChange={(e) => setTargetValue(e.target.value)}
 									className="mt-1 bg-input/30"
@@ -990,7 +1019,7 @@ function GoalFormDialog({
 								/>
 							</div>
 							<div>
-								<Label htmlFor="pr-target">Target Weight (kg)</Label>
+								<Label htmlFor="pr-target">Target Weight ({unit})</Label>
 								<Input
 									id="pr-target"
 									type="number"

--- a/src/app/components/InsightsFeed.tsx
+++ b/src/app/components/InsightsFeed.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Info, TrendingUp, Trophy } from "lucide-react";
 import { Card, CardContent } from "@/app/components/ui/card";
 import { Skeleton } from "@/app/components/ui/skeleton";
+import { isWeightUnit } from "@/lib/units";
 
 export interface InsightItem {
 	id: string;
@@ -34,6 +35,13 @@ const TYPE_CONFIG = {
 		Icon: Trophy,
 	},
 } as const;
+
+function formatMetric(value: number, unit: string): string {
+	const formattedValue = value.toLocaleString();
+	return isWeightUnit(unit)
+		? `${formattedValue} ${unit}`
+		: `${formattedValue}${unit}`;
+}
 
 function InsightSkeleton() {
 	return (
@@ -109,8 +117,7 @@ export function InsightsFeed({ insights, loading = false }: InsightsFeedProps) {
 											{insight.metric.name}:
 										</span>
 										<span className="text-xs font-medium text-foreground">
-											{insight.metric.value}
-											{insight.metric.unit}
+											{formatMetric(insight.metric.value, insight.metric.unit)}
 										</span>
 										{insight.metric.delta !== undefined && (
 											<span
@@ -121,8 +128,10 @@ export function InsightsFeed({ insights, loading = false }: InsightsFeedProps) {
 												}}
 											>
 												{insight.metric.delta >= 0 ? "+" : ""}
-												{insight.metric.delta}
-												{insight.metric.unit}
+												{formatMetric(
+													insight.metric.delta,
+													insight.metric.unit,
+												)}
 											</span>
 										)}
 									</div>

--- a/src/app/components/Leaderboard.tsx
+++ b/src/app/components/Leaderboard.tsx
@@ -16,6 +16,8 @@ import {
 	TabsList,
 	TabsTrigger,
 } from "@/app/components/ui/tabs";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
+import { formatLeaderboardValue, type WeightUnit } from "@/lib/units";
 import { useAuth } from "@/providers/AuthProvider";
 import {
 	type GlobalLeaderboard,
@@ -50,9 +52,9 @@ function getRankBg(rank: number): string {
 	return "bg-card border-border";
 }
 
-function formatValue(value: number, metric: string): string {
+function formatValue(value: number, metric: string, unit: WeightUnit): string {
 	if (metric.toLowerCase().includes("volume")) {
-		return value >= 1000 ? `${(value / 1000).toFixed(1)}k kg` : `${value} kg`;
+		return formatLeaderboardValue(value, metric, unit);
 	}
 	if (
 		metric.toLowerCase().includes("streak") ||
@@ -69,10 +71,11 @@ function formatValue(value: number, metric: string): string {
 interface EntryRowProps {
 	entry: LeaderboardEntry;
 	metric: string;
+	unit: WeightUnit;
 	isCurrentUser: boolean;
 }
 
-function EntryRow({ entry, metric, isCurrentUser }: EntryRowProps) {
+function EntryRow({ entry, metric, unit, isCurrentUser }: EntryRowProps) {
 	return (
 		<motion.div
 			initial={{ opacity: 0, x: -8 }}
@@ -105,7 +108,7 @@ function EntryRow({ entry, metric, isCurrentUser }: EntryRowProps) {
 			</div>
 
 			<span className="shrink-0 text-sm font-semibold text-foreground">
-				{formatValue(entry.value, metric)}
+				{formatValue(entry.value, metric, unit)}
 			</span>
 		</motion.div>
 	);
@@ -118,6 +121,7 @@ interface RankingCardProps {
 	icon: React.ReactNode;
 	entries: LeaderboardEntry[];
 	metric: string;
+	unit: WeightUnit;
 	currentUserId: string | undefined;
 	userEntry?: LeaderboardEntry;
 }
@@ -127,6 +131,7 @@ function RankingCard({
 	icon,
 	entries,
 	metric,
+	unit,
 	currentUserId,
 	userEntry,
 }: RankingCardProps) {
@@ -154,6 +159,7 @@ function RankingCard({
 							key={entry.userId}
 							entry={entry}
 							metric={metric}
+							unit={unit}
 							isCurrentUser={entry.userId === currentUserId}
 						/>
 					))
@@ -166,7 +172,12 @@ function RankingCard({
 							<span className="text-xs text-muted-foreground">your rank</span>
 							<div className="h-px flex-1 bg-border" />
 						</div>
-						<EntryRow entry={userEntry} metric={metric} isCurrentUser />
+						<EntryRow
+							entry={userEntry}
+							metric={metric}
+							unit={unit}
+							isCurrentUser
+						/>
 					</>
 				)}
 			</CardContent>
@@ -196,12 +207,14 @@ function RankingCardSkeleton() {
 interface GlobalRankingsProps {
 	data: GlobalLeaderboard | undefined;
 	isLoading: boolean;
+	unit: WeightUnit;
 	currentUserId: string | undefined;
 }
 
 function GlobalRankings({
 	data,
 	isLoading,
+	unit,
 	currentUserId,
 }: GlobalRankingsProps) {
 	if (isLoading) {
@@ -284,6 +297,7 @@ function GlobalRankings({
 					icon={icon}
 					entries={data[key]}
 					metric={metricLabel}
+					unit={unit}
 					currentUserId={currentUserId}
 					userEntry={findUserEntry(data[key], currentUserId)}
 				/>
@@ -297,12 +311,14 @@ function GlobalRankings({
 interface WeeklyChallengeProps {
 	data: WeeklyCompetition | undefined;
 	isLoading: boolean;
+	unit: WeightUnit;
 	currentUserId: string | undefined;
 }
 
 function WeeklyChallengeTab({
 	data,
 	isLoading,
+	unit,
 	currentUserId,
 }: WeeklyChallengeProps) {
 	if (isLoading) {
@@ -392,6 +408,7 @@ function WeeklyChallengeTab({
 								key={entry.userId}
 								entry={entry}
 								metric={data.metric}
+								unit={unit}
 								isCurrentUser={entry.userId === currentUserId}
 							/>
 						))
@@ -408,6 +425,7 @@ interface MyRankingsProps {
 	data: UserRanking[] | undefined;
 	isLoading: boolean;
 	isLoggedIn: boolean;
+	unit: WeightUnit;
 }
 
 const METRIC_META: Record<
@@ -417,7 +435,7 @@ const METRIC_META: Record<
 	totalVolume: {
 		label: "Total Volume",
 		icon: <TrendingUp className="size-4 text-primary" />,
-		unit: "kg",
+		unit: "",
 	},
 	workoutCount: {
 		label: "Workout Count",
@@ -446,7 +464,7 @@ const METRIC_META: Record<
 	},
 };
 
-function MyRankingsTab({ data, isLoading, isLoggedIn }: MyRankingsProps) {
+function MyRankingsTab({ data, isLoading, isLoggedIn, unit }: MyRankingsProps) {
 	if (!isLoggedIn) {
 		return (
 			<Card className="border-border p-8 text-center text-sm text-muted-foreground">
@@ -478,6 +496,9 @@ function MyRankingsTab({ data, isLoading, isLoggedIn }: MyRankingsProps) {
 		<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			{data.map((ranking, index) => {
 				const meta = METRIC_META[ranking.metric];
+				const valueLabel = ranking.metric.toLowerCase().includes("volume")
+					? formatLeaderboardValue(ranking.value, ranking.metric, unit)
+					: `${ranking.value.toLocaleString()} ${meta?.unit ?? ""}`;
 				return (
 					<motion.div
 						key={ranking.metric}
@@ -510,7 +531,7 @@ function MyRankingsTab({ data, isLoading, isLoggedIn }: MyRankingsProps) {
 											Top {ranking.percentile}%
 										</p>
 										<p className="text-xs text-muted-foreground">
-											{ranking.value.toLocaleString()} {meta?.unit ?? ""}
+											{valueLabel}
 										</p>
 									</div>
 								</div>
@@ -527,6 +548,7 @@ function MyRankingsTab({ data, isLoading, isLoggedIn }: MyRankingsProps) {
 
 export function Leaderboard() {
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 
 	const { data: globalData, isLoading: globalLoading } = useQuery(
 		globalLeaderboardOptions(),
@@ -582,6 +604,7 @@ export function Leaderboard() {
 						<GlobalRankings
 							data={globalData}
 							isLoading={globalLoading}
+							unit={unit}
 							currentUserId={user?.id}
 						/>
 					</TabsContent>
@@ -590,6 +613,7 @@ export function Leaderboard() {
 						<WeeklyChallengeTab
 							data={weeklyData}
 							isLoading={weeklyLoading}
+							unit={unit}
 							currentUserId={user?.id}
 						/>
 					</TabsContent>
@@ -599,6 +623,7 @@ export function Leaderboard() {
 							data={userRankings}
 							isLoading={userRankingsLoading}
 							isLoggedIn={user != null}
+							unit={unit}
 						/>
 					</TabsContent>
 				</Tabs>

--- a/src/app/components/MuscleHeatmap.tsx
+++ b/src/app/components/MuscleHeatmap.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from "react";
 import { PHOENIX } from "@/lib/colors";
+import { formatVolume, type WeightUnit } from "@/lib/units";
 
 export interface MuscleHeatmapProps {
 	muscleVolumes: Record<string, number>;
+	unit?: WeightUnit;
 }
 
 interface MuscleRegion {
@@ -191,13 +193,10 @@ const BODY_OUTLINE_BACK =
 
 const EMBER = PHOENIX.ember;
 
-function formatVolume(value: number): string {
-	return value >= 1000
-		? `${(value / 1000).toFixed(1)}K kg`
-		: `${Math.round(value)} kg`;
-}
-
-export function MuscleHeatmap({ muscleVolumes }: MuscleHeatmapProps) {
+export function MuscleHeatmap({
+	muscleVolumes,
+	unit = "kg",
+}: MuscleHeatmapProps) {
 	const [hoveredGroup, setHoveredGroup] = useState<string | null>(null);
 	const [hoveredDataKey, setHoveredDataKey] = useState<string | null>(null);
 	const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
@@ -346,7 +345,7 @@ export function MuscleHeatmap({ muscleVolumes }: MuscleHeatmapProps) {
 					</span>
 					:{" "}
 					{(muscleVolumes[hoveredDataKey] ?? 0) > 0
-						? formatVolume(muscleVolumes[hoveredDataKey])
+						? formatVolume(muscleVolumes[hoveredDataKey], unit)
 						: "No data"}
 				</div>
 			)}

--- a/src/app/components/RoutineBuilder.tsx
+++ b/src/app/components/RoutineBuilder.tsx
@@ -10,6 +10,7 @@ import {
 	Eye,
 	GripVertical,
 	Loader2,
+	PlayCircle,
 	Plus,
 	Save,
 	Search,
@@ -39,6 +40,7 @@ import { Label } from "@/app/components/ui/label";
 import { Switch } from "@/app/components/ui/switch";
 import { UnsavedChangesDialog } from "@/app/components/ui/unsaved-changes-dialog";
 import { useExerciseCatalog } from "@/hooks/useExerciseCatalog";
+import { getPrimaryExerciseDemoMedia } from "@/lib/exercise-demo-media";
 import {
 	convertWeight,
 	formatWeight,
@@ -1303,15 +1305,21 @@ function ExercisePickerModal({
 
 	// Fetch exercises from the exercise_catalog table
 	const { data: catalogExercises, isLoading: catalogLoading } =
-		useExerciseCatalog();
+		useExerciseCatalog({ includeArchived: true });
 
 	const allExercises = useMemo(() => {
-		return (catalogExercises ?? []).map((ex) => ({
-			name: ex.display_name,
-			muscleGroup: ex.muscle_group,
-			exerciseId: ex.id,
-			equipment: ex.equipment,
-		}));
+		return (catalogExercises ?? []).map((ex) => {
+			const demoMedia = getPrimaryExerciseDemoMedia(ex.id);
+
+			return {
+				name: ex.display_name,
+				muscleGroup: ex.muscle_group,
+				exerciseId: ex.id,
+				equipment: ex.equipment,
+				demoThumbnailUrl: ex.thumbnail_url ?? demoMedia?.thumbnailUrl ?? null,
+				demoVideoUrl: demoMedia?.videoUrl ?? null,
+			};
+		});
 	}, [catalogExercises]);
 
 	// Get unique muscle groups for filter buttons
@@ -1418,22 +1426,40 @@ function ExercisePickerModal({
 									className="w-full p-4 rounded-lg bg-surface-2 border border-secondary hover:border-primary transition-all text-left"
 								>
 									<div className="flex items-center justify-between">
-										<div>
-											<h4 className="font-semibold text-white mb-1">
-												{exercise.name}
-											</h4>
-											<div className="flex gap-1.5 flex-wrap">
-												<Badge className="bg-primary text-white border-0 text-xs">
-													{exercise.muscleGroup}
-												</Badge>
-												{exercise.equipment.length > 0 && (
-													<Badge className="bg-secondary text-muted-foreground border-0 text-xs">
-														{formatEquipment(exercise.equipment)}
+										<div className="flex min-w-0 items-center gap-3">
+											{exercise.demoThumbnailUrl && (
+												<div className="relative h-14 w-14 flex-shrink-0 overflow-hidden rounded-md border border-secondary bg-background">
+													<img
+														src={exercise.demoThumbnailUrl}
+														alt={`Demo preview for ${exercise.name}`}
+														loading="lazy"
+														className="h-full w-full object-cover"
+													/>
+													<div
+														aria-hidden="true"
+														className="absolute inset-0 flex items-center justify-center bg-black/20"
+													>
+														<PlayCircle className="h-5 w-5 text-white drop-shadow" />
+													</div>
+												</div>
+											)}
+											<div className="min-w-0">
+												<h4 className="mb-1 truncate font-semibold text-white">
+													{exercise.name}
+												</h4>
+												<div className="flex flex-wrap gap-1.5">
+													<Badge className="bg-primary text-white border-0 text-xs">
+														{exercise.muscleGroup}
 													</Badge>
-												)}
+													{exercise.equipment.length > 0 && (
+														<Badge className="bg-secondary text-muted-foreground border-0 text-xs">
+															{formatEquipment(exercise.equipment)}
+														</Badge>
+													)}
+												</div>
 											</div>
 										</div>
-										<Plus className="w-5 h-5 text-muted-foreground" />
+										<Plus className="ml-3 h-5 w-5 flex-shrink-0 text-muted-foreground" />
 									</div>
 								</button>
 							))}

--- a/src/app/components/SummaryReport.tsx
+++ b/src/app/components/SummaryReport.tsx
@@ -16,12 +16,19 @@ import { Card } from "@/app/components/ui/card";
 import { Skeleton } from "@/app/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
 import { PHOENIX } from "@/lib/colors";
+import {
+	convertWeight,
+	formatVolume,
+	formatWeight,
+	type WeightUnit,
+} from "@/lib/units";
 import { weeklySummaryOptions } from "@/queries/progress";
 import type { ExerciseProgress } from "@/schemas/telemetry";
 import { useProfileFilterStore } from "@/stores/useProfileFilterStore";
 
 export interface SummaryReportProps {
 	userId: string;
+	unit?: WeightUnit;
 }
 
 /** Reasonable default workout targets per period.
@@ -309,7 +316,7 @@ function SkeletonCards() {
 	);
 }
 
-export function SummaryReport({ userId }: SummaryReportProps) {
+export function SummaryReport({ userId, unit = "kg" }: SummaryReportProps) {
 	const [period, setPeriod] = useState<"week" | "month">("week");
 	const { activeProfileId } = useProfileFilterStore();
 
@@ -320,6 +327,14 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 	const summary = useMemo(
 		() => computeSummary(rawData ?? [], period),
 		[rawData, period],
+	);
+	const displayDailyVolume = useMemo(
+		() =>
+			summary.dailyVolume.map((entry) => ({
+				...entry,
+				volume: Math.round(convertWeight(entry.volume, unit)),
+			})),
+		[summary.dailyVolume, unit],
 	);
 
 	const volumeChange = percentChange(
@@ -406,16 +421,13 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 							</span>
 						</div>
 						<div className="text-2xl font-semibold text-white mb-2">
-							{summary.totalVolume > 1000
-								? `${(summary.totalVolume / 1000).toFixed(1)}K`
-								: summary.totalVolume}{" "}
-							<span className="text-sm text-muted-foreground">kg</span>
+							{formatVolume(summary.totalVolume, unit)}
 						</div>
-						{summary.dailyVolume.length > 0 && (
+						{displayDailyVolume.length > 0 && (
 							<div className="mb-2">
 								<div role="img" aria-label="Daily volume sparkline">
 									<ResponsiveContainer width="100%" height={40}>
-										<LineChart data={summary.dailyVolume}>
+										<LineChart data={displayDailyVolume}>
 											<Line
 												type="monotone"
 												dataKey="volume"
@@ -530,8 +542,8 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 										{pr.exercise}{" "}
 										<span className="text-success">
 											{pr.isFirstPR
-												? `${pr.improvement}kg (first!)`
-												: `+${pr.improvement}kg`}
+												? `${formatWeight(pr.improvement, unit)} (first!)`
+												: `+${formatWeight(pr.improvement, unit)}`}
 										</span>
 									</div>
 								))}
@@ -605,7 +617,7 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 											Best session by volume:{" "}
 										</span>
 										<span className="text-primary text-sm font-medium">
-											{summary.bestSessionVolume} kg
+											{formatVolume(summary.bestSessionVolume, unit)}
 										</span>
 										{summary.bestSessionDate && (
 											<span className="text-muted-foreground text-xs ml-1">
@@ -622,7 +634,7 @@ export function SummaryReport({ userId }: SummaryReportProps) {
 										<span className="text-white text-sm">Most improved: </span>
 										<span className="text-success text-sm font-medium">
 											{summary.mostImprovedExercise} (+
-											{summary.mostImprovedAmount}kg)
+											{formatWeight(summary.mostImprovedAmount, unit)})
 										</span>
 									</div>
 								</div>

--- a/src/app/components/__tests__/InsightsFeed.test.tsx
+++ b/src/app/components/__tests__/InsightsFeed.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InsightsFeed } from "../InsightsFeed";
+
+describe("InsightsFeed", () => {
+	it("renders weight metrics with a unit separator", () => {
+		render(
+			<InsightsFeed
+				insights={[
+					{
+						id: "pr",
+						type: "achievement",
+						title: "New PR: Bench Press",
+						description: "You set a personal record on Bench Press.",
+						metric: {
+							name: "Bench Press",
+							value: 496,
+							unit: "lbs",
+							delta: 22,
+						},
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("496 lbs")).toBeInTheDocument();
+		expect(screen.getByText("+22 lbs")).toBeInTheDocument();
+	});
+
+	it("keeps compact formatting for non-weight metrics", () => {
+		render(
+			<InsightsFeed
+				insights={[
+					{
+						id: "volume",
+						type: "success",
+						title: "Volume Trending Up",
+						description: "Your training volume increased.",
+						metric: {
+							name: "Volume Change",
+							value: 12,
+							unit: "%",
+						},
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("12%")).toBeInTheDocument();
+	});
+});

--- a/src/app/components/__tests__/RoutineBuilder.test.tsx
+++ b/src/app/components/__tests__/RoutineBuilder.test.tsx
@@ -44,6 +44,29 @@ vi.mock("@/mutations/routines", () => ({
 	}),
 }));
 
+const mockCatalog = vi.hoisted(() => {
+	const state = {
+		exercises: [] as Array<Record<string, unknown>>,
+		filters: [] as unknown[],
+	};
+	return {
+		state,
+		useExerciseCatalog: vi.fn((filters?: { includeArchived?: boolean }) => {
+			state.filters.push(filters);
+			return {
+				data: filters?.includeArchived
+					? state.exercises
+					: state.exercises.filter((exercise) => !exercise.archived),
+				isLoading: false,
+			};
+		}),
+	};
+});
+
+vi.mock("@/hooks/useExerciseCatalog", () => ({
+	useExerciseCatalog: mockCatalog.useExerciseCatalog,
+}));
+
 // --- Supabase mock ---
 vi.mock("@/lib/supabase", () => ({
 	supabase: {
@@ -86,10 +109,37 @@ vi.mock("sonner", () => ({
 	toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+function tricepPushdownCatalogRow() {
+	return {
+		id: "BUxuV42l6oolZVde",
+		name: "Tricep Pushdown",
+		display_name: "Tricep Pushdown",
+		description: null,
+		muscle_group: "ARMS",
+		muscle_groups: ["ARMS"],
+		muscles: ["triceps"],
+		equipment: ["SHORT_BAR"],
+		movement: "tricep_extension",
+		sidedness: "bilateral",
+		grip: "pronated",
+		grip_width: null,
+		default_cable_config: "DOUBLE",
+		min_rep_range: 5,
+		popularity: 0,
+		aliases: [],
+		thumbnail_url:
+			"https://image.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8/thumbnail.jpg",
+		archived: true,
+		is_custom: false,
+	};
+}
+
 describe("RoutineBuilder", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockParams.current = {};
+		mockCatalog.state.exercises = [];
+		mockCatalog.state.filters = [];
 	});
 
 	// ---------------------------------------------------------------
@@ -221,6 +271,65 @@ describe("RoutineBuilder", () => {
 		await waitFor(() => {
 			expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
 		});
+	});
+
+	it("requests archived catalog exercises for routine creation parity with mobile", async () => {
+		const user = userEvent.setup();
+		renderWithProviders(<RoutineBuilder />);
+
+		await user.click(screen.getByRole("button", { name: /add exercise/i }));
+
+		await waitFor(() => {
+			expect(mockCatalog.useExerciseCatalog).toHaveBeenCalledWith({
+				includeArchived: true,
+			});
+		});
+	});
+
+	it("allows selecting archived catalog exercises and preserves the catalog ID in the saved routine", async () => {
+		mockCatalog.state.exercises = [tricepPushdownCatalogRow()];
+		const user = userEvent.setup();
+		renderWithProviders(<RoutineBuilder />);
+
+		await user.click(screen.getByRole("button", { name: /add exercise/i }));
+		await user.type(
+			await screen.findByPlaceholderText(/search exercises/i),
+			"tricep pushdown",
+		);
+		await user.click(
+			await screen.findByRole("button", { name: /tricep pushdown/i }),
+		);
+		await user.click(screen.getByRole("button", { name: /save routine/i }));
+
+		expect(mockSaveMutate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				exercises: [
+					expect.objectContaining({
+						name: "Tricep Pushdown",
+						muscle_group: "ARMS",
+						exercise_id: "BUxuV42l6oolZVde",
+					}),
+				],
+			}),
+			expect.any(Object),
+		);
+	});
+
+	it("renders a demo thumbnail affordance for catalog exercises with media", async () => {
+		mockCatalog.state.exercises = [tricepPushdownCatalogRow()];
+		const user = userEvent.setup();
+		renderWithProviders(<RoutineBuilder />);
+
+		await user.click(screen.getByRole("button", { name: /add exercise/i }));
+
+		expect(
+			await screen.findByRole("img", {
+				name: /demo preview for tricep pushdown/i,
+			}),
+		).toHaveAttribute(
+			"src",
+			"https://image.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8/thumbnail.jpg",
+		);
 	});
 
 	// ---------------------------------------------------------------

--- a/src/app/components/community/CommunityContentPreview.tsx
+++ b/src/app/components/community/CommunityContentPreview.tsx
@@ -1,6 +1,6 @@
 import { Calendar, Clock, Dumbbell, Repeat } from "lucide-react";
 import { Badge } from "@/app/components/ui/badge";
-import { formatWeight } from "@/lib/units";
+import { formatWeight, type WeightUnit } from "@/lib/units";
 import type {
 	CycleSnapshot,
 	EmbeddedRoutineSnapshot,
@@ -25,13 +25,16 @@ function formatStoredDurationMinutes(duration: number | null | undefined) {
 	return `${Math.round(duration / 60)} min`;
 }
 
-function formatLoad(exercise: RoutineExerciseSnapshot) {
+function formatLoad(exercise: RoutineExerciseSnapshot, unit: WeightUnit) {
 	if (exercise.is_bodyweight) return "Bodyweight";
-	return formatWeight((exercise.weight ?? 0) * WEIGHT_MULTIPLIER, "kg");
+	return formatWeight((exercise.weight ?? 0) * WEIGHT_MULTIPLIER, unit);
 }
 
-function formatPrescription(exercise: RoutineExerciseSnapshot) {
-	const load = formatLoad(exercise);
+function formatPrescription(
+	exercise: RoutineExerciseSnapshot,
+	unit: WeightUnit,
+) {
+	const load = formatLoad(exercise, unit);
 	if (exercise.duration_seconds) {
 		return `${exercise.sets} sets / ${exercise.duration_seconds}s / ${load}`;
 	}
@@ -54,10 +57,10 @@ function exerciseBadges(exercise: RoutineExerciseSnapshot) {
 	].filter(Boolean) as string[];
 }
 
-function perSetRows(exercise: RoutineExerciseSnapshot) {
+function perSetRows(exercise: RoutineExerciseSnapshot, unit: WeightUnit) {
 	const weights = asPrimitiveArray(exercise.per_set_weights).map((value) =>
 		typeof value === "number"
-			? formatWeight(value * WEIGHT_MULTIPLIER, "kg")
+			? formatWeight(value * WEIGHT_MULTIPLIER, unit)
 			: String(value),
 	);
 	const reps = asPrimitiveArray(exercise.per_set_reps).map(String);
@@ -77,11 +80,13 @@ function perSetRows(exercise: RoutineExerciseSnapshot) {
 function RoutineExerciseCard({
 	exercise,
 	index,
+	unit,
 }: {
 	exercise: RoutineExerciseSnapshot;
 	index: number;
+	unit: WeightUnit;
 }) {
-	const perSet = perSetRows(exercise);
+	const perSet = perSetRows(exercise, unit);
 
 	return (
 		<div className="rounded-lg border border-secondary bg-surface-2 p-3">
@@ -99,7 +104,7 @@ function RoutineExerciseCard({
 						</Badge>
 					</div>
 					<p className="text-sm text-secondary-foreground">
-						{formatPrescription(exercise)}
+						{formatPrescription(exercise, unit)}
 					</p>
 					<p className="mt-1 text-xs text-muted-foreground">
 						Rest: {exercise.rest_seconds}s between sets
@@ -131,9 +136,11 @@ function RoutineExerciseCard({
 export function RoutineSnapshotPreview({
 	exercises,
 	title = "Routine Details",
+	unit = "kg",
 }: {
 	exercises: RoutineExerciseSnapshot[] | null | undefined;
 	title?: string;
+	unit?: WeightUnit;
 }) {
 	if (!exercises || exercises.length === 0) {
 		return (
@@ -205,6 +212,7 @@ export function RoutineSnapshotPreview({
 							key={`${item.exercise.name}-${item.exercise.order_index}`}
 							exercise={item.exercise}
 							index={item.index}
+							unit={unit}
 						/>
 					) : (
 						<div
@@ -232,6 +240,7 @@ export function RoutineSnapshotPreview({
 										key={`${exercise.name}-${exercise.order_index}`}
 										exercise={exercise}
 										index={index}
+										unit={unit}
 									/>
 								))}
 							</div>
@@ -271,8 +280,10 @@ function SettingList({ title, value }: { title: string; value: unknown }) {
 
 function CycleRoutineDetails({
 	routine,
+	unit,
 }: {
 	routine: EmbeddedRoutineSnapshot | null | undefined;
+	unit: WeightUnit;
 }) {
 	if (!routine) {
 		return (
@@ -291,6 +302,7 @@ function CycleRoutineDetails({
 				<RoutineSnapshotPreview
 					exercises={routine.exercises}
 					title={`${routine.name} Exercises`}
+					unit={unit}
 				/>
 			</div>
 		</details>
@@ -299,8 +311,10 @@ function CycleRoutineDetails({
 
 export function CycleSnapshotPreview({
 	snapshot,
+	unit = "kg",
 }: {
 	snapshot: CycleSnapshot | null | undefined;
+	unit?: WeightUnit;
 }) {
 	if (!snapshot) {
 		return (
@@ -419,7 +433,9 @@ export function CycleSnapshotPreview({
 									{day.notes}
 								</p>
 							)}
-							{isWorkout && <CycleRoutineDetails routine={routine} />}
+							{isWorkout && (
+								<CycleRoutineDetails routine={routine} unit={unit} />
+							)}
 						</div>
 					);
 				})}

--- a/src/app/components/community/CommunityDetailDrawer.tsx
+++ b/src/app/components/community/CommunityDetailDrawer.tsx
@@ -29,6 +29,7 @@ import {
 	DrawerTitle,
 } from "@/app/components/ui/drawer";
 import { useIsMobile } from "@/app/hooks/useIsMobile";
+import { usePreferredWeightUnit } from "@/app/hooks/usePreferredWeightUnit";
 import { PHOENIX } from "@/lib/colors";
 import { useSaveItem, useVote } from "@/mutations/community";
 import { useAuth } from "@/providers/AuthProvider";
@@ -73,6 +74,7 @@ function DetailContent({
 	detailError: boolean;
 }) {
 	const { user } = useAuth();
+	const unit = usePreferredWeightUnit();
 	const displayItem = detail ?? item;
 	const isDeletedUser = displayItem.user_id === null;
 	const authorName = isDeletedUser
@@ -191,12 +193,14 @@ function DetailContent({
 							? displayItem.exercises_snapshot
 							: null
 					}
+					unit={unit}
 				/>
 			) : (
 				<CycleSnapshotPreview
 					snapshot={
 						"cycle_snapshot" in displayItem ? displayItem.cycle_snapshot : null
 					}
+					unit={unit}
 				/>
 			)}
 

--- a/src/app/components/community/__tests__/CommunityContentPreview.test.tsx
+++ b/src/app/components/community/__tests__/CommunityContentPreview.test.tsx
@@ -32,9 +32,42 @@ describe("CommunityContentPreview", () => {
 		);
 
 		expect(screen.getByText("Bench Press")).toBeInTheDocument();
-		expect(screen.getByText(/3 sets \/ 8 reps/i)).toBeInTheDocument();
+		expect(screen.getByText(/3 sets \/ 8 reps \/ 80 kg/i)).toBeInTheDocument();
 		expect(screen.getByText(/Weights:/i)).toBeInTheDocument();
 		expect(screen.getByText(/Rest: 90s between sets/i)).toBeInTheDocument();
+	});
+
+	it("renders routine loads in lbs when requested", () => {
+		render(
+			<RoutineSnapshotPreview
+				unit="lbs"
+				exercises={[
+					{
+						name: "Bench Press",
+						muscle_group: "Chest",
+						sets: 3,
+						reps: 8,
+						weight: 40,
+						rest_seconds: 90,
+						duration_seconds: null,
+						mode: "OLD_SCHOOL",
+						order_index: 0,
+						per_set_weights: [40, 45],
+						per_set_reps: [8, 6],
+						per_set_rest: [90, 120],
+						is_amrap: false,
+						is_bodyweight: false,
+					},
+				]}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/3 sets \/ 8 reps \/ 176.4 lbs/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/Weights: 176.4 lbs, 198.4 lbs/),
+		).toBeInTheDocument();
 	});
 
 	it("keeps exercise numbering sequential when supersets are rendered", () => {

--- a/src/app/components/cycle-builder/ProgressionRules.tsx
+++ b/src/app/components/cycle-builder/ProgressionRules.tsx
@@ -5,6 +5,12 @@ import { Card } from "@/app/components/ui/card";
 import { Input } from "@/app/components/ui/input";
 import { Label } from "@/app/components/ui/label";
 import { Switch } from "@/app/components/ui/switch";
+import {
+	formatWeight,
+	type WeightUnit,
+	weightInputToKg,
+	weightInputValue,
+} from "@/lib/units";
 import type { DeloadConfig, ProgressionConfig } from "./types";
 
 interface ProgressionRulesProps {
@@ -16,6 +22,7 @@ interface ProgressionRulesProps {
 	onProgressionConfigChange: (config: ProgressionConfig) => void;
 	onDeloadEnabledChange: (enabled: boolean) => void;
 	onDeloadConfigChange: (config: DeloadConfig) => void;
+	unit?: WeightUnit;
 }
 
 export function ProgressionRules({
@@ -27,13 +34,20 @@ export function ProgressionRules({
 	onProgressionConfigChange,
 	onDeloadEnabledChange,
 	onDeloadConfigChange,
+	unit = "kg",
 }: ProgressionRulesProps) {
 	const [isExpanded, setIsExpanded] = useState(true);
+	const fixedStep = 0.5;
 
 	const currentDeload = deloadConfig || {
 		frequencyWeeks: 4,
 		intensityPercent: 60,
 		volumePercent: 50,
+	};
+
+	const adjustFixedIncrement = (valueKg: number | undefined, delta: number) => {
+		const displayValue = Number(weightInputValue(valueKg ?? 0, unit));
+		return weightInputToKg(String(Math.max(0, displayValue + delta)), unit);
 	};
 
 	return (
@@ -231,8 +245,15 @@ export function ProgressionRules({
 									<div className="text-sm text-muted-foreground">
 										<span className="text-accent">💡 EXAMPLE</span>
 										<br />
-										If you're lifting 80kg and complete the cycle successfully,
-										next cycle will use 82kg (+
+										If you're lifting {formatWeight(80, unit)} and complete the
+										cycle successfully, next cycle will use{" "}
+										{formatWeight(
+											80 *
+												(1 +
+													(progressionConfig.percentageIncrease || 2.5) / 100),
+											unit,
+										)}{" "}
+										(+
 										{progressionConfig.percentageIncrease || 2.5}%)
 									</div>
 								</div>
@@ -259,7 +280,10 @@ export function ProgressionRules({
 													...progressionConfig,
 													upperBodyIncrement: Math.max(
 														0,
-														(progressionConfig.upperBodyIncrement || 2.5) - 0.5,
+														adjustFixedIncrement(
+															progressionConfig.upperBodyIncrement ?? 2.5,
+															-fixedStep,
+														),
 													),
 												})
 											}
@@ -270,25 +294,35 @@ export function ProgressionRules({
 										<span className="text-muted-foreground">+</span>
 										<Input
 											type="number"
-											step="0.5"
-											value={progressionConfig.upperBodyIncrement || 2.5}
+											step={fixedStep}
+											value={weightInputValue(
+												progressionConfig.upperBodyIncrement ?? 2.5,
+												unit,
+											)}
 											onChange={(e) =>
 												onProgressionConfigChange({
 													...progressionConfig,
-													upperBodyIncrement: parseFloat(e.target.value) || 2.5,
+													upperBodyIncrement: weightInputToKg(
+														e.target.value,
+														unit,
+													),
 												})
 											}
 											className="text-center bg-background border-secondary"
 										/>
-										<span className="text-muted-foreground">kg per cycle</span>
+										<span className="text-muted-foreground">
+											{unit} per cycle
+										</span>
 										<Button
 											size="sm"
 											variant="outline"
 											onClick={() =>
 												onProgressionConfigChange({
 													...progressionConfig,
-													upperBodyIncrement:
-														(progressionConfig.upperBodyIncrement || 2.5) + 0.5,
+													upperBodyIncrement: adjustFixedIncrement(
+														progressionConfig.upperBodyIncrement ?? 2.5,
+														fixedStep,
+													),
 												})
 											}
 											className="border-secondary"
@@ -311,7 +345,10 @@ export function ProgressionRules({
 													...progressionConfig,
 													lowerBodyIncrement: Math.max(
 														0,
-														(progressionConfig.lowerBodyIncrement || 5.0) - 0.5,
+														adjustFixedIncrement(
+															progressionConfig.lowerBodyIncrement ?? 5.0,
+															-fixedStep,
+														),
 													),
 												})
 											}
@@ -322,25 +359,35 @@ export function ProgressionRules({
 										<span className="text-muted-foreground">+</span>
 										<Input
 											type="number"
-											step="0.5"
-											value={progressionConfig.lowerBodyIncrement || 5.0}
+											step={fixedStep}
+											value={weightInputValue(
+												progressionConfig.lowerBodyIncrement ?? 5.0,
+												unit,
+											)}
 											onChange={(e) =>
 												onProgressionConfigChange({
 													...progressionConfig,
-													lowerBodyIncrement: parseFloat(e.target.value) || 5.0,
+													lowerBodyIncrement: weightInputToKg(
+														e.target.value,
+														unit,
+													),
 												})
 											}
 											className="text-center bg-background border-secondary"
 										/>
-										<span className="text-muted-foreground">kg per cycle</span>
+										<span className="text-muted-foreground">
+											{unit} per cycle
+										</span>
 										<Button
 											size="sm"
 											variant="outline"
 											onClick={() =>
 												onProgressionConfigChange({
 													...progressionConfig,
-													lowerBodyIncrement:
-														(progressionConfig.lowerBodyIncrement || 5.0) + 0.5,
+													lowerBodyIncrement: adjustFixedIncrement(
+														progressionConfig.lowerBodyIncrement ?? 5.0,
+														fixedStep,
+													),
 												})
 											}
 											className="border-secondary"

--- a/src/app/components/cycle-builder/ProgressionRules.tsx
+++ b/src/app/components/cycle-builder/ProgressionRules.tsx
@@ -47,7 +47,7 @@ export function ProgressionRules({
 
 	const adjustFixedIncrement = (valueKg: number | undefined, delta: number) => {
 		const displayValue = Number(weightInputValue(valueKg ?? 0, unit));
-		return weightInputToKg(String(Math.max(0, displayValue + delta)), unit);
+		return weightInputToKg(Math.max(0, displayValue + delta), unit);
 	};
 
 	return (

--- a/src/app/components/routine-builder/ExerciseCard.tsx
+++ b/src/app/components/routine-builder/ExerciseCard.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import { Badge } from "@/app/components/ui/badge";
 import { Button } from "@/app/components/ui/button";
 import { Card } from "@/app/components/ui/card";
+import { formatWeight, type WeightUnit } from "@/lib/units";
 import type { RoutineExercise } from "./superset-types";
 
 interface ExerciseCardProps {
@@ -12,6 +13,7 @@ interface ExerciseCardProps {
 	isDragging?: boolean;
 	isSelectionMode?: boolean;
 	isSelected?: boolean;
+	unit?: WeightUnit;
 	onToggleSelect?: () => void;
 }
 
@@ -22,6 +24,7 @@ export function ExerciseCard({
 	isDragging = false,
 	isSelectionMode = false,
 	isSelected = false,
+	unit = "kg",
 	onToggleSelect,
 }: ExerciseCardProps) {
 	const handleCardClick = () => {
@@ -81,7 +84,8 @@ export function ExerciseCard({
 							</div>
 							<div className="text-sm text-muted-foreground">
 								{exercise.sets.length} sets • {exercise.sets[0]?.reps || 0} reps
-								• {exercise.sets[0]?.weight || 0} kg • {exercise.programMode}
+								• {formatWeight(exercise.sets[0]?.weight ?? 0, unit)} •{" "}
+								{exercise.programMode}
 							</div>
 						</div>
 					</div>

--- a/src/app/components/routine-builder/SupersetContainer.tsx
+++ b/src/app/components/routine-builder/SupersetContainer.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import { useState } from "react";
 import { Button } from "@/app/components/ui/button";
 import { Input } from "@/app/components/ui/input";
+import { formatWeight, type WeightUnit } from "@/lib/units";
 import {
 	getSupersetColorHex,
 	getSupersetLabel,
@@ -20,6 +21,7 @@ interface SupersetContainerProps {
 	onEditExercise: (exerciseId: string) => void;
 	onAddExercise: () => void;
 	isDragging?: boolean;
+	unit?: WeightUnit;
 }
 
 export function SupersetContainer({
@@ -32,6 +34,7 @@ export function SupersetContainer({
 	onEditExercise,
 	onAddExercise,
 	isDragging = false,
+	unit = "kg",
 }: SupersetContainerProps) {
 	const supersetExercises = exercises
 		.filter((ex) => superset.exerciseIds.includes(ex.id))
@@ -104,7 +107,7 @@ export function SupersetContainer({
 										<div className="text-sm text-muted-foreground">
 											{exercise.sets.length} sets •{" "}
 											{exercise.sets[0]?.reps || 0} reps •{" "}
-											{exercise.sets[0]?.weight || 0} kg •{" "}
+											{formatWeight(exercise.sets[0]?.weight ?? 0, unit)} •{" "}
 											{exercise.programMode}
 										</div>
 									</div>

--- a/src/app/hooks/usePreferredWeightUnit.ts
+++ b/src/app/hooks/usePreferredWeightUnit.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { normalizeWeightUnit, type WeightUnit } from "@/lib/units";
+import { useAuth } from "@/providers/AuthProvider";
+import { profileOptions } from "@/queries/profile";
+
+export function usePreferredWeightUnit(): WeightUnit {
+	const { user } = useAuth();
+	const { data: profile } = useQuery({
+		...profileOptions(user?.id ?? ""),
+		enabled: !!user?.id,
+	});
+
+	return normalizeWeightUnit(profile?.weight_unit);
+}

--- a/src/lib/__tests__/challenges.test.ts
+++ b/src/lib/__tests__/challenges.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatChallengeValue } from "../challenges";
+
+describe("formatChallengeValue", () => {
+	it("formats volume challenges with the preferred weight unit", () => {
+		expect(formatChallengeValue(1000, "volume", "lbs", "kg")).toBe("2.2K lbs");
+	});
+
+	it("leaves non-volume challenge metrics unit-specific without conversion", () => {
+		expect(formatChallengeValue(12, "workouts", "lbs", "workouts")).toBe(
+			"12 workouts",
+		);
+	});
+});

--- a/src/lib/__tests__/exercise-demo-media.test.ts
+++ b/src/lib/__tests__/exercise-demo-media.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+	getExerciseDemoMedia,
+	getPrimaryExerciseDemoMedia,
+} from "../exercise-demo-media";
+
+describe("exercise demo media lookup", () => {
+	it("returns bundled demo media for Tricep Pushdown", () => {
+		const media = getExerciseDemoMedia("BUxuV42l6oolZVde");
+
+		expect(media).toEqual([
+			{
+				angle: "ISOMETRIC",
+				thumbnailUrl:
+					"https://image.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8/thumbnail.jpg",
+				videoUrl:
+					"https://stream.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8.m3u8",
+			},
+		]);
+	});
+
+	it("returns the first bundled demo as the primary media item", () => {
+		expect(getPrimaryExerciseDemoMedia("BUxuV42l6oolZVde")?.thumbnailUrl).toBe(
+			"https://image.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8/thumbnail.jpg",
+		);
+	});
+
+	it("returns no media for unknown or custom exercise IDs", () => {
+		expect(getExerciseDemoMedia("custom_1714700000000")).toEqual([]);
+		expect(getPrimaryExerciseDemoMedia("missing-exercise")).toBeNull();
+	});
+});

--- a/src/lib/__tests__/insights.test.ts
+++ b/src/lib/__tests__/insights.test.ts
@@ -43,6 +43,37 @@ describe("generateInsights", () => {
 		expect(pr).toBeDefined();
 	});
 
+	it("formats PR descriptions and metric badges in kg by default", () => {
+		const insights = generateInsights(baseInput);
+		const pr = insights.find(
+			(i) => i.type === "achievement" && i.title.includes("PR"),
+		);
+		expect(pr?.description).toContain("225 kg");
+		expect(pr?.description).toContain("up 10 kg from 215 kg");
+		expect(pr?.description).not.toContain("lbs");
+		expect(pr?.metric).toMatchObject({
+			name: "Bench Press",
+			value: 225,
+			unit: "kg",
+			delta: 10,
+		});
+	});
+
+	it("formats PR descriptions and metric badges in lbs when requested", () => {
+		const insights = generateInsights(baseInput, "lbs");
+		const pr = insights.find(
+			(i) => i.type === "achievement" && i.title.includes("PR"),
+		);
+		expect(pr?.description).toContain("496.0 lbs");
+		expect(pr?.description).toContain("up 22.0 lbs from 474.0 lbs");
+		expect(pr?.metric).toMatchObject({
+			name: "Bench Press",
+			value: 496,
+			unit: "lbs",
+			delta: 22,
+		});
+	});
+
 	it("flags plateau exercises", () => {
 		const insights = generateInsights(baseInput);
 		const plateau = insights.find((i) => i.title.includes("Plateau"));

--- a/src/lib/__tests__/units.test.ts
+++ b/src/lib/__tests__/units.test.ts
@@ -69,6 +69,14 @@ describe("units", () => {
 		it("converts and abbreviates lbs volume from canonical kg", () => {
 			expect(formatVolume(1000, "lbs")).toBe("2.2K lbs");
 		});
+
+		it("formats million-scale volumes with an M suffix", () => {
+			expect(formatVolume(1_200_000, "kg")).toBe("1.2M kg");
+		});
+
+		it("uses absolute magnitude when abbreviating negative volume deltas", () => {
+			expect(formatVolume(-2300, "kg")).toBe("-2.3K kg");
+		});
 	});
 
 	describe("getUnitLabel", () => {

--- a/src/lib/__tests__/units.test.ts
+++ b/src/lib/__tests__/units.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
 	convertWeight,
+	convertWeightFromUnit,
+	formatLeaderboardValue,
 	formatVolume,
 	formatWeight,
 	getUnitLabel,
+	isWeightUnit,
+	normalizeWeightUnit,
 	toKg,
+	weightInputToKg,
+	weightInputValue,
 } from "../units";
 
 describe("units", () => {
@@ -59,12 +65,79 @@ describe("units", () => {
 		it("formats lbs volumes", () => {
 			expect(formatVolume(1000, "lbs")).toMatch(/lbs$/);
 		});
+
+		it("converts and abbreviates lbs volume from canonical kg", () => {
+			expect(formatVolume(1000, "lbs")).toBe("2.2K lbs");
+		});
 	});
 
 	describe("getUnitLabel", () => {
 		it("returns the unit label", () => {
 			expect(getUnitLabel("kg")).toBe("kg");
 			expect(getUnitLabel("lbs")).toBe("lbs");
+		});
+	});
+
+	describe("normalizeWeightUnit", () => {
+		it("returns lbs only for the explicit lbs preference", () => {
+			expect(normalizeWeightUnit("lbs")).toBe("lbs");
+			expect(normalizeWeightUnit("kg")).toBe("kg");
+			expect(normalizeWeightUnit(null)).toBe("kg");
+			expect(normalizeWeightUnit("stone")).toBe("kg");
+		});
+	});
+
+	describe("weight input helpers", () => {
+		it("converts kg values to preferred display input values", () => {
+			expect(weightInputValue(42.5, "kg")).toBe("42.5");
+			expect(weightInputValue(42.5, "lbs")).toBe("93.7");
+		});
+
+		it("round-trips lbs display inputs back to canonical kg", () => {
+			const displayValue = weightInputValue(42.5, "lbs");
+			expect(weightInputToKg(displayValue, "lbs")).toBeCloseTo(42.5, 1);
+		});
+
+		it("handles blank and null input values as zero kg", () => {
+			expect(weightInputValue(null, "lbs")).toBe("");
+			expect(weightInputToKg("", "lbs")).toBe(0);
+			expect(weightInputToKg(null, "kg")).toBe(0);
+		});
+	});
+
+	describe("convertWeightFromUnit", () => {
+		it("converts source lbs to the requested display unit", () => {
+			expect(convertWeightFromUnit(220.462, "lbs", "kg")).toBeCloseTo(100, 1);
+			expect(convertWeightFromUnit(220.462, "lbs", "lbs")).toBeCloseTo(
+				220.462,
+				1,
+			);
+		});
+
+		it("treats non-lbs source values as canonical kg", () => {
+			expect(convertWeightFromUnit(100, "kg", "lbs")).toBeCloseTo(220.462, 1);
+			expect(convertWeightFromUnit(100, "%", "lbs")).toBeCloseTo(220.462, 1);
+		});
+	});
+
+	describe("isWeightUnit", () => {
+		it("identifies supported weight unit strings", () => {
+			expect(isWeightUnit("kg")).toBe(true);
+			expect(isWeightUnit("lbs")).toBe(true);
+			expect(isWeightUnit("%")).toBe(false);
+			expect(isWeightUnit(null)).toBe(false);
+		});
+	});
+
+	describe("formatLeaderboardValue", () => {
+		it("formats volume metrics with the preferred weight unit", () => {
+			expect(formatLeaderboardValue(1000, "totalVolume", "lbs")).toBe(
+				"2.2K lbs",
+			);
+		});
+
+		it("does not convert non-volume metrics", () => {
+			expect(formatLeaderboardValue(42, "workoutCount", "lbs")).toBe("42");
 		});
 	});
 });

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -1,0 +1,13 @@
+import { formatVolume, type WeightUnit } from "@/lib/units";
+
+export function formatChallengeValue(
+	value: number,
+	challengeType: string,
+	unit: WeightUnit,
+	targetUnit?: string | null,
+): string {
+	if (challengeType === "volume") {
+		return formatVolume(value, unit);
+	}
+	return `${value.toLocaleString()}${targetUnit ? ` ${targetUnit}` : ""}`;
+}

--- a/src/lib/exercise-demo-media-manifest.ts
+++ b/src/lib/exercise-demo-media-manifest.ts
@@ -1,0 +1,5314 @@
+// Generated from supabase/seed-data/exercise_dump.json.
+// Keep this media-only manifest small so the client does not bundle the raw seed dump.
+export const EXERCISE_DEMO_MEDIA = {
+	"4kmhj9yyZcBI54Vi": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/rWzKq2uIkyLugRNykhByplVZdNtmvkcD1J02wjK4O00xs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/rWzKq2uIkyLugRNykhByplVZdNtmvkcD1J02wjK4O00xs/high.mp4",
+		},
+	],
+	aJS5lGH6jjwC_Zga: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ZosQ9rhFf6ILn3K02mekobQcmBQ55lSRiGAWFhrBsQGI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ZosQ9rhFf6ILn3K02mekobQcmBQ55lSRiGAWFhrBsQGI/high.mp4",
+		},
+	],
+	yDtqz11KA7nK4FHi: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/inqvs00WJVa00Z00j01G5G3SAzdXpWMycbPdSaVmvqF45Ok/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/inqvs00WJVa00Z00j01G5G3SAzdXpWMycbPdSaVmvqF45Ok.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/U00u1DQa6xn8nd4lGhGIKKoTqvT5akFxFSNMwFLFxjhU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/U00u1DQa6xn8nd4lGhGIKKoTqvT5akFxFSNMwFLFxjhU.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/bP71HZ75bmDwwFxsKdSQl4lc9NAlRI3Q8b7fJ4ZOM01k/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/bP71HZ75bmDwwFxsKdSQl4lc9NAlRI3Q8b7fJ4ZOM01k.m3u8",
+		},
+	],
+	nDUCrDOuYn1VJAyD: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1r00wVx005hKGi02UVdlVzKpgeHXFvDUEH23YVu02W5WBkE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1r00wVx005hKGi02UVdlVzKpgeHXFvDUEH23YVu02W5WBkE.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/pyB00etXcB8BeZrbeAKfIeH4FUVt87U9ORQPBz1wLQFU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/pyB00etXcB8BeZrbeAKfIeH4FUVt87U9ORQPBz1wLQFU.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/e9q5gQzWOj92Jyv3miwttabA28RvrcXGyGXuXgFoEQk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/e9q5gQzWOj92Jyv3miwttabA28RvrcXGyGXuXgFoEQk.m3u8",
+		},
+	],
+	"cT86LPCEm_5l2-Y2": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oSuD0201kQOzTOFNmsxCxIkCxNi01897mfmeIJjdeMZuFo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oSuD0201kQOzTOFNmsxCxIkCxNi01897mfmeIJjdeMZuFo.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/i01tD9Y4Bkm011vOgpqCPqVXlDki22vZriiiCBDHFKlU4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/i01tD9Y4Bkm011vOgpqCPqVXlDki22vZriiiCBDHFKlU4.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/uD4RjOzGVaXgg00R5OwBd7jRHa1PXlivl6J9dcV5jPP00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/uD4RjOzGVaXgg00R5OwBd7jRHa1PXlivl6J9dcV5jPP00.m3u8",
+		},
+	],
+	A7GbtHsBjyZu3Jyv: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/2Ve7mcn6cn4OLXkVqHUp4bfyKlmiVKP02OeExIZaUCAA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/2Ve7mcn6cn4OLXkVqHUp4bfyKlmiVKP02OeExIZaUCAA/high.mp4",
+		},
+	],
+	opo1QzcHfFKMx1hI: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/nhRjvgUTsgYo900Sw400UoLW2IWgGVClUEGeJD024rARfo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/nhRjvgUTsgYo900Sw400UoLW2IWgGVClUEGeJD024rARfo/high.mp4",
+		},
+	],
+	A6dPtSIx7AYijn8s: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1gRVhi7TKunyaiHDF3vClzTRXsHm4lwA6Q02oq00lc3Hw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1gRVhi7TKunyaiHDF3vClzTRXsHm4lwA6Q02oq00lc3Hw/high.mp4",
+		},
+	],
+	YS6W8OXgd2jLCljr: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/I4BgdnvxfxWHStsIlFxhzvVxMMxU2Xgmt95rLGD1XbA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/I4BgdnvxfxWHStsIlFxhzvVxMMxU2Xgmt95rLGD1XbA/high.mp4",
+		},
+	],
+	ZZEybJ7j3YmjLy_o: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/87xhnlC00xHXa1s6SG8dggdDcUSYogHEmL6HRliEXBck/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/87xhnlC00xHXa1s6SG8dggdDcUSYogHEmL6HRliEXBck/high.mp4",
+		},
+	],
+	XfkITKH5emJFlGv7: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/WzwC8oQWCq902Zw101HVkd2LKBAgZx9jfpkiJtmpl5Njc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/WzwC8oQWCq902Zw101HVkd2LKBAgZx9jfpkiJtmpl5Njc.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/MOVA2LUWoILHSuKEmZk00cohNEACdqV5lt01TJ501fZIcA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/MOVA2LUWoILHSuKEmZk00cohNEACdqV5lt01TJ501fZIcA.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/BwyiqBUrqXeNMY01Mly3Ei4z4qcgi9HbPAGRCz01EPr01g/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/BwyiqBUrqXeNMY01Mly3Ei4z4qcgi9HbPAGRCz01EPr01g.m3u8",
+		},
+	],
+	rCG6HJi50F2REZCw: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/lcMA8IPDNSeVDmXMpmjzKZhUQZqfeaPAoUO0201HjPjus/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/lcMA8IPDNSeVDmXMpmjzKZhUQZqfeaPAoUO0201HjPjus/high.mp4",
+		},
+	],
+	"9ZDED7N8ni7NDsVj": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/MVPqLu013FyOP00ifN7ec8WxqdivEtA00K00YNA2iyr7DWY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/MVPqLu013FyOP00ifN7ec8WxqdivEtA00K00YNA2iyr7DWY/high.mp4",
+		},
+	],
+	"RWfoqIUvfHyOgg_-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/UEgMoMECi00nU9HldNWA01Kra8HTtdX2oA7EEpD02oz6yQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/UEgMoMECi00nU9HldNWA01Kra8HTtdX2oA7EEpD02oz6yQ/high.mp4",
+		},
+	],
+	GPxqQoLkxj_Vcqbe: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/A69g5k00Dd7ppeuH4pOb1u02DUIgLh1r2r7GXQ3BiFpw4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/A69g5k00Dd7ppeuH4pOb1u02DUIgLh1r2r7GXQ3BiFpw4/high.mp4",
+		},
+	],
+	Qkm5D3V0z13e7LGT: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ExP02ZvMSkG12BSBVEd02JkDvLnhrfXLlTGQPPlukC01JA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ExP02ZvMSkG12BSBVEd02JkDvLnhrfXLlTGQPPlukC01JA/high.mp4",
+		},
+	],
+	hVN8gR7bdeRE3uzn: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/gLVgTI5PVmh5MOhNS00kT7kGIL5PaMjrBeNn42lRBA3I/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/gLVgTI5PVmh5MOhNS00kT7kGIL5PaMjrBeNn42lRBA3I/high.mp4",
+		},
+	],
+	bPCXvQV5baCujiNS: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/aVV02wsbwvZ7SUIuAurpuNoRn4fg02caR9GCH65ouByLE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/aVV02wsbwvZ7SUIuAurpuNoRn4fg02caR9GCH65ouByLE/high.mp4",
+		},
+	],
+	o7_WM7zxaulEavqh: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/CHFGX27bY6Zt5AdQiO027wp5bILVJ01ObiT5aOYWDN9kI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/CHFGX27bY6Zt5AdQiO027wp5bILVJ01ObiT5aOYWDN9kI/high.mp4",
+		},
+	],
+	S_MwKyRVHgu57rOk: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/uQbMTlCkiuMG02QVKjqSgLi4fijdJwjiOvDbYFVHKcw00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/uQbMTlCkiuMG02QVKjqSgLi4fijdJwjiOvDbYFVHKcw00/high.mp4",
+		},
+	],
+	D7IHBdqkHR5z2wFn: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/U7db9bXLwINluOOAq02C6hOsArgYkBH9dj01ngLqH2kR00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/U7db9bXLwINluOOAq02C6hOsArgYkBH9dj01ngLqH2kR00/high.mp4",
+		},
+	],
+	"3cd0a0cb-8e56-4b0e-83a0-d88ff369749f": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/PEVPZVgKvseRAFQY1UVkT8YZvKjih45x602fUnnVMpjY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/PEVPZVgKvseRAFQY1UVkT8YZvKjih45x602fUnnVMpjY/high.mp4",
+		},
+	],
+	"5df6aa2a-69a8-4ec7-94b0-ec626044209c": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/MKtKIX90001XuqghPNP5fTDRTNyXKyKpKXpndkAH00hIyw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/MKtKIX90001XuqghPNP5fTDRTNyXKyKpKXpndkAH00hIyw/high.mp4",
+		},
+	],
+	NlAi6WA8guFWhVpS: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/zS5Mks003ogZ1UPYduS4YChx4I01Za1RCyqiwgTs4JvOg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/zS5Mks003ogZ1UPYduS4YChx4I01Za1RCyqiwgTs4JvOg/high.mp4",
+		},
+	],
+	BLOOMD_TqbF8WyzE: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/XUvrgwRkyJFvMlHgnqZhIejW23AdeA802IlC7yb3oEIQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/XUvrgwRkyJFvMlHgnqZhIejW23AdeA802IlC7yb3oEIQ/high.mp4",
+		},
+	],
+	YZyOPnvr5kxvP1Fz: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/B6v00RZiX6x02BazJWr4ekHO2nrP00p01s01iCa1Y8nS7mLA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/B6v00RZiX6x02BazJWr4ekHO2nrP00p01s01iCa1Y8nS7mLA/high.mp4",
+		},
+	],
+	fqanIzGS6FgTxqbk: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/S3pfcnrKk4kirClzgZtHumSnAuUUs00lJ2DrkEpD7kU00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/S3pfcnrKk4kirClzgZtHumSnAuUUs00lJ2DrkEpD7kU00/high.mp4",
+		},
+	],
+	"zL2v6W-mPds9HvRy": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/SgNhG5VzVcXKxx01z00XTQ78jfQ3kRq00xlqtXA5aEixys/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/SgNhG5VzVcXKxx01z00XTQ78jfQ3kRq00xlqtXA5aEixys/high.mp4",
+		},
+	],
+	"8_lUmqQpm5jQhEvA": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/G8ORIHWmsGAahCx1SLKWSzk3TLxb3RPFSoexB4b2Gpw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/G8ORIHWmsGAahCx1SLKWSzk3TLxb3RPFSoexB4b2Gpw/high.mp4",
+		},
+	],
+	"1vS7ZNfrz2qF6KId": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/VW8l86Ugbgj1uY8hF45SqKOIrRdU3Ty02xg17SEsKz4c/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/VW8l86Ugbgj1uY8hF45SqKOIrRdU3Ty02xg17SEsKz4c/high.mp4",
+		},
+	],
+	QzWldJ1xdgra87Z1: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/502e4uCFsxUVfJHDrpCTn9S8Kez8ZpAN02A300PaG95ANA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/502e4uCFsxUVfJHDrpCTn9S8Kez8ZpAN02A300PaG95ANA/high.mp4",
+		},
+	],
+	n8MfdJCDxckBGV_4: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/EkIn3a5paseKFxVdDCY5K84TWznDtamsV13J02YdWDaI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/EkIn3a5paseKFxVdDCY5K84TWznDtamsV13J02YdWDaI/high.mp4",
+		},
+	],
+	VEBxiXQ_UMwoycdo: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/GIJ8TzNgVkQOhwzJaN702VYgrxEmluR93w6vNySeWjG00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/GIJ8TzNgVkQOhwzJaN702VYgrxEmluR93w6vNySeWjG00/high.mp4",
+		},
+	],
+	_AErsqZDhmRWm_rU: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2575g01LndVzgKCclHktDRR6SPmFwTL7YVWrciNo8SGo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2575g01LndVzgKCclHktDRR6SPmFwTL7YVWrciNo8SGo/high.mp4",
+		},
+	],
+	ZZ92N8QsBdp6HCh3: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/qsrFHJPCU01taFLecMewh1699jG3GcIH6XP56tedSgm8/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/qsrFHJPCU01taFLecMewh1699jG3GcIH6XP56tedSgm8/high.mp4",
+		},
+	],
+	"b5d0f3d1-994b-4589-9d2b-b3f36f1412c7": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/f9WPm7D4NWtvnNPkCsoWm3gJa5LmxvXOTPRI1yMHjZ4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/f9WPm7D4NWtvnNPkCsoWm3gJa5LmxvXOTPRI1yMHjZ4/high.mp4",
+		},
+	],
+	IIEVWF16VLSOCdA2: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Qjhpg3d01XjhfwXSa2okY89djbZZb7Lozdm9V9ASfiYY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Qjhpg3d01XjhfwXSa2okY89djbZZb7Lozdm9V9ASfiYY/high.mp4",
+		},
+	],
+	QPiIhCZA7LwgHjrf: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/SvkuhCCNCEWH2d3Hf1sx347iWuxX12h46Y01qA8HPCng/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/SvkuhCCNCEWH2d3Hf1sx347iWuxX12h46Y01qA8HPCng/high.mp4",
+		},
+	],
+	ku9GWXoCLuBShLm0: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/JB01zPwOVPdP701qfTgMQb33CI5ht01mpYVg1F4aaxsaVo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/JB01zPwOVPdP701qfTgMQb33CI5ht01mpYVg1F4aaxsaVo/high.mp4",
+		},
+	],
+	n_dHzWbRx3isCsDt: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/UJu5w8Vhh1GhFkYsXhDBvWyqp3H9X6ZtNTW00XQbs5uY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/UJu5w8Vhh1GhFkYsXhDBvWyqp3H9X6ZtNTW00XQbs5uY/high.mp4",
+		},
+	],
+	cJt26IdtckFcJsq1: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/E01sjZN1IEQ9QMFxesHG4kDihs1oG1vBe1coqEPaDhgQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/E01sjZN1IEQ9QMFxesHG4kDihs1oG1vBe1coqEPaDhgQ/high.mp4",
+		},
+	],
+	rC0baJJTFuQdbwng: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/tj01DVjWdv1HdAIGFR2xPRtV84OF700G4qllxdCrAgCBI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/tj01DVjWdv1HdAIGFR2xPRtV84OF700G4qllxdCrAgCBI/high.mp4",
+		},
+	],
+	"67195cbd-7e2b-4d96-804b-0182b8bf2bab": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/O14IWZG02evjcqb7UDUM3NWPawC5ytbfwW02h2ZAi6mJ4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/O14IWZG02evjcqb7UDUM3NWPawC5ytbfwW02h2ZAi6mJ4/high.mp4",
+		},
+	],
+	"31ea9d9e-669c-4752-9f44-80c3fa864021": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Q00Tz2JnQlZ01BdJX02eYgfK00SfzWdRCjTe3005bOyLefFU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Q00Tz2JnQlZ01BdJX02eYgfK00SfzWdRCjTe3005bOyLefFU/high.mp4",
+		},
+	],
+	"cc7f2c3a-20bd-4a3e-8d5a-393420386c23": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ELsf599XGYDKldI5F11ZzEoiwBuF8peTqKI8BTAI4Yw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ELsf599XGYDKldI5F11ZzEoiwBuF8peTqKI8BTAI4Yw/high.mp4",
+		},
+	],
+	BRd2HV_4zo1M5V1e: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Srt8UrGw301ebO902qu6lwcLdSHM1qOzYR37EJscnCauQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Srt8UrGw301ebO902qu6lwcLdSHM1qOzYR37EJscnCauQ/high.mp4",
+		},
+	],
+	"aea28a4b-d442-4bba-8c64-1e1780d243dd": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/p1UJidbeYYIFkG3lM01U1Pg7jn9nBO02Mgu1rE02r02jbuM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/p1UJidbeYYIFkG3lM01U1Pg7jn9nBO02Mgu1rE02r02jbuM/high.mp4",
+		},
+	],
+	U4yuZdXmjYhMHANs: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/wC01XL8LRR4fvCrHUrCZVl3COXuZBnfrnWozyE00x5qG4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/wC01XL8LRR4fvCrHUrCZVl3COXuZBnfrnWozyE00x5qG4/high.mp4",
+		},
+	],
+	useRdaf9DVqyjBD8: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/stHUgvsARnlPNggxfS9YWALrJJZLN001d02vY004uIDbhQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/stHUgvsARnlPNggxfS9YWALrJJZLN001d02vY004uIDbhQ/high.mp4",
+		},
+	],
+	"2b09f28a-b765-4aab-90ec-8c14318d63eb": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ftPfc02gFDTPzOxVRDhtSTKmkUIEAOwPE5pigy1003G8U/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ftPfc02gFDTPzOxVRDhtSTKmkUIEAOwPE5pigy1003G8U/high.mp4",
+		},
+	],
+	"4e3de525-1be3-4b1c-a95c-07e74697f7b4": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/5H2Kv9ap1fM003whIWAFAkifzyC02RJrJfCQRP4gwqdUg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/5H2Kv9ap1fM003whIWAFAkifzyC02RJrJfCQRP4gwqdUg/high.mp4",
+		},
+	],
+	bMavugVodLEh2ltO: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/lG4oYDKZ3KPYqGyhnsFG8xncqvAA01VkpJHlI3qfQeV4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/lG4oYDKZ3KPYqGyhnsFG8xncqvAA01VkpJHlI3qfQeV4/high.mp4",
+		},
+	],
+	"2YFK0aiPUOIOlThL": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/WrEYDSbdUr7SOM65wEcZJVmO014V7301rsHlYXBbqPask/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/WrEYDSbdUr7SOM65wEcZJVmO014V7301rsHlYXBbqPask/high.mp4",
+		},
+	],
+	dbUz7Op2hhKbax4u: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3ZohQotEOL8OKjH00LwdrODEMeuCWiIFR9bYkcuWvCsI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3ZohQotEOL8OKjH00LwdrODEMeuCWiIFR9bYkcuWvCsI/high.mp4",
+		},
+	],
+	"4c78ed02-89bb-4de4-b346-72a268b0d4c0": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/U3Gw6v3P9c01ZNPMSCcphEz5gjN1eOVDC9ElhUgc6XaE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/U3Gw6v3P9c01ZNPMSCcphEz5gjN1eOVDC9ElhUgc6XaE/high.mp4",
+		},
+	],
+	"1VBYUlGszYuK29Rh": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/REhsE02N00SQiNrMO2NS4oJAQLm5oKe7dtitTOlxaP38Q/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/REhsE02N00SQiNrMO2NS4oJAQLm5oKe7dtitTOlxaP38Q/high.mp4",
+		},
+	],
+	"cc0b27a7-679a-406e-a56e-44778bafaec5": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/02xs1awsNvLpyL02bjHm1kPzwMhPB7W02Hw02ZUz4L02bBmA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/02xs1awsNvLpyL02bjHm1kPzwMhPB7W02Hw02ZUz4L02bBmA/high.mp4",
+		},
+	],
+	"k-PGXPztgc5uS42S": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/M02005HItEgYyx5b81wWLnAXLHFhSqQjLAOeyGtXkUEBE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/M02005HItEgYyx5b81wWLnAXLHFhSqQjLAOeyGtXkUEBE/high.mp4",
+		},
+	],
+	"b2fb6fcd-3f47-403d-bad1-0f5e3f62d048": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/HREfuiT28COjOVXgTqikAFZUL3r00DY00P8yxahnWMJv4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/HREfuiT28COjOVXgTqikAFZUL3r00DY00P8yxahnWMJv4/high.mp4",
+		},
+	],
+	"fc5ca114-3cb6-462a-ab54-7ef1233b5fc2": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/gQZFKLf7Vf13wRtlCUq00ip4KQqufgUcsfudWqdPARmA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/gQZFKLf7Vf13wRtlCUq00ip4KQqufgUcsfudWqdPARmA/high.mp4",
+		},
+	],
+	X9EUD_qwbhc2EIQw: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/gaMwwiEfJDQGMO01X4007g7PJ02NyZ02Vhh011DsrBIUo2Cc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/gaMwwiEfJDQGMO01X4007g7PJ02NyZ02Vhh011DsrBIUo2Cc/high.mp4",
+		},
+	],
+	NFtfHV_LdJnwXJO8: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/g02N7miNfhLv5NEQ2WnsWkyKW7zHejrs4vtEEQG1xC3Q/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/g02N7miNfhLv5NEQ2WnsWkyKW7zHejrs4vtEEQG1xC3Q/high.mp4",
+		},
+	],
+	lird71_6aqwu88tw: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/AUQCWe4jmp72Wt4Zi00yNZdJ39g1uWsfyxvmxpc6jZ24/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/AUQCWe4jmp72Wt4Zi00yNZdJ39g1uWsfyxvmxpc6jZ24/high.mp4",
+		},
+	],
+	"6EIQ-UEuPz3uuRqk": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/00WjNOkBlsB005lQMC7xcafbTKmuku4C00mCVjDlP01WqHw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/00WjNOkBlsB005lQMC7xcafbTKmuku4C00mCVjDlP01WqHw/high.mp4",
+		},
+	],
+	"ui8LejWIv-bX3USV": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/7FsVGv01BlT01MilQjsSJ1L8YZw7b8ISkZpA7qsJCIUTg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/7FsVGv01BlT01MilQjsSJ1L8YZw7b8ISkZpA7qsJCIUTg/high.mp4",
+		},
+	],
+	oFP4aOA23Uo82gRD: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/S9HCvceWFHiRz4ZEQELDogcdtTtpfUHQOFeTmyU2iuU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/S9HCvceWFHiRz4ZEQELDogcdtTtpfUHQOFeTmyU2iuU/high.mp4",
+		},
+	],
+	sjMAbrtMa0KptZ3y: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/fpAOZmpAkbQFqm02nHp3c4GOagL4yraZEi2feapE4KDI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/fpAOZmpAkbQFqm02nHp3c4GOagL4yraZEi2feapE4KDI/high.mp4",
+		},
+	],
+	"WOJDY9rvYsG-LsIb": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/z5CBoCMxgh01aBNp3P4Zb702A6jTHRMW1vDtxKfxdei1M/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/z5CBoCMxgh01aBNp3P4Zb702A6jTHRMW1vDtxKfxdei1M/high.mp4",
+		},
+	],
+	"-YjRuMgOttzv0yZW": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/yHeYAdoqZxTjCW0202EIRI8Qx2kH3CHv5wZuOYy631x024/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yHeYAdoqZxTjCW0202EIRI8Qx2kH3CHv5wZuOYy631x024/high.mp4",
+		},
+	],
+	"2R1uXL45E-ZnUYYx": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ITa59NrgBUbdVhk49berMTdlWMsIygx8lApyh5iLLwU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ITa59NrgBUbdVhk49berMTdlWMsIygx8lApyh5iLLwU.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/EEFspr4PU3N4DAx3aO00cZHChTExkUGe3700YxCi9l9yU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/EEFspr4PU3N4DAx3aO00cZHChTExkUGe3700YxCi9l9yU.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/7mi2PGr2JTDILuX5rgN2TvJhEWsbV6DcGm6CTrqRgdY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/7mi2PGr2JTDILuX5rgN2TvJhEWsbV6DcGm6CTrqRgdY.m3u8",
+		},
+	],
+	ePpAzISZjVFNQfSM: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Ra6zaWPX8FsLerOChi9NwI82lvViXY64wgCi2rqiWJ00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Ra6zaWPX8FsLerOChi9NwI82lvViXY64wgCi2rqiWJ00/high.mp4",
+		},
+	],
+	"7tufZzs2Sq8JFCdw": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/AaGF0201ZhNy00301y02oYB3ZefpLSht02oWReQz5r8lYuDTo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/AaGF0201ZhNy00301y02oYB3ZefpLSht02oWReQz5r8lYuDTo/high.mp4",
+		},
+	],
+	I07dmYTfP17hH2U9: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/GeBpVld0168tAqSgcRvQ1qLbj023lg7zscCJsUNUP7QK00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/GeBpVld0168tAqSgcRvQ1qLbj023lg7zscCJsUNUP7QK00/high.mp4",
+		},
+	],
+	mG5IivMZ7IORv3Pn: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/TBka4LfbOTPfiPseJneE2b9sYfGH3D6uHDHnLXdU3SE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/TBka4LfbOTPfiPseJneE2b9sYfGH3D6uHDHnLXdU3SE/high.mp4",
+		},
+	],
+	YSIasv929EVKowG5: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/md5C00G8vEJmiIF6BWy01dnjnkuw02lDptB1I4RfvWtYA00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/md5C00G8vEJmiIF6BWy01dnjnkuw02lDptB1I4RfvWtYA00/high.mp4",
+		},
+	],
+	"Gw-7cQme_mS2hA07": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/lPe9LIo02D19WE9XQMDudk1yAtUv18oSkCYgRnsOFZX8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/lPe9LIo02D19WE9XQMDudk1yAtUv18oSkCYgRnsOFZX8/high.mp4",
+		},
+	],
+	"a255fcc3-af4d-44b1-8f88-8de014b39ed3": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/tUK1iRdm003erYFGtmoK4pdfmJW02mJDFS02l01TxuzXuKs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/tUK1iRdm003erYFGtmoK4pdfmJW02mJDFS02l01TxuzXuKs/high.mp4",
+		},
+	],
+	OvUIbKIxKWFw5UbY: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/PZcXmQNIR1X4IIHOb01TYeDzbkvr8TPe2CgrrJV8mXSQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/PZcXmQNIR1X4IIHOb01TYeDzbkvr8TPe2CgrrJV8mXSQ/high.mp4",
+		},
+	],
+	"10eb76e6-2aa5-482a-af8f-fc3a57cb0ac9": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/fH9aAH3A2CQ89DIkDQinsOBef7VHb4vk8QzAdjV01G3M/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/fH9aAH3A2CQ89DIkDQinsOBef7VHb4vk8QzAdjV01G3M/high.mp4",
+		},
+	],
+	"09e41c35-60b7-433a-9642-de420a727937": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/a00dCUbvzSYLwGN3d5JdF34jbU786X87ZK36rYq3X2Kw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/a00dCUbvzSYLwGN3d5JdF34jbU786X87ZK36rYq3X2Kw/high.mp4",
+		},
+	],
+	WIWjE2EC_O1VswRp: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/v3i00YvGtyrLgkDstxql5YM5EulKjGlm41n85dN5BrAM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/v3i00YvGtyrLgkDstxql5YM5EulKjGlm41n85dN5BrAM/high.mp4",
+		},
+	],
+	"b3ba4645-6b3f-4058-b1f4-0d8fc3e49dff": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/D87dMH1t7C1uDjtQEDDRNxoRTaQ53pT15xtZWRVegow/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/D87dMH1t7C1uDjtQEDDRNxoRTaQ53pT15xtZWRVegow/high.mp4",
+		},
+	],
+	j3Y1MpvaeGPy0o99: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Kp8Qnmry5ztMHRDZuR01k8ZdUZ01loE00msdo02nziehA9E/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Kp8Qnmry5ztMHRDZuR01k8ZdUZ01loE00msdo02nziehA9E/high.mp4",
+		},
+	],
+	"VY_wFggrTF1Mg-PR": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/nquXVlsFUJc8OQK00ETgqe01DZcmBjWRrnh19mAv7HA9c/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/nquXVlsFUJc8OQK00ETgqe01DZcmBjWRrnh19mAv7HA9c/high.mp4",
+		},
+	],
+	e74RvoLRZs5arglE: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/6MRpJ8FY02xNSg9As01QZGZbnNyjIlY1YwFNEe6fnWZWA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/6MRpJ8FY02xNSg9As01QZGZbnNyjIlY1YwFNEe6fnWZWA/high.mp4",
+		},
+	],
+	SfPmFe9Tm9CVQ9hC: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/00z7LtAs3qv9900301e7cJjF9v6BLyCpLbjkTC00eHsXC01M/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/00z7LtAs3qv9900301e7cJjF9v6BLyCpLbjkTC00eHsXC01M/high.mp4",
+		},
+	],
+	"957be087-320a-4e24-ac49-daef883cc6f9": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/FD8CiXJ01tbffXVYWaVu1Sdao5ULI02frX2fHi76FtLXQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/FD8CiXJ01tbffXVYWaVu1Sdao5ULI02frX2fHi76FtLXQ/high.mp4",
+		},
+	],
+	"287a9e39-fd0f-426f-bac1-2b121befb397": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/mpnr3xcgTY2DCtscUTsmw01CkavGORshpXZHxVTf02bAk/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/mpnr3xcgTY2DCtscUTsmw01CkavGORshpXZHxVTf02bAk/high.mp4",
+		},
+	],
+	"0YcECfvzxa6W7EdI": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/2DusUWC4OWvSMxkDhU00rkEt6zdTXzFRA01xOaoLGVYZQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/2DusUWC4OWvSMxkDhU00rkEt6zdTXzFRA01xOaoLGVYZQ/high.mp4",
+		},
+	],
+	"17ace32b-c83b-454e-9964-e0f0d91730bb": [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/lvnfQ9h0/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/lvnfQ9h0.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/QYbaCPqO/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/QYbaCPqO.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/vJDO6HJn/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/vJDO6HJn.m3u8",
+		},
+	],
+	fA7ZFTOKTBLncn6h: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/D2xCCh6uXyedt400OsiaB3im99LGIztkL21pLyQP013K8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/D2xCCh6uXyedt400OsiaB3im99LGIztkL21pLyQP013K8/high.mp4",
+		},
+	],
+	"63dc79af-81cd-4180-afea-e07204d2b0fd": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/YtcXJzrCgP788jTBijfhwfdEhkO76kfazUjG1mvZCMs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/YtcXJzrCgP788jTBijfhwfdEhkO76kfazUjG1mvZCMs/high.mp4",
+		},
+	],
+	WtNID3Z4AN5C4WYc: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/mV302802dYJAT018tsR01DPHlO196wPRET1hQB91nlnnEdI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/mV302802dYJAT018tsR01DPHlO196wPRET1hQB91nlnnEdI/high.mp4",
+		},
+	],
+	VjcXuTvqtCRz25Il: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/DxeWp4PhuIooWbezcmnZVDdR5nqr38e02CAPOlIvYFcY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/DxeWp4PhuIooWbezcmnZVDdR5nqr38e02CAPOlIvYFcY.m3u8",
+		},
+	],
+	"3VaWHQajM7bvFXg-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/UQveexMjk01RMHBT0233qI9rEPdSY02qvqWD3N5LxuRV01s/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/UQveexMjk01RMHBT0233qI9rEPdSY02qvqWD3N5LxuRV01s/high.mp4",
+		},
+	],
+	G_RNflCwbcCj5gxN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/sR8R02pPcqqw02gKWnIpD8gSKGvpHFOSFd37Un01fNYMfs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/sR8R02pPcqqw02gKWnIpD8gSKGvpHFOSFd37Un01fNYMfs/high.mp4",
+		},
+	],
+	yeRuEcTX7sn2wPiA: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01f6toPcWTT022dB4tF9Rg02Aedg9qf02aTFhrVrM6Jjlfw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01f6toPcWTT022dB4tF9Rg02Aedg9qf02aTFhrVrM6Jjlfw/high.mp4",
+		},
+	],
+	"reuAZQ6xN3otjnw-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Fefq8eD1hZ3Dl9E56IFBPLVabAvJlR8vM02HIa02vgTWc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Fefq8eD1hZ3Dl9E56IFBPLVabAvJlR8vM02HIa02vgTWc/high.mp4",
+		},
+	],
+	wgiwmR1yt3QJtiWs: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Q6dpTnWvpx1whxORTpkNwUQbEu008i2StC68ggAUH1SU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Q6dpTnWvpx1whxORTpkNwUQbEu008i2StC68ggAUH1SU/high.mp4",
+		},
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/U8WJGiBEhd5y9bV1J6u4Z8UNVvkMzZKNVh9tmYV02GTg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/U8WJGiBEhd5y9bV1J6u4Z8UNVvkMzZKNVh9tmYV02GTg/high.mp4",
+		},
+	],
+	y7Pkp7Xi2hcXTiJH: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/YtDswJP5bSRR5gpS017BMBjHUZXqf101qI3oALfotWDKo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/YtDswJP5bSRR5gpS017BMBjHUZXqf101qI3oALfotWDKo/high.mp4",
+		},
+	],
+	XcGMgLkg47Ax96gj: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/593gvj7FaNt02rm8V5YvBRQXm02C4xjDleRMETXobD1YU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/593gvj7FaNt02rm8V5YvBRQXm02C4xjDleRMETXobD1YU/high.mp4",
+		},
+	],
+	"e64c7837-52e2-4b97-b771-cf08ab861af1": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ItuOLxh7Oj1KjAhFemnicVW902RSxdJauUhkF01phZMqQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ItuOLxh7Oj1KjAhFemnicVW902RSxdJauUhkF01phZMqQ/high.mp4",
+		},
+	],
+	ap50el1J3FSodPME: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/UodRTMHMeUfdahS6UFjkZcXczT5nvB33lV7JXYVmehg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/UodRTMHMeUfdahS6UFjkZcXczT5nvB33lV7JXYVmehg/high.mp4",
+		},
+	],
+	E51S5gP_OfDAy_sr: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oCcvl02I8wEGkPRS00z02RWX4QkekjwJ7vsqqINHvxB4xA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oCcvl02I8wEGkPRS00z02RWX4QkekjwJ7vsqqINHvxB4xA/high.mp4",
+		},
+	],
+	"5G3irxA8agxz7OOq": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Rsz1dDjruXrOspRDeqy2YyPTKEHvjT4NCn4otGOoUlI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Rsz1dDjruXrOspRDeqy2YyPTKEHvjT4NCn4otGOoUlI/high.mp4",
+		},
+	],
+	"b2662fb9-c671-49b8-8dfb-41b4db9b659c": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/QP2AYWyGBZQ01U9DJR1z2rXSmYAqS9fSuq6VYtXIg9n4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/QP2AYWyGBZQ01U9DJR1z2rXSmYAqS9fSuq6VYtXIg9n4/high.mp4",
+		},
+	],
+	"c00f79e4-e8ec-4202-bade-e725df823a54": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Fb001QoKTGUScw5G4Ojhzf5iHh7fES4xLX7sxP2wC1cU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Fb001QoKTGUScw5G4Ojhzf5iHh7fES4xLX7sxP2wC1cU/high.mp4",
+		},
+	],
+	"8976ed4a-43a7-4196-85f3-efdf012f144d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/e2yGEvAOQfF2pBRDRu02DWpij9zRhdKJhtLRjA9uW68A/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/e2yGEvAOQfF2pBRDRu02DWpij9zRhdKJhtLRjA9uW68A/high.mp4",
+		},
+	],
+	Q0lBY7fh2g35aPP0: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oZ1023lO3S02bvhdZej3HhuuDo7uJexxYZK6jNAqYBX5k/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oZ1023lO3S02bvhdZej3HhuuDo7uJexxYZK6jNAqYBX5k/high.mp4",
+		},
+	],
+	z70P8xJtRTKpAUbr: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/p1YU023SroaMsXWsqfdAHO02JfPQuSpoRIqWEfDY01eJ9w/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/p1YU023SroaMsXWsqfdAHO02JfPQuSpoRIqWEfDY01eJ9w/high.mp4",
+		},
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/jFEazG7WLiB8YQSC71T48g00IqTAGHbaXNa6E6zR02uAs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/jFEazG7WLiB8YQSC71T48g00IqTAGHbaXNa6E6zR02uAs/high.mp4",
+		},
+	],
+	"8bd88d71-8fd2-4bab-93b8-1508b9e7d711": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/F8U00wfNfM1Q00PIsEHXdbcbedAylysis6z6Pu005DxMwg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/F8U00wfNfM1Q00PIsEHXdbcbedAylysis6z6Pu005DxMwg/high.mp4",
+		},
+	],
+	"e37b0252-18c5-4953-945e-02e52430e669": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/gWq01yh9VKs702dXHeEGK852kL7mklTaXgUo02LamaF2OY/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/gWq01yh9VKs702dXHeEGK852kL7mklTaXgUo02LamaF2OY/high.mp4",
+		},
+	],
+	"20b9cd61-8720-4546-a3c0-8926e3b37559": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/5zSZvXpogDSC4SrPjc7h6fC02hgjZv013V02oQcXYX5e2I/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/5zSZvXpogDSC4SrPjc7h6fC02hgjZv013V02oQcXYX5e2I/high.mp4",
+		},
+	],
+	sr674W7IvMJKk_Ft: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/QK2jxu0188c7tvN14M700yaBt5tUNfQbHY1aJgEDRdYSY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/QK2jxu0188c7tvN14M700yaBt5tUNfQbHY1aJgEDRdYSY/high.mp4",
+		},
+	],
+	"6685fa0b-d06a-44d3-96b1-372c9e08e6f6": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/SVc8ie59VZm444Sp49brjxafkMTln2LQ2nCHjLA5H1Q/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/SVc8ie59VZm444Sp49brjxafkMTln2LQ2nCHjLA5H1Q/high.mp4",
+		},
+	],
+	"5zzWOT6P_27Lx0ji": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/G02wDMRHedQhUsNW26Z01Gj01yU3NV9V00iUjxllVjVfN9E/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/G02wDMRHedQhUsNW26Z01Gj01yU3NV9V00iUjxllVjVfN9E/high.mp4",
+		},
+	],
+	"6f2a6d7e-b34d-4875-b57f-1ae3ad61e881": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/CIUp1CwM01ECMXv1LU00YCluk60200ob4NYTUsW6BYorVao/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/CIUp1CwM01ECMXv1LU00YCluk60200ob4NYTUsW6BYorVao/high.mp4",
+		},
+	],
+	"3bb4fb5f-7043-432c-b05c-4c74b25296bc": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/RpN22F9ZxFyE1MvoELmbMHFUwUiL27KXx1sQRx5q2mQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/RpN22F9ZxFyE1MvoELmbMHFUwUiL27KXx1sQRx5q2mQ/high.mp4",
+		},
+	],
+	"5f404b78-63b1-4300-8985-2616c67a6387": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/VSPOj8WP8xIt360201ZOJcQFHmOLX00H55kPWT5yKac2HQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/VSPOj8WP8xIt360201ZOJcQFHmOLX00H55kPWT5yKac2HQ/high.mp4",
+		},
+	],
+	FLyfmJWYyxLus7e8: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/1kIQxEC6ZMYzITS2Lim7kM01UKyqYk01Dj6Zh8N01zPeQQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/1kIQxEC6ZMYzITS2Lim7kM01UKyqYk01Dj6Zh8N01zPeQQ/high.mp4",
+		},
+	],
+	"66ggji_PJQIsQbS0": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/5n1RNO00VY01aTnNNL7ugp9qX1c3vvj5YdPnb2cTFE26c/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/5n1RNO00VY01aTnNNL7ugp9qX1c3vvj5YdPnb2cTFE26c/high.mp4",
+		},
+	],
+	"ee664ea6-c80e-4c4b-a668-972287800fd8": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/S2pPWeqK5yXIGf37Io1sUPHZ86Chx1PqoEyRuPJJBh4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/S2pPWeqK5yXIGf37Io1sUPHZ86Chx1PqoEyRuPJJBh4/high.mp4",
+		},
+	],
+	egUQWULHDoSjtL8V: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/xVh24QLNJnZQJ54qTm8rXl5RcBAscejrRi8J700Roj8s/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/xVh24QLNJnZQJ54qTm8rXl5RcBAscejrRi8J700Roj8s/high.mp4",
+		},
+	],
+	"868001a3-9f16-46c3-893a-c5dcda8baba9": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/vrKqr1ioiGu2mfBiGyOSn4tJkaB4Zhap2cTpW9fTxOc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/vrKqr1ioiGu2mfBiGyOSn4tJkaB4Zhap2cTpW9fTxOc/high.mp4",
+		},
+	],
+	QBSeHJ9M1ZlHgKX2: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/sLpv02Om5T31fi6620101uspyCbicOTk1SRppcExyuXvLg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/sLpv02Om5T31fi6620101uspyCbicOTk1SRppcExyuXvLg/high.mp4",
+		},
+	],
+	"NNxOd-C972Jqef4L": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Dp9PUECg02g02jCXWH5hXVVnPwap4abjFmge8o3Bt7f44/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Dp9PUECg02g02jCXWH5hXVVnPwap4abjFmge8o3Bt7f44/high.mp4",
+		},
+	],
+	"1j1WimoER0Y18K3E": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/sDtkZDyqIY0165ijeqbAVsyUsTA6QON008eWb8wiOJxKs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/sDtkZDyqIY0165ijeqbAVsyUsTA6QON008eWb8wiOJxKs/high.mp4",
+		},
+	],
+	q6DefK78W0OQ7_SO: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/02oyKNVSzCUwZGUiV2Ofb77Kj1FdV7tzfSmM29ndoTKI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/02oyKNVSzCUwZGUiV2Ofb77Kj1FdV7tzfSmM29ndoTKI/high.mp4",
+		},
+	],
+	"d3dac0a9-730d-467f-aae5-1bb94912ad2a": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Q33oYo8MHerJcmDxbS01Xu8u02BN01jxA7J5yaDvwC5Acc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Q33oYo8MHerJcmDxbS01Xu8u02BN01jxA7J5yaDvwC5Acc/high.mp4",
+		},
+	],
+	"e192a7f4-fec2-4a84-9fe2-325807ecc729": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/gNqd6O6ocgm01koJSOstKsrz00iFJJZ00P3aGRHAx00Xa400/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/gNqd6O6ocgm01koJSOstKsrz00iFJJZ00P3aGRHAx00Xa400/high.mp4",
+		},
+	],
+	Hgy56KiC5KIkfnKa: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/512s3MsiJqnWuGnjwNWQMMVNflS1OZ701tlHmSamC02l4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/512s3MsiJqnWuGnjwNWQMMVNflS1OZ701tlHmSamC02l4/high.mp4",
+		},
+	],
+	"86CrkMrBHgaM0F37": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/nnVoNFi7Ool11dvC3lGCjTb2hbhsS1NCTGay02HHG1XU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/nnVoNFi7Ool11dvC3lGCjTb2hbhsS1NCTGay02HHG1XU/high.mp4",
+		},
+	],
+	"AeiPi6KkNR9qIDh-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ha5HmRXT5bYWj2xLSSdtxmixggeumXhcot1Tev9CXq8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ha5HmRXT5bYWj2xLSSdtxmixggeumXhcot1Tev9CXq8/high.mp4",
+		},
+	],
+	v0NgxXnrmmuzAfnY: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/n6bbe2aOsbbMCpHhLBo019B02FVMBs8KwZpPwsnwgPy6M/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/n6bbe2aOsbbMCpHhLBo019B02FVMBs8KwZpPwsnwgPy6M/high.mp4",
+		},
+	],
+	JV4Yi4GmzVk0UGtl: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/LLZlIOsG8t8kKTfC02TRI76lD029pXNV3sb8rHLP6u7eU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/LLZlIOsG8t8kKTfC02TRI76lD029pXNV3sb8rHLP6u7eU/high.mp4",
+		},
+	],
+	"oDeHGZQ-nlQOBxmz": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/GE1cpCNA8nVgd15BEpqCZOQpL79q4RfJ01WpRsnaIJ9Y/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/GE1cpCNA8nVgd15BEpqCZOQpL79q4RfJ01WpRsnaIJ9Y/high.mp4",
+		},
+	],
+	"4a6a6919-8f0d-4aaa-bf02-e95ed4dd5c35": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/IrXkB01Iu6HVXMwyEpbar00lJQOEGhAdyNxyigOpJ6HYk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/IrXkB01Iu6HVXMwyEpbar00lJQOEGhAdyNxyigOpJ6HYk/high.mp4",
+		},
+	],
+	"0UZlcqCFg96PjE8-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4A1XR5AQiJCMAp19Ngh7ENt6AeNfVu4fGfiIE02MP5Jg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4A1XR5AQiJCMAp19Ngh7ENt6AeNfVu4fGfiIE02MP5Jg/high.mp4",
+		},
+	],
+	WSDB1LCOKOsX9YXk: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/belPNXYg00zyPUTWnFpD6ZkW8yaLWsMy8hVDt7w2eUBU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/belPNXYg00zyPUTWnFpD6ZkW8yaLWsMy8hVDt7w2eUBU/high.mp4",
+		},
+	],
+	G0g8AZrQu7f59s1x: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/uilYSsZ4zSPhE4TrCUk005QEJaQVtrLlpTEidJDPfkcA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/uilYSsZ4zSPhE4TrCUk005QEJaQVtrLlpTEidJDPfkcA/high.mp4",
+		},
+	],
+	hSimW4jxLocg_EKr: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/024lS2nQhBLW02U91BPnVp5Cn02TqgxXWRvPCt02Jw9QUhI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/024lS2nQhBLW02U91BPnVp5Cn02TqgxXWRvPCt02Jw9QUhI/high.mp4",
+		},
+	],
+	"f81ee440-c855-4f3a-b1c8-f9ecf7d094cb": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Z02UYItSOqnEZlhOz46hkB8LsvFwd6CrMKWkQNvmVr5c/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Z02UYItSOqnEZlhOz46hkB8LsvFwd6CrMKWkQNvmVr5c/high.mp4",
+		},
+	],
+	"4OXK82acFzVXTrZe": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/VeRBQFF02RjUkegDygtTvh3u01JhdOvEO5YNg4TLGM7Fw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/VeRBQFF02RjUkegDygtTvh3u01JhdOvEO5YNg4TLGM7Fw/high.mp4",
+		},
+	],
+	"2eed878d-2012-4afb-ad70-f64f984d5dc2": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/bwflGLvCOq2ZTySw02pWW01G7QBCthhM93kP01AxQAqz9M/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/bwflGLvCOq2ZTySw02pWW01G7QBCthhM93kP01AxQAqz9M/high.mp4",
+		},
+	],
+	"KFn-lgt-UV6b-yAK": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/hu3TldFNQXXRtYF5ceLrPmh93Y9hmBQ7NNq2qwpwQdc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/hu3TldFNQXXRtYF5ceLrPmh93Y9hmBQ7NNq2qwpwQdc/high.mp4",
+		},
+	],
+	"6LmWpxKB2deeX7iQ": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/TqigOwQ007mveUAUWGA5oWquQfOSTicu6PVUhHdQkyHw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/TqigOwQ007mveUAUWGA5oWquQfOSTicu6PVUhHdQkyHw/high.mp4",
+		},
+	],
+	"l-itz-TCl2e1_uUp": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/M9uDScUGAF6AVLx2GvNO1edn8fI6bz9FBH87FwVaGNE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/M9uDScUGAF6AVLx2GvNO1edn8fI6bz9FBH87FwVaGNE/high.mp4",
+		},
+	],
+	MUu5o4_srT0c4ptN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/BrqxfGomJqd6FJN1kBy02vP02C9hviCQYRpx01NuTvfOxs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/BrqxfGomJqd6FJN1kBy02vP02C9hviCQYRpx01NuTvfOxs/high.mp4",
+		},
+	],
+	"nQIaQ-Kp7cM4Oy9s": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Ezg3rlEWdZWgeWcbaInCKkYwZoYS4DqqmuR5V4h01rLo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Ezg3rlEWdZWgeWcbaInCKkYwZoYS4DqqmuR5V4h01rLo/high.mp4",
+		},
+	],
+	vONctzRAV3GZWpTV: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/cStJddAj4Hln6QRMx1R5K6AGZmXJbfw0287GgHD5100a00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/cStJddAj4Hln6QRMx1R5K6AGZmXJbfw0287GgHD5100a00/high.mp4",
+		},
+	],
+	GyiZjtq5QAQy1hzN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/O631u00NFwju6rGSAiEW01wXHrBv1DdIVIfU900Nu3sHvk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/O631u00NFwju6rGSAiEW01wXHrBv1DdIVIfU900Nu3sHvk/high.mp4",
+		},
+	],
+	lKxWrGuEzVcxLYqG: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ZKu4cPiuA3MB4nMgrnki35DxJE01xQ02zgduCChNUIPu8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ZKu4cPiuA3MB4nMgrnki35DxJE01xQ02zgduCChNUIPu8/high.mp4",
+		},
+	],
+	CZp8oeIT32m1oO8o: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/eyX1CY6tOfsLLw6OHPRYY8nVfTbcE4Yq2agAZrvG4so/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/eyX1CY6tOfsLLw6OHPRYY8nVfTbcE4Yq2agAZrvG4so/high.mp4",
+		},
+	],
+	zwaotHCXoNwVjrNT: [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/Udr69DIv/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/Udr69DIv.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/NJglemOw/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/NJglemOw.m3u8",
+		},
+	],
+	"1QjQwyZheylDBykH": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/HbxqNooHXD02SrrrUJ4auOXJ35KfU5VVcPPFme4z2QQc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/HbxqNooHXD02SrrrUJ4auOXJ35KfU5VVcPPFme4z2QQc/high.mp4",
+		},
+	],
+	"0c131bda-bf01-41b2-97ce-80d1fc83026e": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/bIPDFhYRKsDpttEAIfsSK4su7RCVqmkaAkC01zESct7M/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/bIPDFhYRKsDpttEAIfsSK4su7RCVqmkaAkC01zESct7M/high.mp4",
+		},
+	],
+	NGccEsSujysaQIed: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3IyMD00R7thsyYL01wgc8JqFknzQxQiM9YdFpqbE27NSA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3IyMD00R7thsyYL01wgc8JqFknzQxQiM9YdFpqbE27NSA/high.mp4",
+		},
+	],
+	"9e739d52-b11f-47f7-bd63-1d4d863b4ab1": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ipp5yP67Tiy4DdQX9CNCV694ZdMN7zXhDax1d6sm00X4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ipp5yP67Tiy4DdQX9CNCV694ZdMN7zXhDax1d6sm00X4/high.mp4",
+		},
+	],
+	Ug8YmwoOxjKOEeNg: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/bnsVbm4wWgcPeO2a9ukjop01aaZPVCgH2AaquXzFwNW4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/bnsVbm4wWgcPeO2a9ukjop01aaZPVCgH2AaquXzFwNW4/high.mp4",
+		},
+	],
+	Y6IywI3vUiG9AeZe: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/qzCervVrCEALVV6NyKhywHAM9202HckttqGYhIo7TW00w/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/qzCervVrCEALVV6NyKhywHAM9202HckttqGYhIo7TW00w.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/OKxOH02PBgC3ZiPIvkIy7yKrOtWsYqBqD1uaSEbtW3Zc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/OKxOH02PBgC3ZiPIvkIy7yKrOtWsYqBqD1uaSEbtW3Zc.m3u8",
+		},
+	],
+	ODHzWyeiiVF_Q3JZ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/jRCbD7dg5aTztYlDHcaGNCX1r01e48hJ4tA2gZgExHBM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/jRCbD7dg5aTztYlDHcaGNCX1r01e48hJ4tA2gZgExHBM/high.mp4",
+		},
+	],
+	X6XG3En5RH8Ka7X9: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/kiqi7hktcWp702IlnCFNnzMwA4gjdJM1K1vYcjJpmGMc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/kiqi7hktcWp702IlnCFNnzMwA4gjdJM1K1vYcjJpmGMc/high.mp4",
+		},
+	],
+	EPSSOT9ozKJ4BPTy: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Nt7M8X6PoCLsJROT7Hf8F01jOs2mcM5pn6CEgi1KYJzY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Nt7M8X6PoCLsJROT7Hf8F01jOs2mcM5pn6CEgi1KYJzY/high.mp4",
+		},
+	],
+	xdCN5W3rPbuctEXz: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/mQG00mFhu8NhXuasRO01DaNRxYzl6GTWedpIHUpleqX5U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/mQG00mFhu8NhXuasRO01DaNRxYzl6GTWedpIHUpleqX5U/high.mp4",
+		},
+	],
+	GTFIH_gOYlCCC92S: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/wFVzqq3Z1CBDKFkO02nGm00E02vdee201hehZg2yCeW2rBY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/wFVzqq3Z1CBDKFkO02nGm00E02vdee201hehZg2yCeW2rBY/high.mp4",
+		},
+	],
+	"h-O6ehUrYas9zfJd": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/dNaWoeugB32Nk02UtYXIdfOKF9bdrpfWweRcE1pNVeAY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/dNaWoeugB32Nk02UtYXIdfOKF9bdrpfWweRcE1pNVeAY/high.mp4",
+		},
+	],
+	FeNQJ6wqTbMYEy4l: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/B02gHJ8BriKhpAHEKUH4UYJuUgpeDpmU1Dbe00v7CLHqM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/B02gHJ8BriKhpAHEKUH4UYJuUgpeDpmU1Dbe00v7CLHqM/high.mp4",
+		},
+	],
+	jNcIFqAdSNjkvkEq: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Ebwp7e01nxbkvfKabxI9RL00QmxbLgJL4X3OsfMLxMZZw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Ebwp7e01nxbkvfKabxI9RL00QmxbLgJL4X3OsfMLxMZZw/high.mp4",
+		},
+	],
+	KHN9hB2veZtKYSQd: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ApoC02J9JzOc99UOtUoHoVBpkr8bIwmh7GRWHd2yvBDA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ApoC02J9JzOc99UOtUoHoVBpkr8bIwmh7GRWHd2yvBDA/high.mp4",
+		},
+	],
+	"2HvNYbiiSYCLGDLm": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1RQmm95Rl5BJibeyW01HzEDfMYk01N4x8015LJ0176UgWqA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1RQmm95Rl5BJibeyW01HzEDfMYk01N4x8015LJ0176UgWqA/high.mp4",
+		},
+	],
+	ZABoOqaKi1l05B60: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/CjNi8CX1Unpu02goXlraSwJi00okzrIOkpR00R4Ni6gAhQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/CjNi8CX1Unpu02goXlraSwJi00okzrIOkpR00R4Ni6gAhQ/high.mp4",
+		},
+	],
+	"Oi7sI-t0pWwFlIrd": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/eWwaXAZgB9qrrMHpRAavTL1x102fjjQQAnga018OyT8OI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/eWwaXAZgB9qrrMHpRAavTL1x102fjjQQAnga018OyT8OI/high.mp4",
+		},
+	],
+	wijHbng_Ko5ZFlHH: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/L1QFxfgV02lf3j2j468sGEoo8GB9B9aADVRnr6K9OOdo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/L1QFxfgV02lf3j2j468sGEoo8GB9B9aADVRnr6K9OOdo/high.mp4",
+		},
+	],
+	"QjQv-c74lSGUDCnE": [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/BRTOnQrb/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/BRTOnQrb.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/QiEQmkhP/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/QiEQmkhP.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/TFVP3VWT/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/TFVP3VWT.m3u8",
+		},
+	],
+	EP_3kiRUPCsB3Ink: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/iqEXc00fEVBcmhUWtAHBQ9tfixXPMvoWTq21MoMSB8tk/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/iqEXc00fEVBcmhUWtAHBQ9tfixXPMvoWTq21MoMSB8tk/high.mp4",
+		},
+	],
+	"-PfFQ98tPSj0XmKz": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4Nfb02jUDehIJS83RWbA8dhj8KDLBO2kLxwoR2ODW02FY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4Nfb02jUDehIJS83RWbA8dhj8KDLBO2kLxwoR2ODW02FY/high.mp4",
+		},
+	],
+	"16aa93f9-6536-4845-9d36-3bf4f25bd53e": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/NBflBxF026pNReq9Zu1Tylb8IxIMRBPAEPGXSrJF02IGI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/NBflBxF026pNReq9Zu1Tylb8IxIMRBPAEPGXSrJF02IGI/high.mp4",
+		},
+	],
+	"5SXkLGb_cZ3y3SEp": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/aPfaBzK3RbHdHDWwMNhzf5amLPyuh6G94FE01oDi2G5U/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/aPfaBzK3RbHdHDWwMNhzf5amLPyuh6G94FE01oDi2G5U/high.mp4",
+		},
+	],
+	"a966c177-a0bf-4a73-9213-603e4c7f874f": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/XVzbStSKUkaxJJNkPVld92WN02h4Szdv1s8MpxfBfFzs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/XVzbStSKUkaxJJNkPVld92WN02h4Szdv1s8MpxfBfFzs/high.mp4",
+		},
+	],
+	aKxQ07JUJupQ228B: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/RVSVjHmW2wH02h02TThqS1mQLwsmfaqQXIuV02JtYPKouU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/RVSVjHmW2wH02h02TThqS1mQLwsmfaqQXIuV02JtYPKouU/high.mp4",
+		},
+	],
+	"g_N-RlzugzHdxrOT": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/xglRWTJbVvpkgH5q4L6hNPyMmlbfefqhwP9plGdzZO8/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/xglRWTJbVvpkgH5q4L6hNPyMmlbfefqhwP9plGdzZO8/high.mp4",
+		},
+	],
+	"c6a055b1-453e-42fa-8e1e-2c7b7337c2a8": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/tjkeMSZNcKfmXNOMZUchalQaKaOW02fFIt2z3cNsP4t8/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/tjkeMSZNcKfmXNOMZUchalQaKaOW02fFIt2z3cNsP4t8/high.mp4",
+		},
+	],
+	"5sKS1-9ZFVE84haI": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/L36gePYrYnuvjD6An02EhC4P8j00sgPIhJ00L02GobdTD4M/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/L36gePYrYnuvjD6An02EhC4P8j00sgPIhJ00L02GobdTD4M/high.mp4",
+		},
+	],
+	DIw77aTVcaREePpN: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/cBSRfFhgMnJ00l6NumCFH7u9jAWPCB01eay8gyswqkuog/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/cBSRfFhgMnJ00l6NumCFH7u9jAWPCB01eay8gyswqkuog/high.mp4",
+		},
+	],
+	"DL9vy76nqDUN-C39": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/qIHJa6yLi51OC01g02BeBkG6D1BwyPw6sPZS00LyPqnS34/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/qIHJa6yLi51OC01g02BeBkG6D1BwyPw6sPZS00LyPqnS34/high.mp4",
+		},
+	],
+	XNfzZZ_CO6H06iPp: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/qcbzEpPyupWXbnd5ZavjS7j2ZD00cNx1dNJfUWAzeICg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/qcbzEpPyupWXbnd5ZavjS7j2ZD00cNx1dNJfUWAzeICg/high.mp4",
+		},
+	],
+	"d38c603f-42a4-4317-8ab9-9a226f41dac7": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/urH02ZxkyPiJ1P4CbsfOjEZlHehd02RtvOCpwIe009F2pI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/urH02ZxkyPiJ1P4CbsfOjEZlHehd02RtvOCpwIe009F2pI/high.mp4",
+		},
+	],
+	YZ82MoaAeOm4rVTL: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/jAqZ9RwmwqOIYx9OIANbZALQzePRhT00CWKgP9oxd94o/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/jAqZ9RwmwqOIYx9OIANbZALQzePRhT00CWKgP9oxd94o/high.mp4",
+		},
+	],
+	"d40ae794-5202-4909-a753-77917bd914d3": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3xVSuIyrVeSH1I8irN4Xipr8LfeXXw3Cc01iDaFJ4fds/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3xVSuIyrVeSH1I8irN4Xipr8LfeXXw3Cc01iDaFJ4fds/high.mp4",
+		},
+	],
+	AXtEXWt1CcZaV28W: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/izWvGcm5mexmAZTsEfM6LCGbmqmbsgA02INmh6A7Gkxg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/izWvGcm5mexmAZTsEfM6LCGbmqmbsgA02INmh6A7Gkxg/high.mp4",
+		},
+	],
+	rwTxzKiYAl8UENGp: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/iQiKGZXmzk00XIWNU9R6vIb8j01FkbSfEaifmN5KUsf7I/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/iQiKGZXmzk00XIWNU9R6vIb8j01FkbSfEaifmN5KUsf7I/high.mp4",
+		},
+	],
+	cGKByiAR77dtK3lu: [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/vntDVNBS/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/vntDVNBS.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/6Z2a3aCp/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/6Z2a3aCp.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/zR1QvvSl/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/zR1QvvSl.m3u8",
+		},
+	],
+	"b254f76e-3109-4db3-bae7-63ea400e63f1": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3iHPCn6DWO0000hg007PDSWWU44WtjE1t79DMiEzPod00Oo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3iHPCn6DWO0000hg007PDSWWU44WtjE1t79DMiEzPod00Oo/high.mp4",
+		},
+	],
+	"7qYIp48o0GJU5M0M": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/A8MsqLkU02i6C5FhYqyN39UOm3uuu01M02VeBduZqjSfGI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/A8MsqLkU02i6C5FhYqyN39UOm3uuu01M02VeBduZqjSfGI/high.mp4",
+		},
+	],
+	"eh2ElKDA1-0NYgK1": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/mDq88pzCSBxe3S01pY01IeMNUeEb57WGEO29q3T02vsMHk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/mDq88pzCSBxe3S01pY01IeMNUeEb57WGEO29q3T02vsMHk/high.mp4",
+		},
+	],
+	"6fQ73rEu3CXnMdY6": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/oT1byPoU2IUEOzZQ0001mHkDdaT9wcsju8U2PZjK02W94Q/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/oT1byPoU2IUEOzZQ0001mHkDdaT9wcsju8U2PZjK02W94Q/high.mp4",
+		},
+	],
+	Nt9h8E_VjwMXl0CP: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/nstehj01Pnpks7XOXyMy3pB8oRVrut8MoipLggkxwMFI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/nstehj01Pnpks7XOXyMy3pB8oRVrut8MoipLggkxwMFI/high.mp4",
+		},
+	],
+	buqjllm5RHJPZySA: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/MABSio02b2xGGSm00003LuKnDWQ2ow2DjM7sVWCb00t802eQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/MABSio02b2xGGSm00003LuKnDWQ2ow2DjM7sVWCb00t802eQ/high.mp4",
+		},
+	],
+	RZtNggNHiRbBJyO2: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/MjdR4XbKRuwb3kp8oWiyms00VlZ3NMwYE00GrmwgJvwY00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/MjdR4XbKRuwb3kp8oWiyms00VlZ3NMwYE00GrmwgJvwY00/high.mp4",
+		},
+	],
+	"a63h4_NqIpx-HBY2": [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/Tet8cXfO/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/Tet8cXfO.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/HJYSKeIk/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/HJYSKeIk.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/WzVmdT36/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/WzVmdT36.m3u8",
+		},
+	],
+	W1Uln6rijqNr0JtJ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/hFcgPiOc/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/hFcgPiOc.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/Wi2RcfmD/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/Wi2RcfmD.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/qYzLYCXT/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/qYzLYCXT.m3u8",
+		},
+	],
+	"e280829c-aa17-4812-b8fa-bcd0d89ad815": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/yV004YanH6W02N6li02PI43BiOfAPaPMZQ61pLWRB00a2ik/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/yV004YanH6W02N6li02PI43BiOfAPaPMZQ61pLWRB00a2ik/high.mp4",
+		},
+	],
+	e5EEv3artsk4BLyj: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/VYzME6MbqFRkJmW3x9kaDYfq68l00dYHqjLa7ZUb7sJI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/VYzME6MbqFRkJmW3x9kaDYfq68l00dYHqjLa7ZUb7sJI/high.mp4",
+		},
+	],
+	M95krGoj6WkwAIgO: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/QUX4QFRwQrucV025q41XUR00hlt4qKxyK2TjpEQt4AvrE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/QUX4QFRwQrucV025q41XUR00hlt4qKxyK2TjpEQt4AvrE/high.mp4",
+		},
+	],
+	"zVTUCilmg4fZPg-N": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/zAmFmVSuWF1psKEmxTsPMfSFGF3fjkBgswpezkEnDkc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/zAmFmVSuWF1psKEmxTsPMfSFGF3fjkBgswpezkEnDkc/high.mp4",
+		},
+	],
+	"2oFMuvdDagw-OcYY": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01VjKibenwWn01Jq2NWHT01JpaF02x02D02U02OneBvXWYjgeU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01VjKibenwWn01Jq2NWHT01JpaF02x02D02U02OneBvXWYjgeU/high.mp4",
+		},
+	],
+	wmNz4Hk9A8_ls07m: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ZadYVgpdV008pf00ROeikBbPPLSMwtoSSEEvv02c6YmOkw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ZadYVgpdV008pf00ROeikBbPPLSMwtoSSEEvv02c6YmOkw/high.mp4",
+		},
+	],
+	"7g8m11dxjxFtlVaE": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/rT5e9voXJJoPCui00BAs2MdgkfWEFBK1XX02lFr9Px0100s/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/rT5e9voXJJoPCui00BAs2MdgkfWEFBK1XX02lFr9Px0100s/high.mp4",
+		},
+	],
+	"8c291e21-6e26-49ff-9e24-048d6868f05d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/rUalg4pL8yLpPv5adqYb3iDSc1DATDIFcb02zaIdsqdE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/rUalg4pL8yLpPv5adqYb3iDSc1DATDIFcb02zaIdsqdE/high.mp4",
+		},
+	],
+	enuJ_FgAzXDLAweK: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/dVsEYZk1W6O801gBjNxhR02LpsUm1YpdZLnKdTjO3kwWE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/dVsEYZk1W6O801gBjNxhR02LpsUm1YpdZLnKdTjO3kwWE/high.mp4",
+		},
+	],
+	HFrc4ELZxjSKX8PW: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Z1mzlC702BTCtKGOruLVt701nDNh15R4XrZnsMsD3lsjk/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Z1mzlC702BTCtKGOruLVt701nDNh15R4XrZnsMsD3lsjk/high.mp4",
+		},
+	],
+	"466aeaab-97f1-4a25-804e-67a87a9e5e75": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/nALAA4FZSmtGPtXoNm2lbwMrmsYW9iG2Og2cAcLzypI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/nALAA4FZSmtGPtXoNm2lbwMrmsYW9iG2Og2cAcLzypI/high.mp4",
+		},
+	],
+	"p5QJuQ4Gpc-2sLZz": [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/tGwK6uyN/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/tGwK6uyN.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/ezB4QGES/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/ezB4QGES.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/rH3LZVhx/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/rH3LZVhx.m3u8",
+		},
+	],
+	SGbLXOqIwiSLAAm2: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/9B4wWrdEb6JHWWSwQs3cuV2WlkrzLFxgRdLMNSEW35A/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/9B4wWrdEb6JHWWSwQs3cuV2WlkrzLFxgRdLMNSEW35A/high.mp4",
+		},
+	],
+	L9ef4EDfoUGYfJBa: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/52VlrPgiQA4SDX00oOJ01hjO28QXki3kBzDkbFQrOGwQc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/52VlrPgiQA4SDX00oOJ01hjO28QXki3kBzDkbFQrOGwQc/high.mp4",
+		},
+	],
+	"00333846-20f5-449a-b836-8568e26d6f43": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/m00WxMFKMgdlbAuC8hKFIjRvXcMrV8qGOL7yHKV01BoYo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/m00WxMFKMgdlbAuC8hKFIjRvXcMrV8qGOL7yHKV01BoYo/high.mp4",
+		},
+	],
+	"5a7fe3d4-b7f2-4d3f-b92d-4db316c4cd68": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/DeeFDfQ8CeBROavLsvzkKcyrzniCUF3ZhfcmkfPbJls/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/DeeFDfQ8CeBROavLsvzkKcyrzniCUF3ZhfcmkfPbJls/high.mp4",
+		},
+	],
+	CL3J9A1NUUk3Lyez: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/YJXgmROeDvcsZ61TEAFbO602I41CbseVP6BSEgZlmX900/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/YJXgmROeDvcsZ61TEAFbO602I41CbseVP6BSEgZlmX900/high.mp4",
+		},
+	],
+	"5f9e4b5c-4831-4e29-8b75-e0d606f3d97e": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/wU8bnSyfnjNkB1IL6DFvA01DEZNqJnG9tE4DdWxk12i8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/wU8bnSyfnjNkB1IL6DFvA01DEZNqJnG9tE4DdWxk12i8/high.mp4",
+		},
+	],
+	NnBFWmAhKBhucHVk: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/XHmVcEs7wBZ73vXL9IICcEqTIF1xASrtgbEUQ00EAEZw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/XHmVcEs7wBZ73vXL9IICcEqTIF1xASrtgbEUQ00EAEZw/high.mp4",
+		},
+	],
+	"05wiA4Eqtrj388Ui": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Svoqp007Ezfz9KrVY202Lji6ouUVCgILQMfE59L64trh00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Svoqp007Ezfz9KrVY202Lji6ouUVCgILQMfE59L64trh00/high.mp4",
+		},
+	],
+	"77f8d4e5-d97c-43ac-b4fc-d5ff35f67f8d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/l5cCcCQbEYTuRA8Q01NOTbz00Mnled7r19P02nnfwBELxA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/l5cCcCQbEYTuRA8Q01NOTbz00Mnled7r19P02nnfwBELxA/high.mp4",
+		},
+	],
+	zobadSBT6nfdv3yI: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/zhMYKf01DiAqGkLXxJP500wEc4tUrLKVK5f6dL97NPVSc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/zhMYKf01DiAqGkLXxJP500wEc4tUrLKVK5f6dL97NPVSc/high.mp4",
+		},
+	],
+	kvPr4LgQyeCDjYKP: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/xzzRHt01gZGp7fo29gwj8FrRPve8NSsMDX02tZ009K2bms/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/xzzRHt01gZGp7fo29gwj8FrRPve8NSsMDX02tZ009K2bms/high.mp4",
+		},
+	],
+	FtvSsh4ZEP6qT2RL: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/83c00NZwx1axAZgeMxPg9vCNmMZlntf00p8gZtWEI01zIY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/83c00NZwx1axAZgeMxPg9vCNmMZlntf00p8gZtWEI01zIY/high.mp4",
+		},
+	],
+	o4uIPacv72Goi9JA: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/xeG7eh2nK00YkcqXzMMs02t300fLS002c01K00f65JlIuUVyY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/xeG7eh2nK00YkcqXzMMs02t300fLS002c01K00f65JlIuUVyY/high.mp4",
+		},
+	],
+	MUqWc_cySh8Szk49: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/OHMbXplg02aM2RJL00bhCB02sFHk6U9AoiDqCoZDI51X100/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/OHMbXplg02aM2RJL00bhCB02sFHk6U9AoiDqCoZDI51X100/high.mp4",
+		},
+	],
+	"9PL2fxrAj07KBsQH": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/yK5PDQX02typEMYelu8ICh01B9di5pFgrbUprJ1oPLMII/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yK5PDQX02typEMYelu8ICh01B9di5pFgrbUprJ1oPLMII.m3u8",
+		},
+	],
+	"8XrdZAWCHGX1f6rH": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/HwMUojbgTfG2YoSkBCBw02b5Njozr01xkDW6U4rjEDCEs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/HwMUojbgTfG2YoSkBCBw02b5Njozr01xkDW6U4rjEDCEs/high.mp4",
+		},
+	],
+	uG_lnrHRRxh5aVUI: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/wCZaGu2P01W9lJUejy3moG4S4Tr012DBW0101u01FUhsvN1Q/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/wCZaGu2P01W9lJUejy3moG4S4Tr012DBW0101u01FUhsvN1Q/high.mp4",
+		},
+	],
+	"HGS1rVxzU-fKxy7U": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01XnJoY00RP5cbFYQKLZk5MTi00tFc2GBcdC02BT65rGpx8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01XnJoY00RP5cbFYQKLZk5MTi00tFc2GBcdC02BT65rGpx8/high.mp4",
+		},
+	],
+	"UIELgL8xBwzqA-B6": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/msJV6g00xYFMfytOa7WVcudUYmbCIN6Lu01a6H8Iz7X7k/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/msJV6g00xYFMfytOa7WVcudUYmbCIN6Lu01a6H8Iz7X7k/high.mp4",
+		},
+	],
+	ilgPPNsBHESEbB2E: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/007B4zfOtamSVH7l13O700RsQmZ00uCsmGHxfSbG8y5qyc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/007B4zfOtamSVH7l13O700RsQmZ00uCsmGHxfSbG8y5qyc/high.mp4",
+		},
+	],
+	f38F12ElLyWFqOrp: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/KptIiP026uLIW9ZrD7kGZ8QacAALnr6vbx85i01paV5MI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/KptIiP026uLIW9ZrD7kGZ8QacAALnr6vbx85i01paV5MI/high.mp4",
+		},
+	],
+	csCzqNi4jTvJwYk1: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/n3PSSAGdyvGlNGJXbk2PocQv7IP5zkLQ7Ee1p01WWH1c/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/n3PSSAGdyvGlNGJXbk2PocQv7IP5zkLQ7Ee1p01WWH1c.m3u8",
+		},
+	],
+	"ZiydGYd_VS4A2E-m": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/q8UPv7025vy8yszwhCTV2AUj00LH025o5bCVdTxtVZOXVI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/q8UPv7025vy8yszwhCTV2AUj00LH025o5bCVdTxtVZOXVI/high.mp4",
+		},
+	],
+	C9PbqbyF98XO4u3h: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/67Z9ETYDC00xOTHPbBkFO8ZlG131DuFMH8cXNEVFH4kw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/67Z9ETYDC00xOTHPbBkFO8ZlG131DuFMH8cXNEVFH4kw/high.mp4",
+		},
+	],
+	"4ejxmL2cNgn1D1Iy": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/iIZZgFvbQ01Qh12WUGx00VNULO7RA8yNVWPJErd00GATZA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/iIZZgFvbQ01Qh12WUGx00VNULO7RA8yNVWPJErd00GATZA/high.mp4",
+		},
+	],
+	"T6Vf4-OIurKVfECK": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/EUc5Xw01Lb4LB8xTnguKsJJ8TscM02o00ImQMYkDOqkjgk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/EUc5Xw01Lb4LB8xTnguKsJJ8TscM02o00ImQMYkDOqkjgk/high.mp4",
+		},
+	],
+	"o6m-8Vt7VBtb0zNj": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/s57y2rs400dHULIrWRkoDnX8nlULMn3qYXYCwLJqiYvY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/s57y2rs400dHULIrWRkoDnX8nlULMn3qYXYCwLJqiYvY/high.mp4",
+		},
+	],
+	"39689096-7fb9-46aa-a411-59c5c6886c5d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ZK01BfWc17oan57l5eajkeqIutQjbQMA00L01R02YHlNsng/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ZK01BfWc17oan57l5eajkeqIutQjbQMA00L01R02YHlNsng/high.mp4",
+		},
+	],
+	ahjtUdXqry3RTxfC: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/8GqKqhWMZywOqQAu01FRrEkSbXkLiIP2IHCCGKOGbxLw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/8GqKqhWMZywOqQAu01FRrEkSbXkLiIP2IHCCGKOGbxLw.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/CZ7arMYtfnrsN7jsdOzc00WaGvsZxJWZqSygA2pZiXfM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/CZ7arMYtfnrsN7jsdOzc00WaGvsZxJWZqSygA2pZiXfM.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/DMt3zZpQEfw6QlP01mun01kaNSsCMuONtBYcBSidbPBLk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/DMt3zZpQEfw6QlP01mun01kaNSsCMuONtBYcBSidbPBLk.m3u8",
+		},
+	],
+	ao5pj3MoMoeNZX4i: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/6vUq6YH9z01CUQmTaO1s00cY3HvTfU8gOqWty8DwX8Cio/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/6vUq6YH9z01CUQmTaO1s00cY3HvTfU8gOqWty8DwX8Cio.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Cfi02t01Qk2nGl0241102afECsdKS01XRRfqVc1MULhjUKKA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Cfi02t01Qk2nGl0241102afECsdKS01XRRfqVc1MULhjUKKA.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/c02scqnefxwIeMjPIeEEI5pqnf8hlqk1xmJcABhmJ02Vg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/c02scqnefxwIeMjPIeEEI5pqnf8hlqk1xmJcABhmJ02Vg.m3u8",
+		},
+	],
+	ntLTaE7RsedsHKZV: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/u9in78wXVWLC014GugPgzspy02sY02JeBxeCjnGZcqQ2dE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/u9in78wXVWLC014GugPgzspy02sY02JeBxeCjnGZcqQ2dE/high.mp4",
+		},
+	],
+	Sn57z0sEiQCQpgfJ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/JHfmwlZFxBZh4uCz01SUnKQ9Xq9tLn4zo00r6mw3BG4WQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/JHfmwlZFxBZh4uCz01SUnKQ9Xq9tLn4zo00r6mw3BG4WQ/high.mp4",
+		},
+	],
+	aR4mXWcgsqNaxw4C: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1nx4KNDapYoX7l9h38XpUu3GcBmpZQ7MFOy22kG2QKQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1nx4KNDapYoX7l9h38XpUu3GcBmpZQ7MFOy22kG2QKQ/high.mp4",
+		},
+	],
+	"99dda2a6-96fa-4d82-970d-58b69425d4db": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01I02I02YXbTgA3IE6kTvAxOp4Mayhjz3Wl2y8Z5cyrdrQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01I02I02YXbTgA3IE6kTvAxOp4Mayhjz3Wl2y8Z5cyrdrQ/high.mp4",
+		},
+	],
+	IRJrP1HLEvLeAYwt: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/AxaVmL500QQuV7U0101b7hQwruDySYC1EfDJDkl01hilesI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/AxaVmL500QQuV7U0101b7hQwruDySYC1EfDJDkl01hilesI/high.mp4",
+		},
+	],
+	"8a1690db-cb4f-4e0a-9f66-425e0d5fc3c3": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/eKvnUxS1JAokB2t01y98FKbUv81lDPJM9LBgwnvxdwTU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/eKvnUxS1JAokB2t01y98FKbUv81lDPJM9LBgwnvxdwTU/high.mp4",
+		},
+	],
+	nLSiGdO5Pt5xB2Jl: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/OBflURl1yvhVNPOCpFzc43a2T9hjRW8XYLer5mBPV6I/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/OBflURl1yvhVNPOCpFzc43a2T9hjRW8XYLer5mBPV6I/high.mp4",
+		},
+	],
+	imQqkbnWAkEtJFVN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/rzndZxhHyG1NJ98dQngpWeaOE7HWfqz2w00xes6qbP6U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/rzndZxhHyG1NJ98dQngpWeaOE7HWfqz2w00xes6qbP6U/high.mp4",
+		},
+	],
+	KUOt38TOSrJUXIFm: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01eDo43vAl6HTgTVLhynRCbFkpADVwhD7RvqS02ydqifU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01eDo43vAl6HTgTVLhynRCbFkpADVwhD7RvqS02ydqifU/high.mp4",
+		},
+	],
+	"3e6095a6-e21c-4e8e-ae86-c6cd8e4c9f47": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/FWwgw47V00W5004ylE1QKFbxMvLuXih8xwBKgYAhOGr9s/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/FWwgw47V00W5004ylE1QKFbxMvLuXih8xwBKgYAhOGr9s/high.mp4",
+		},
+	],
+	"60i5YhMCUmSrvC0E": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/TZdJBmvY9FQR8BHZs4qNy025QKdBKulEoX72K3HXqPjs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/TZdJBmvY9FQR8BHZs4qNy025QKdBKulEoX72K3HXqPjs.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/01BYJQdco6frpJ4XTXwRcoddZ01U3qLCj00XMmh00yA01VI00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01BYJQdco6frpJ4XTXwRcoddZ01U3qLCj00XMmh00yA01VI00.m3u8",
+		},
+	],
+	"1919lq3w9ygAXn5a": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/HMKZAD00rxq7eb1w3hhd4eYvvWbWWU02C0201W3VKRjk3kE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/HMKZAD00rxq7eb1w3hhd4eYvvWbWWU02C0201W3VKRjk3kE/high.mp4",
+		},
+	],
+	WL5DgNRLlWuV4Z1e: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2cWW6iTlskqJrW9ldZpbWZTZmJh00jWWgDSSnPExLxfo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2cWW6iTlskqJrW9ldZpbWZTZmJh00jWWgDSSnPExLxfo/high.mp4",
+		},
+	],
+	"AROgN8hQF-MJXYGX": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/qO6hVHK3de7riSg01dqNoU9fG5P2BBWkF02ywMoivuqEE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/qO6hVHK3de7riSg01dqNoU9fG5P2BBWkF02ywMoivuqEE/high.mp4",
+		},
+	],
+	"2nTn2QR6MyezFYmK": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/502jsjJ1bHV3fUejIsZ4AlVYolbKVB02y8WIPEZc1e7ZE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/502jsjJ1bHV3fUejIsZ4AlVYolbKVB02y8WIPEZc1e7ZE/high.mp4",
+		},
+	],
+	"6a039e64-c680-407b-b327-f60651f259ad": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/yIjusgmfD7nVPQxnlcWevcKPY997mal00Pa00heDc00mnc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yIjusgmfD7nVPQxnlcWevcKPY997mal00Pa00heDc00mnc/high.mp4",
+		},
+	],
+	jczA1loFruC9mHFD: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/gwyMr1gtiGphCBkeihuFhaFSdCaGFPXj5ODI00VeEDPY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/gwyMr1gtiGphCBkeihuFhaFSdCaGFPXj5ODI00VeEDPY/high.mp4",
+		},
+	],
+	tfsJJRS6I7cOSo71: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/NgLq8lVPRgJMOgx3o5xMydW00lMRU9w3wLNQDya3wi34/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/NgLq8lVPRgJMOgx3o5xMydW00lMRU9w3wLNQDya3wi34/high.mp4",
+		},
+	],
+	euBpwFXDmK3qak2_: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/D01MEMSF4FjWV3PmU82qOhpinvFx2RdMX02h7Zng1VBHA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/D01MEMSF4FjWV3PmU82qOhpinvFx2RdMX02h7Zng1VBHA/high.mp4",
+		},
+	],
+	"y1ydZQjxjqNn-Fl7": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/D022IpqF5h01ywKWK2RZcNC8PA2B00O2HkRBVqR4tFnMDs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/D022IpqF5h01ywKWK2RZcNC8PA2B00O2HkRBVqR4tFnMDs/high.mp4",
+		},
+	],
+	"kEwXnlEyK-gLtp1J": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ec8nzk00yC59CBLd7FYl3GPDiFzyr5O2e8RFKuzg9i01k/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ec8nzk00yC59CBLd7FYl3GPDiFzyr5O2e8RFKuzg9i01k/high.mp4",
+		},
+	],
+	qcAqLw_mt6nnAefJ: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/rTvgiFRdSdX5Wa202vP45gsa6G6Rp38USczocWnD476Q/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/rTvgiFRdSdX5Wa202vP45gsa6G6Rp38USczocWnD476Q/high.mp4",
+		},
+	],
+	"90f40bd9-7870-4dfd-8a7a-d7114d1e1e4b": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/yuy4716dscxUDtL01F7G02wxAaB6Zrrx8shv44xFeHqVw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/yuy4716dscxUDtL01F7G02wxAaB6Zrrx8shv44xFeHqVw/high.mp4",
+		},
+	],
+	g8ORRFXiKwPYJSuk: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/77DZGbBQqWV01TuQzYbexx7yv1Zwpo2Mb2z00ItQjMMds/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/77DZGbBQqWV01TuQzYbexx7yv1Zwpo2Mb2z00ItQjMMds/high.mp4",
+		},
+	],
+	"7YlYX83qqe_MjJbS": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/mO4pE7W9F5ZxwLEqmtIFU5Ictz900mCLNx01prR7D6Vso/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/mO4pE7W9F5ZxwLEqmtIFU5Ictz900mCLNx01prR7D6Vso/high.mp4",
+		},
+	],
+	pONqA7dx9ROVRNMN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/EzfFJboMYo2lSVVJOpz8Yu2J2VliMRrGmV3tnq02vHgQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/EzfFJboMYo2lSVVJOpz8Yu2J2VliMRrGmV3tnq02vHgQ/high.mp4",
+		},
+	],
+	MLcolTxOLfRTxRTu: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/OfVFkjvK02HYkRhEj2oOXIyExNe8rEincCLNImeb5Dts/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/OfVFkjvK02HYkRhEj2oOXIyExNe8rEincCLNImeb5Dts/high.mp4",
+		},
+	],
+	"0QhlDEy6q95TInlZ": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2UJKphuziZZFCCHKxapBwq5KJ4GNzasn8YamYVA67ck/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2UJKphuziZZFCCHKxapBwq5KJ4GNzasn8YamYVA67ck/high.mp4",
+		},
+	],
+	OqH0Hh9eHMhJrPmN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/BKNJVUqZYuzp2P00ckjeQ4MWPO8tc6XYhLTCjr00tXZ8A/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/BKNJVUqZYuzp2P00ckjeQ4MWPO8tc6XYhLTCjr00tXZ8A/high.mp4",
+		},
+	],
+	"5g98sjn_L1EN7_11": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/nE1400AGmvJ02sjjBaKHdZ4hHZSX01w54KfZSPEALmVwaw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/nE1400AGmvJ02sjjBaKHdZ4hHZSX01w54KfZSPEALmVwaw/high.mp4",
+		},
+	],
+	kFJrgV343MD0uOZs: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/u3ntuUPLxjtt1joNvyG4b025025YkETcP5yc00bamDj5600/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/u3ntuUPLxjtt1joNvyG4b025025YkETcP5yc00bamDj5600/high.mp4",
+		},
+	],
+	"8WHxwWifeoVP8vLq": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/FMPTT43fVG7Dqk4SGbtQjPifegdcOvHzw2v00dC01OqW4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/FMPTT43fVG7Dqk4SGbtQjPifegdcOvHzw2v00dC01OqW4/high.mp4",
+		},
+	],
+	Y030qNm3LisddglM: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/g65fkp00XZ6uw69fMY02tzLUCt004nt02Xd5N3ufwCUmi7A/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/g65fkp00XZ6uw69fMY02tzLUCt004nt02Xd5N3ufwCUmi7A/high.mp4",
+		},
+	],
+	qfeYOQWqoOIAw_0H: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/u8xZMLVBGUWTV01xoxy00AhptWXVB6XuxGl0200BPdivNJY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/u8xZMLVBGUWTV01xoxy00AhptWXVB6XuxGl0200BPdivNJY/high.mp4",
+		},
+	],
+	rIjnJFQUK3mDbwBW: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/eUUBNmA7Y7LXI9ovmlFuG01roWD4Vf8XMlYQ3tDT02DrA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/eUUBNmA7Y7LXI9ovmlFuG01roWD4Vf8XMlYQ3tDT02DrA/high.mp4",
+		},
+	],
+	"444f2537-5323-4383-a5ef-f6a4713089e6": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/fLnSATrFHT5d201eCbZOUPN01O02uYl01KuZdAaLreGEu6s/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/fLnSATrFHT5d201eCbZOUPN01O02uYl01KuZdAaLreGEu6s/high.mp4",
+		},
+	],
+	"6f2112ee-73db-44e8-bef7-cd159b240ee6": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/RNE6iFyZS76xtZy8TTcpUclfH101RgRMWRkFt48bbCtE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/RNE6iFyZS76xtZy8TTcpUclfH101RgRMWRkFt48bbCtE/high.mp4",
+		},
+	],
+	mp97oJ4W0SI78jvT: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/JYcXRp6GsKSa5kB4pO35KQWx9eqrPuENy9I8rS175rY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/JYcXRp6GsKSa5kB4pO35KQWx9eqrPuENy9I8rS175rY/high.mp4",
+		},
+	],
+	"3Z7atG3_ZBQ4OUF2": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/b4MoavYx300owsYWgW702ZWzWGYftJdR4j4HZNICTdcnM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/b4MoavYx300owsYWgW702ZWzWGYftJdR4j4HZNICTdcnM/high.mp4",
+		},
+	],
+	qBo43vpQrKDn3MNW: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/wEiErPskXmIuBS3aJF3CiuLWig1QPFyClXRCGvaEeiA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/wEiErPskXmIuBS3aJF3CiuLWig1QPFyClXRCGvaEeiA/high.mp4",
+		},
+	],
+	"edf191ba-df39-45a3-b2b2-d14c266fc805": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/DpNvVaL38JXfvlZEKxuSXaor38aqJSL3j7FJrb301ZpM/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/DpNvVaL38JXfvlZEKxuSXaor38aqJSL3j7FJrb301ZpM/high.mp4",
+		},
+	],
+	vvG84utDyVrhhcJB: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/7FNWvalUu015jZVt49FrHCE2C001jRg02xhUCvDYz01DaFw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/7FNWvalUu015jZVt49FrHCE2C001jRg02xhUCvDYz01DaFw/high.mp4",
+		},
+	],
+	quqCUFHCothZ1u2_: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/02Ib4alTTVoc7gFs01w6y02zlldiuPE8U4v9Cew43HhLY4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/02Ib4alTTVoc7gFs01w6y02zlldiuPE8U4v9Cew43HhLY4/high.mp4",
+		},
+	],
+	zh9OICfiuWpUzFOl: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/46IqGdnvKhBRi91rtY7M02V3F6HSPnfpqaUbl75maQds/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/46IqGdnvKhBRi91rtY7M02V3F6HSPnfpqaUbl75maQds/high.mp4",
+		},
+	],
+	xmHV0WcogmH6JHUD: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/qmOUwyQHZjfeZvpiol3A2FBc1P2PLK8ddcrmvG400hUY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/qmOUwyQHZjfeZvpiol3A2FBc1P2PLK8ddcrmvG400hUY/high.mp4",
+		},
+	],
+	"2d576803-aaaa-414b-8e9f-c79a771ca0a6": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/02sSuSbAS9nVjtUC5wPkfMDCL5v5Gddbg6bAUjKJzqhE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/02sSuSbAS9nVjtUC5wPkfMDCL5v5Gddbg6bAUjKJzqhE/high.mp4",
+		},
+	],
+	SNST6WaWx0UFbOW7: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/yqSG4Nh3NWp2smX7CrHXVIHrA00ZKlWVe9xv4ub5QZF00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yqSG4Nh3NWp2smX7CrHXVIHrA00ZKlWVe9xv4ub5QZF00/high.mp4",
+		},
+	],
+	WHNs4slzrNpbufWN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/XfRaXWHV00R5Z01d64h6W2EHFyONJ5003a2V8wxQxU00cu00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/XfRaXWHV00R5Z01d64h6W2EHFyONJ5003a2V8wxQxU00cu00/high.mp4",
+		},
+	],
+	D1Y2OXKWho0zFgv9: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/tNpZFuPRqkUgvNremtkX4yrWLFg9nyMUW00OIpfuBMCE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/tNpZFuPRqkUgvNremtkX4yrWLFg9nyMUW00OIpfuBMCE/high.mp4",
+		},
+	],
+	"022e4412-1a63-4b75-8685-11f8a1136f56": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/a2ZM01ri66MmKHPoTXxxH35qzlB4UhH5mcERgIRCttDg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/a2ZM01ri66MmKHPoTXxxH35qzlB4UhH5mcERgIRCttDg/high.mp4",
+		},
+	],
+	fLu7cq8ndoGD7o1N: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/etTbycbFVyTjNwmlcnJFsIsLvY7OtoBu01kdH7AXZ100U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/etTbycbFVyTjNwmlcnJFsIsLvY7OtoBu01kdH7AXZ100U/high.mp4",
+		},
+	],
+	xh7phUUawthAuF41: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1cPll2ozE13uDwAzwzwTl6QJQLsr8N01NZGq7w1Ns02aw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1cPll2ozE13uDwAzwzwTl6QJQLsr8N01NZGq7w1Ns02aw/high.mp4",
+		},
+	],
+	cJkTi7rZz0DmvcIF: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/OHLuCRobmGKsfrbFEimxvZXGfoBNcIo3tUMBcjnL9x4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/OHLuCRobmGKsfrbFEimxvZXGfoBNcIo3tUMBcjnL9x4/high.mp4",
+		},
+	],
+	IIglddaLiD3aFW9a: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/NLvRW01pMdBl83KU5HTwJtmLb9DFG9eK9PPODvMpKz6k/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/NLvRW01pMdBl83KU5HTwJtmLb9DFG9eK9PPODvMpKz6k/high.mp4",
+		},
+	],
+	"K-YedLFEl0jIZ0Oy": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/RcJi02agoN601shB8YWpqUy0202lNK2zuZMad8fsubOd2Ng/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/RcJi02agoN601shB8YWpqUy0202lNK2zuZMad8fsubOd2Ng/high.mp4",
+		},
+	],
+	yEp_qL0Rdlu8lURJ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/MRrOgOPKPfKu8diSCHhommGyEeyLIdCSFJmQqjypu2E/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/MRrOgOPKPfKu8diSCHhommGyEeyLIdCSFJmQqjypu2E/high.mp4",
+		},
+	],
+	Xcaj16Dwf3CFZp7G: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2U48drppZrv5h43ddcXggd52tyARQs5ha028011XhdJts/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2U48drppZrv5h43ddcXggd52tyARQs5ha028011XhdJts/high.mp4",
+		},
+	],
+	"128a2325-bee2-46e5-9124-1d2f2f44f44c": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/GtjNVvCvQHt02RbfRc6xeTvntsNjBJo2nNFPvSPoH4to/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/GtjNVvCvQHt02RbfRc6xeTvntsNjBJo2nNFPvSPoH4to/high.mp4",
+		},
+	],
+	"d476fb75-69c2-44c9-8cb5-f477572a20c4": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/IStHf602wxFVBTF1DSzSURaSgh3w00kRoI301pw5AD7fOc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/IStHf602wxFVBTF1DSzSURaSgh3w00kRoI301pw5AD7fOc/high.mp4",
+		},
+	],
+	kSLyRg4bjLuzTeIM: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/6fvERcVrmB9500UFqBXiPeL5OCdms7RgPYsCtfncOiWE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/6fvERcVrmB9500UFqBXiPeL5OCdms7RgPYsCtfncOiWE/high.mp4",
+		},
+	],
+	"2S9GLUWvISCI0RFC": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/pnSpZACKKMxJO3rKiviyfAKWRM4skxS1wsV7s2a02uFc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/pnSpZACKKMxJO3rKiviyfAKWRM4skxS1wsV7s2a02uFc/high.mp4",
+		},
+	],
+	"b905e73f-fb98-4fc6-aa70-e949fec85168": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/FMlB8D3NIqtxY8l91SEsIJXCkIMEGSL37Cqd2YUUCo8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/FMlB8D3NIqtxY8l91SEsIJXCkIMEGSL37Cqd2YUUCo8/high.mp4",
+		},
+	],
+	NmuYV1NROjrd0NaU: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1M2gmIWgNgAugHtCHhXsf3F72G88I11WZrsoS900M1wU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1M2gmIWgNgAugHtCHhXsf3F72G88I11WZrsoS900M1wU/high.mp4",
+		},
+	],
+	"547f2b6e-3ff8-485f-8250-2be98d7c308b": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/GLg00OZKikmiO01PXrwbHWQbT9YlHLclkYkRkmQdz94L4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/GLg00OZKikmiO01PXrwbHWQbT9YlHLclkYkRkmQdz94L4/high.mp4",
+		},
+	],
+	"30916191-9c65-49a8-83c9-c1a90c4ecdf0": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4uB2m01P8qhxi1KqyvnW7agpLQVXCjM9yJqDfd1WcJDM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4uB2m01P8qhxi1KqyvnW7agpLQVXCjM9yJqDfd1WcJDM/high.mp4",
+		},
+	],
+	"6554009f-e200-44db-8630-41b477beebb1": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/CuHXyoiUKwh01HyVgIwN02lUd7h4JYNHBorAVUDzA8WKg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/CuHXyoiUKwh01HyVgIwN02lUd7h4JYNHBorAVUDzA8WKg/high.mp4",
+		},
+	],
+	jWS9wZZCxvD9dId8: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/qUZcfFR4Dqv201vSrC9IqMgsVX1cFAyiKEKcV5DBxl01o/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/qUZcfFR4Dqv201vSrC9IqMgsVX1cFAyiKEKcV5DBxl01o/high.mp4",
+		},
+	],
+	fzx9ee24mUvP9myC: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/n1mML2KKKae2HuWKpGFqJzYrrCJnSzDZ01sB01VAS5kFE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/n1mML2KKKae2HuWKpGFqJzYrrCJnSzDZ01sB01VAS5kFE/high.mp4",
+		},
+	],
+	"e467f6b8-1e92-4571-b3e6-c020ca7099c3": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/fHPxn2U9Gjzd7IKWXzAyH3xE2WJBVLoc00RzvcIFflk00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/fHPxn2U9Gjzd7IKWXzAyH3xE2WJBVLoc00RzvcIFflk00/high.mp4",
+		},
+	],
+	iXyCCE5OzEeOL72t: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/hnzcs1jEYTDGA39PmxBn012cRxBZnOCkjFBHSv5UrCuQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/hnzcs1jEYTDGA39PmxBn012cRxBZnOCkjFBHSv5UrCuQ/high.mp4",
+		},
+	],
+	"qzYXOq7xVNS-9gcT": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/zBPwWAvzf8jeYH1QZXpRwJcbbCxfiV5Y300ntqk7mLE4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/zBPwWAvzf8jeYH1QZXpRwJcbbCxfiV5Y300ntqk7mLE4/high.mp4",
+		},
+	],
+	_i1E704BS8bngWrv: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/sNOfpXOgTskWLh901rXM2knzbKyZQRZ4c4TCTOpYHNHE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/sNOfpXOgTskWLh901rXM2knzbKyZQRZ4c4TCTOpYHNHE/high.mp4",
+		},
+	],
+	L3m5K_4X7ztA2yXV: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/s00QymqjHlQ9xxKSsLtqNNZJ6BLEu01p8nss01jMHHVTps/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/s00QymqjHlQ9xxKSsLtqNNZJ6BLEu01p8nss01jMHHVTps/high.mp4",
+		},
+	],
+	RASpI84AvAi3ucvr: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/XrNI6efG01DJ1KVz2gLCjHzfMF0072I7ZebYnvJHUpr74/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/XrNI6efG01DJ1KVz2gLCjHzfMF0072I7ZebYnvJHUpr74/high.mp4",
+		},
+	],
+	"e3c59976-efa7-4e7d-8848-77e864ba1d0f": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/JqtiRjXag00VzzKwoqffTQ3vlTgVgiSknWB00NRUFHvBU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/JqtiRjXag00VzzKwoqffTQ3vlTgVgiSknWB00NRUFHvBU/high.mp4",
+		},
+	],
+	"bf1437e9-f8ca-4bfe-b766-af5fee1834a5": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ddH01PKXjw7FezGed2xx5iA6NMVWFXqO5df02I02SfF6Dg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ddH01PKXjw7FezGed2xx5iA6NMVWFXqO5df02I02SfF6Dg/high.mp4",
+		},
+	],
+	"1dcc023d-b326-4b48-bd31-b3cdebba3ac8": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/e00mXZ01ditzxRtrWrpb02tYIhVtJUCJRT9uFbWiohBHro/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/e00mXZ01ditzxRtrWrpb02tYIhVtJUCJRT9uFbWiohBHro/high.mp4",
+		},
+	],
+	wKPa4Aa0r_CxAQgN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/WDuFGk6OFn3fjceV00y02RuLfu00pQJEI8V1BrBNLGFpRM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/WDuFGk6OFn3fjceV00y02RuLfu00pQJEI8V1BrBNLGFpRM/high.mp4",
+		},
+	],
+	oiMw4v1LrceC02LN: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/uvGrFux8sZqvTOFrbhPzq85SbhxKvPohPTjNd01JqwYQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/uvGrFux8sZqvTOFrbhPzq85SbhxKvPohPTjNd01JqwYQ/high.mp4",
+		},
+	],
+	HR3hn_5rarrq73qw: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1vi6sU2oTTylpUwBT3oOdsc4SfNgyxMpZ1gEDl8zFPQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1vi6sU2oTTylpUwBT3oOdsc4SfNgyxMpZ1gEDl8zFPQ/high.mp4",
+		},
+	],
+	hcWWZ4_kB2Ukps4r: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/PCw3ia02BZ8lQFKx3fTLj5XBbg1j9Aic2MW00IAaKwf9U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/PCw3ia02BZ8lQFKx3fTLj5XBbg1j9Aic2MW00IAaKwf9U/high.mp4",
+		},
+	],
+	WEM5B4mlGozBpuLV: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/7fZ01n6C5Nx3gUYwU02sVgXIjQi8K5QsWiFTBr4wl02tYU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/7fZ01n6C5Nx3gUYwU02sVgXIjQi8K5QsWiFTBr4wl02tYU/high.mp4",
+		},
+	],
+	UHLV7OA_q4D4UBk5: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/lFMrhlYn8Y00Ax01doSI95IhEvOyOa01XirKjyBbP02yb9c/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/lFMrhlYn8Y00Ax01doSI95IhEvOyOa01XirKjyBbP02yb9c/high.mp4",
+		},
+	],
+	"U9nn8f-vcAltrR-E": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/kQCjwNHj8ULQhUsXsOF2YS6kjLjJs2ANwZZxAJ02OWOo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/kQCjwNHj8ULQhUsXsOF2YS6kjLjJs2ANwZZxAJ02OWOo/high.mp4",
+		},
+	],
+	_YQXCLQ49sZ9xus0: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/p02L853U00V5Rm848gB5srgLNBkrv9KObYrKaX5ltQAhY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/p02L853U00V5Rm848gB5srgLNBkrv9KObYrKaX5ltQAhY/high.mp4",
+		},
+	],
+	uXHXPtiaxE27nIwE: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/AUulNBxfTf4T029cK9DPNuXLyQeeEak1zoZ00LpghP8FA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/AUulNBxfTf4T029cK9DPNuXLyQeeEak1zoZ00LpghP8FA/high.mp4",
+		},
+	],
+	"08uL8Rd_dMyUWmon": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/PoDLLiOrrQtsIlixV02LFSARuOBz5YVCnaIOB8P2Yd24/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/PoDLLiOrrQtsIlixV02LFSARuOBz5YVCnaIOB8P2Yd24/high.mp4",
+		},
+	],
+	"4ksnpJ1IfVp7QH5n": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/hAqAugAEWmBZ93ptwI4WyXPHLRV2qpYQMEKENx7YyFI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/hAqAugAEWmBZ93ptwI4WyXPHLRV2qpYQMEKENx7YyFI/high.mp4",
+		},
+	],
+	JSKDIBv70sJdwaSX: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/TeVTBk9ilSyQoKWoE01ft00eH6q3zj2GPqqASWk01zGtz4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/TeVTBk9ilSyQoKWoE01ft00eH6q3zj2GPqqASWk01zGtz4/high.mp4",
+		},
+	],
+	"qoA-t0Aa6EdiK1z-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/RnmVjgWec3q8FgtSpt7fxX4X01f0001asJBmOo02ahviwHw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/RnmVjgWec3q8FgtSpt7fxX4X01f0001asJBmOo02ahviwHw/high.mp4",
+		},
+	],
+	F0CpuwCmcgtM_E0n: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Qz01d02jw1jZp4xE3qV01btT01xE1lHgenYnc8q6tRgw7Lw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Qz01d02jw1jZp4xE3qV01btT01xE1lHgenYnc8q6tRgw7Lw/high.mp4",
+		},
+	],
+	"282ae5c8-3237-4b36-9545-b3bfcdbb7186": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/LJC00gssibjjmpGXkz02jHQMu3b02d7ETdsPYifVnTMqqw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/LJC00gssibjjmpGXkz02jHQMu3b02d7ETdsPYifVnTMqqw/high.mp4",
+		},
+	],
+	"9eb0aa7a-f91b-415c-ac95-1f3e66e2bb79": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/L54QIqZqDWaexWlXlh9vphxqpN6AhoQvLHNLHuTBPnE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/L54QIqZqDWaexWlXlh9vphxqpN6AhoQvLHNLHuTBPnE/high.mp4",
+		},
+	],
+	"LoaPkKfJhQSfn-vH": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/n801rtBSwbeEgLPbAPZxC6skqEKj4ZDdeyCZsyn2bSf8/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/n801rtBSwbeEgLPbAPZxC6skqEKj4ZDdeyCZsyn2bSf8/high.mp4",
+		},
+	],
+	"7va2ht0vPUhOE9g_": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/u701pv54Y01j3iOj5lS5bOLlGX3Z2cTMn5krLcMcKkYhk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/u701pv54Y01j3iOj5lS5bOLlGX3Z2cTMn5krLcMcKkYhk.m3u8",
+		},
+	],
+	"1yRM4s2GawA9w3mE": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ht8bds97KkbOS7XUIbenosmv00GXKczuYA01KsKAlDcz8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ht8bds97KkbOS7XUIbenosmv00GXKczuYA01KsKAlDcz8/high.mp4",
+		},
+	],
+	fZSw0ohInfxQnOmN: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/aLGADFphCob82tEjkSg9vzUGyD4tWegKJLOXtGMpu02c/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/aLGADFphCob82tEjkSg9vzUGyD4tWegKJLOXtGMpu02c/high.mp4",
+		},
+	],
+	"Tr5k89TXxDznw-re": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/s0000vRgeMP6DHAuOAFbeO1yU4GojDVmw5DTG8O00vgkaw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/s0000vRgeMP6DHAuOAFbeO1yU4GojDVmw5DTG8O00vgkaw/high.mp4",
+		},
+	],
+	"XnLDPIrt-UB8UHe_": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/YOdbvtAjIqclv5HgSdeG2Wt6Xs4Xf9FawnU01iwgcD9g/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/YOdbvtAjIqclv5HgSdeG2Wt6Xs4Xf9FawnU01iwgcD9g/high.mp4",
+		},
+	],
+	"WvU4CAjaUzYto-HK": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/9UcaVJcAiFZvolw1oa3pA1O3GvuL4twv89KXwUn7XZY/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/9UcaVJcAiFZvolw1oa3pA1O3GvuL4twv89KXwUn7XZY/high.mp4",
+		},
+	],
+	"060MtnqsajfwLfCG": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/401xL01mJDGqUaFcKG00gAx9w3BsfoGgwVyvyWRYHEb3ik/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/401xL01mJDGqUaFcKG00gAx9w3BsfoGgwVyvyWRYHEb3ik/high.mp4",
+		},
+	],
+	COPwrFLlJNQGK1x_: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/yudfPMkap01t9oI01v98Yxyh00gzsY4ky02ve7EprgQdQBM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yudfPMkap01t9oI01v98Yxyh00gzsY4ky02ve7EprgQdQBM/high.mp4",
+		},
+	],
+	h2AvnFc5IUvR5Rsy: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/aAaRT5C3O8bgzhqlQnF5WzdO01JrgBYIhEF8l402Yu5HM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/aAaRT5C3O8bgzhqlQnF5WzdO01JrgBYIhEF8l402Yu5HM.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ke1OIoev2QInrlO6sEy12XuiJ6vSDLN5vbdCEbXLuB00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ke1OIoev2QInrlO6sEy12XuiJ6vSDLN5vbdCEbXLuB00.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/vycQW6v35p7VmWcJeeVJFZsc1oUpf7ecOizYFyZbgpw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/vycQW6v35p7VmWcJeeVJFZsc1oUpf7ecOizYFyZbgpw.m3u8",
+		},
+	],
+	xWS1Dz47uN0Lvikf: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Ho02sSC4e01UqO02ynOuu74RW4FmetTVfp0298l54MH1gvA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Ho02sSC4e01UqO02ynOuu74RW4FmetTVfp0298l54MH1gvA/high.mp4",
+		},
+	],
+	Pa7L7GPGmD7zSNOr: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oQJUzWtNnqUxOuc2bpgW02CMqtPhj02oBmKnEHaqIgVg8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oQJUzWtNnqUxOuc2bpgW02CMqtPhj02oBmKnEHaqIgVg8/high.mp4",
+		},
+	],
+	KLl6MIB5BPwo7Ere: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/n8wREweQN021NTxtJc3vmBRLBWUct601GGR1xfAlVhLE8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/n8wREweQN021NTxtJc3vmBRLBWUct601GGR1xfAlVhLE8/high.mp4",
+		},
+	],
+	"0zZA4M7uhQ9zi-qi": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/aofpNxjTa2f01qRNWWfjWt01qfXsSbJSUfuVWPl024ty2U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/aofpNxjTa2f01qRNWWfjWt01qfXsSbJSUfuVWPl024ty2U/high.mp4",
+		},
+	],
+	w7GvCyjz7FQ_18iw: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/nFlQ4ttLY6Rp2TY00X00srDmnC02NC5SSLqwj4Z1gZ3kMk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/nFlQ4ttLY6Rp2TY00X00srDmnC02NC5SSLqwj4Z1gZ3kMk/high.mp4",
+		},
+	],
+	L1rpJxWOVkooOilR: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/EnR6O3UAgXvmXVeapD6eL00ca9mimM42uoud8nbQV2g8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/EnR6O3UAgXvmXVeapD6eL00ca9mimM42uoud8nbQV2g8/high.mp4",
+		},
+	],
+	"abb1ce56-759d-4cd9-af94-c14c0d7537c7": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/rgYuIA6vsQBgc8Zo1u5ekbdcnzR3OmooPrvOI5A6kyU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/rgYuIA6vsQBgc8Zo1u5ekbdcnzR3OmooPrvOI5A6kyU/high.mp4",
+		},
+	],
+	qbcMU1eW8y3PBRxk: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2QSI01W02AUBBaRkinilGY02WS01cn7WP021jQTORpX3rdak/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2QSI01W02AUBBaRkinilGY02WS01cn7WP021jQTORpX3rdak/high.mp4",
+		},
+	],
+	"iIh4XO5YfBOm1yL-": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/m401TKLfmP4Adb4zu1io3LQ4gLBfpZu02geTZoZmklrnI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/m401TKLfmP4Adb4zu1io3LQ4gLBfpZu02geTZoZmklrnI/high.mp4",
+		},
+	],
+	"0TxEMNqgtYWzFf7D": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oku5AgKy5dJmEK00VdlDvMPZpqrXKX99pRlgvFIJVbRc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oku5AgKy5dJmEK00VdlDvMPZpqrXKX99pRlgvFIJVbRc/high.mp4",
+		},
+	],
+	dFzr_9Ii894yDsLe: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/sJH7EqgVdPUVJgmang8uK01WVM8ossqcKuvQW7fQYrOQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/sJH7EqgVdPUVJgmang8uK01WVM8ossqcKuvQW7fQYrOQ/high.mp4",
+		},
+	],
+	WAB_Z7EUGeUxF9ce: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/02VDsdEMNDKNdwV1eAcDQkeu6SkwoUmnOtvNFsOLIwbs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/02VDsdEMNDKNdwV1eAcDQkeu6SkwoUmnOtvNFsOLIwbs/high.mp4",
+		},
+	],
+	"1c4f037a-1cab-4133-b72a-458be3e7018d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/BRBvpGOigbtx51umT902BTCUC1LUDECbLEw7BdYL1Rd4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/BRBvpGOigbtx51umT902BTCUC1LUDECbLEw7BdYL1Rd4/high.mp4",
+		},
+	],
+	rMYzHKGP3u9agdih: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/2i8jXo701GWhVeLJFfwqo55dOpxbjl7Vr6ePBSefdmdw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/2i8jXo701GWhVeLJFfwqo55dOpxbjl7Vr6ePBSefdmdw/high.mp4",
+		},
+	],
+	"49c4594c-f997-4d70-8008-b293e247e2e4": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/neG6n6vqT8dvey6LU5v00pyUU9HJLPT68DJlEYvcZWrs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/neG6n6vqT8dvey6LU5v00pyUU9HJLPT68DJlEYvcZWrs/high.mp4",
+		},
+	],
+	lgYX50v_dhlQzGkS: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/j01nbnpmMl4T8eKXSVQqpmxNPB8ttc7haf3iGFbdDIz00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/j01nbnpmMl4T8eKXSVQqpmxNPB8ttc7haf3iGFbdDIz00/high.mp4",
+		},
+	],
+	mfBF5EZDbOgIzoqK: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/XMXuE02V02evSIfReGRt9500YpL01SsNHcaw5PRPvhEMwuI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/XMXuE02V02evSIfReGRt9500YpL01SsNHcaw5PRPvhEMwuI/high.mp4",
+		},
+	],
+	WGC8yyeuikjTpwFv: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/H5jM0116qowsNwk4WV7U7M01Lo2uDtbW01ik5PeoHWqBso/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/H5jM0116qowsNwk4WV7U7M01Lo2uDtbW01ik5PeoHWqBso/high.mp4",
+		},
+	],
+	"2d798867-d392-433c-8a5c-ea81f9091fb7": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3v00j00kQnyo01S19OA01tVAnoBFl29zo02USrJqiGs2iBCU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3v00j00kQnyo01S19OA01tVAnoBFl29zo02USrJqiGs2iBCU/high.mp4",
+		},
+	],
+	ru7mTLyeqg5JpRQg: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oMgiKWjYpPirwozgS003900KOAVYH2AgVxKTNQF9rx9m4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oMgiKWjYpPirwozgS003900KOAVYH2AgVxKTNQF9rx9m4/high.mp4",
+		},
+	],
+	nN6qtG3fAljE_Z83: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/RcKHsR00K02FXpvdzOM6802300Be9XGtYCL00NSxkP8JADlQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/RcKHsR00K02FXpvdzOM6802300Be9XGtYCL00NSxkP8JADlQ/high.mp4",
+		},
+	],
+	"8e29ca58-5069-4047-8332-5fee7705948e": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/IIALrS1VW7PVB3f3jDwVcdRm6kX4mlQdgr7Jq9aGKnY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/IIALrS1VW7PVB3f3jDwVcdRm6kX4mlQdgr7Jq9aGKnY/high.mp4",
+		},
+	],
+	"95Y3m1BFa2p2mrDk": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4bnMoeGqqL002url600fZ4G3700sJZY6p402LAfz7HEEcLA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4bnMoeGqqL002url600fZ4G3700sJZY6p402LAfz7HEEcLA/high.mp4",
+		},
+	],
+	ttHTA71H0f3mB31g: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/v9yxhz8PzgO7gZ9nmqTdCrFuNJJ2z1iCj2lD02vm1GjU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/v9yxhz8PzgO7gZ9nmqTdCrFuNJJ2z1iCj2lD02vm1GjU/high.mp4",
+		},
+	],
+	"U6M_Wf-AewcK3CnD": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ME8xtXmzHeYcbQ4FhWBDiA1On3vvhZsxNbIXE0001Tq01o/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ME8xtXmzHeYcbQ4FhWBDiA1On3vvhZsxNbIXE0001Tq01o/high.mp4",
+		},
+	],
+	"48683355-ee78-40f8-89fb-384bdfc9997d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/9YtRpB2lMgdCgiayaqMf223OqQeSV7pBytX3uyZm6XQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/9YtRpB2lMgdCgiayaqMf223OqQeSV7pBytX3uyZm6XQ/high.mp4",
+		},
+	],
+	GIQYOXGxJkgszu1e: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01gQs95aggyTK9HjiVxVTycKXqD00YP02e013vYtc1quUvg/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01gQs95aggyTK9HjiVxVTycKXqD00YP02e013vYtc1quUvg/high.mp4",
+		},
+	],
+	"59af78e5-96b2-4cc1-bc40-350b78b55224": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/rMRFGXMqqpSV6IEgLtoHJgXNVWRCxxmROpuemB2j01xI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/rMRFGXMqqpSV6IEgLtoHJgXNVWRCxxmROpuemB2j01xI/high.mp4",
+		},
+	],
+	"93b9131e-2976-4ea7-94e7-a029ec799c67": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2ypOWTeG6vJ02ysgQ4tPD6hqaAXFa9hoYYpT8YqM8yH4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2ypOWTeG6vJ02ysgQ4tPD6hqaAXFa9hoYYpT8YqM8yH4/high.mp4",
+		},
+	],
+	"02375fb3-3a7f-48aa-9db4-9c0a2ab3a9e5": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/zj5ozZdpmu5hKwZoAj7U01XxQySm01wa4f2H948w01n32A/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/zj5ozZdpmu5hKwZoAj7U01XxQySm01wa4f2H948w01n32A/high.mp4",
+		},
+	],
+	o9UBgAOU0nw2EfzY: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/y3sYbshciJsXeIt02AN026nIScAotOUjedYa6Eg900pqtw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/y3sYbshciJsXeIt02AN026nIScAotOUjedYa6Eg900pqtw/high.mp4",
+		},
+	],
+	"6a965651-ed7a-4fb6-a676-c95bc3f244d7": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/01qD2va1CrRzX0102dAFNKIE9IQTIzI4lA9yCCkdMrzPBc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/01qD2va1CrRzX0102dAFNKIE9IQTIzI4lA9yCCkdMrzPBc/high.mp4",
+		},
+	],
+	"3aoNnPe1hglnTZ-s": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ke4M01IEpWXWK4GkrKJh8MdhuGkxHoHKT9tAEEAbOBko/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ke4M01IEpWXWK4GkrKJh8MdhuGkxHoHKT9tAEEAbOBko/high.mp4",
+		},
+	],
+	ArAbShPxyzqLCyA8: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/UnZDyXlqjTgoN89lFzboWpqu8yKcSeraI02ghgT2jD5k/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/UnZDyXlqjTgoN89lFzboWpqu8yKcSeraI02ghgT2jD5k/high.mp4",
+		},
+	],
+	kPq2JUnIZhTRv9ap: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Bj1Mfmtl3rZmg3Igst4baZcv4n003ybCGuPeSjItXF1Q/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Bj1Mfmtl3rZmg3Igst4baZcv4n003ybCGuPeSjItXF1Q/high.mp4",
+		},
+	],
+	a8_tAX7to3xRrMnQ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/VYpWqoFvasmoMOW2FA6lDzMOV9dz7iGMy00TpeR9e5sw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/VYpWqoFvasmoMOW2FA6lDzMOV9dz7iGMy00TpeR9e5sw/high.mp4",
+		},
+	],
+	xfANU256X8tv1hUU: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/nWBCtEwDnUekrZAgTsL01E00grF74XhDC3GYUkOfraWvo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/nWBCtEwDnUekrZAgTsL01E00grF74XhDC3GYUkOfraWvo/high.mp4",
+		},
+	],
+	I4ZzPJg0qt7dw8sV: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/myO98rzR8F21YH5MOEqy100yEpWvSAQVQU9QJeSah02Mg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/myO98rzR8F21YH5MOEqy100yEpWvSAQVQU9QJeSah02Mg/high.mp4",
+		},
+	],
+	"4e437374-5b96-4e9f-bf20-5ad275266fb6": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/z00VoUUnMdBjy3RMpjEj2uiNSjfcI2woh01u01eyM82vn4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/z00VoUUnMdBjy3RMpjEj2uiNSjfcI2woh01u01eyM82vn4/high.mp4",
+		},
+	],
+	uswNmWgAK9AdRXja: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/w8disGvECeXMyWwd6b8F023saPBEB4detAC1KvQWL1O00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/w8disGvECeXMyWwd6b8F023saPBEB4detAC1KvQWL1O00/high.mp4",
+		},
+	],
+	nFR6tLChZbdWvLhP: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/E3iOtnIwqWqIN02TiGxTrhWcdMDtnFLPZvfPY17SF01a4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/E3iOtnIwqWqIN02TiGxTrhWcdMDtnFLPZvfPY17SF01a4/high.mp4",
+		},
+	],
+	VdQc5XkuKLuauqhn: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/aeKrImYDIChP5PTk8o00005trEhQlYjRefQWomjx2ak02M/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/aeKrImYDIChP5PTk8o00005trEhQlYjRefQWomjx2ak02M/high.mp4",
+		},
+	],
+	GfdnN4MlZrweuEbe: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/cHjuAD6UvsAL01jX4JHkkMZMYAMZDfNCkIuo9W02K9qoE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/cHjuAD6UvsAL01jX4JHkkMZMYAMZDfNCkIuo9W02K9qoE/high.mp4",
+		},
+	],
+	pWWQdfycIrKmbVTS: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/YO01yPmorfrSBXm1sBGyBQXKmiYxS8rmknUWghew01xw4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/YO01yPmorfrSBXm1sBGyBQXKmiYxS8rmknUWghew01xw4/high.mp4",
+		},
+	],
+	j7YZvM4iUfMsm1Cj: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/9q98IzwCsXznOgk85DMWJ33kBKyvS9EbDyM3Q00IlQJw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/9q98IzwCsXznOgk85DMWJ33kBKyvS9EbDyM3Q00IlQJw/high.mp4",
+		},
+	],
+	UHoVboL0UG5PobzU: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/NZrDRiAh2svWA00cbs1GeOyOCJwBN9XMITeguCjI3IP4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/NZrDRiAh2svWA00cbs1GeOyOCJwBN9XMITeguCjI3IP4/high.mp4",
+		},
+	],
+	tn8HJeXMdU_8IDT_: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/hdi3bdrimwTqUkKB8zCXYCCizznuVE9OvA3myUrGBXU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/hdi3bdrimwTqUkKB8zCXYCCizznuVE9OvA3myUrGBXU/high.mp4",
+		},
+	],
+	"RlsTRSKnxy-NQ8DY": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/GNKi6QF02BvfVhVFPQChxp9hqxvdiMJl9RYpWO3syGpc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/GNKi6QF02BvfVhVFPQChxp9hqxvdiMJl9RYpWO3syGpc/high.mp4",
+		},
+	],
+	"6wzKESB8SJc5h7Vu": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/nBEVwp8egVW6Q02Mz1z1nuFvH2wxglycflzf53oJY01ms/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/nBEVwp8egVW6Q02Mz1z1nuFvH2wxglycflzf53oJY01ms.m3u8",
+		},
+	],
+	dn1p_QdQgEyMS1y8: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/gJWu01D96GONpQYCv6Z1ocZdReuW6001nTpHHTgBiZ5QQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/gJWu01D96GONpQYCv6Z1ocZdReuW6001nTpHHTgBiZ5QQ/high.mp4",
+		},
+	],
+	"6lVw6FkK5vYW8lGl": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/hL9UCqYQiFqa1jgmyaNAVkry81AgMT4yImNAPENuNhU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/hL9UCqYQiFqa1jgmyaNAVkry81AgMT4yImNAPENuNhU/high.mp4",
+		},
+	],
+	"6cpDDeMzOKRsKKYv": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/anRZ3vVqM60102RnBmk9GxQ4EVTXawj7RMIwI0002zjO5Og/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/anRZ3vVqM60102RnBmk9GxQ4EVTXawj7RMIwI0002zjO5Og/high.mp4",
+		},
+	],
+	lqezCotrgYPfpuDg: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3aeJE1OcFNTAqiRZBcgHFUdUwmxWYUEh4XcznDUz1CY/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3aeJE1OcFNTAqiRZBcgHFUdUwmxWYUEh4XcznDUz1CY/high.mp4",
+		},
+	],
+	T5PUUfKqJit3qCvD: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/14blbHmMtuO01AkBmLBwTj8qGsU511KygOoWjxMu02J94/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/14blbHmMtuO01AkBmLBwTj8qGsU511KygOoWjxMu02J94/high.mp4",
+		},
+	],
+	"6b9d0649-6f92-4e91-8db0-1170f3a33f4b": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/9RB1GGHD82ZIIm3j01x9W024p8EGFYlsEWR7IT1f6NFU00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/9RB1GGHD82ZIIm3j01x9W024p8EGFYlsEWR7IT1f6NFU00/high.mp4",
+		},
+	],
+	"nR-lOrEDQJ0L0Vyu": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/GK2ijUjyPsDrgkVZrF5FhtWHLZ4SGxEJ6vHo5bQ00WCA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/GK2ijUjyPsDrgkVZrF5FhtWHLZ4SGxEJ6vHo5bQ00WCA/high.mp4",
+		},
+	],
+	aHq0L7BGJ421LjAl: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/3UGWIzey9hYbnrqSdJQpBTJXvJnSmb1qpFtnl7s30138/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/3UGWIzey9hYbnrqSdJQpBTJXvJnSmb1qpFtnl7s30138/high.mp4",
+		},
+	],
+	"8xfEOJJincwXHQqt": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/BjlESpUoPj702Phv4nOvS00glLkdwopFNbuVmw3eSbO4o/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/BjlESpUoPj702Phv4nOvS00glLkdwopFNbuVmw3eSbO4o/high.mp4",
+		},
+	],
+	"e8ded86f-112d-45ca-9e6e-8b9adf71a787": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/sXpSFMPi01lUg75uUkQgVLCPS73kkaj2HGkM024H7L4cE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/sXpSFMPi01lUg75uUkQgVLCPS73kkaj2HGkM024H7L4cE/high.mp4",
+		},
+	],
+	"8IjpojkVyCE8GEob": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/hU00cmICpvnjgv01SpY00Dg01rhZ7juL5wgZUPQKdl1p1Hk/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/hU00cmICpvnjgv01SpY00Dg01rhZ7juL5wgZUPQKdl1p1Hk/high.mp4",
+		},
+	],
+	DAMowL4fXivfWnFF: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/caH38vRMhRMX701fzwUX9U8H7UMD2L6mLNEwEyaz5FZo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/caH38vRMhRMX701fzwUX9U8H7UMD2L6mLNEwEyaz5FZo/high.mp4",
+		},
+	],
+	oFlrSYKQ2ZpmyP69: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/8BQmjEpvC01lNyzv01fHpNzuTHsJI6Q6OHYNvYQFfIDpE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/8BQmjEpvC01lNyzv01fHpNzuTHsJI6Q6OHYNvYQFfIDpE/high.mp4",
+		},
+	],
+	"9ekHzCsiV_EbzS0Q": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/OqkTsLnDbG2KpaEdy01hsrzoHjVLgeZTig1AU017kENAM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/OqkTsLnDbG2KpaEdy01hsrzoHjVLgeZTig1AU017kENAM/high.mp4",
+		},
+	],
+	IellRPhjOXa5Rlc4: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/zi4CCcYyJEuajPQZW3YwAkz8Zk2pIb01F3A7pQOAvgGI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/zi4CCcYyJEuajPQZW3YwAkz8Zk2pIb01F3A7pQOAvgGI/high.mp4",
+		},
+	],
+	"Bff9--feKFxbNzFk": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/IDEXeeImA5x9sUkbYAKzgvh02rK2hiKIkYP012NPvQzNA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/IDEXeeImA5x9sUkbYAKzgvh02rK2hiKIkYP012NPvQzNA/high.mp4",
+		},
+	],
+	XgPSiQhDOFgjCBWZ: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/CGnzcnEe5k400y01bicCbjtlCs56L7f6lv5bIB9b7Ss6s/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/CGnzcnEe5k400y01bicCbjtlCs56L7f6lv5bIB9b7Ss6s/high.mp4",
+		},
+	],
+	"0040d53f-85c7-4564-b14e-9b38c979b461": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/FAxWVq3xaBZd4k91028JNW1xxXiaUbo8KXdy00QC019ABU/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/FAxWVq3xaBZd4k91028JNW1xxXiaUbo8KXdy00QC019ABU/high.mp4",
+		},
+	],
+	"68c3b06f-1767-44fd-9676-e1a4d1c7699b": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/bBCbfoUqf4d00OedBoUhzQ52WaWZBvgBu6LcOO3yNhNs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/bBCbfoUqf4d00OedBoUhzQ52WaWZBvgBu6LcOO3yNhNs/high.mp4",
+		},
+	],
+	"37dfe4b0-0e5f-485c-95d7-8cb3c75c82f1": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/AJwhMxQY00f001UmdVnlHR9zA02GbVLiDhNCrdkXlQ7DAA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/AJwhMxQY00f001UmdVnlHR9zA02GbVLiDhNCrdkXlQ7DAA/high.mp4",
+		},
+	],
+	"a696262a-b3ca-450a-844c-66593bffdb4f": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1ZPiGBv8600k00baHN00QfvsBf4spIMtKgUlCEX2Mp2WZ8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1ZPiGBv8600k00baHN00QfvsBf4spIMtKgUlCEX2Mp2WZ8/high.mp4",
+		},
+	],
+	"1cAPp9FYOqgEFDfm": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/uguACKztBZRplGlGPICWA4VeZKDP5WKw7oVqMDZAAg4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/uguACKztBZRplGlGPICWA4VeZKDP5WKw7oVqMDZAAg4/high.mp4",
+		},
+	],
+	"e1e6eda5-42e7-45ee-82e6-ce97746ae0ca": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/t2YI2I94Qjp7alpuoxIDFahHXWp4KmKJGfUgZN4lJV00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/t2YI2I94Qjp7alpuoxIDFahHXWp4KmKJGfUgZN4lJV00/high.mp4",
+		},
+	],
+	"MNyFj-nf0aJz74Fi": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/adIrtnJIQcqlYIoHJL02f7wNaw02ArbhMnzqSXgIYSing/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/adIrtnJIQcqlYIoHJL02f7wNaw02ArbhMnzqSXgIYSing/high.mp4",
+		},
+	],
+	"fac6aba0-44a3-4a97-8db4-7ec08c1d942b": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ujgajZ1MxKEFBYLwrhlstM02OfI6Fv01Q500kFS2EP9ISw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ujgajZ1MxKEFBYLwrhlstM02OfI6Fv01Q500kFS2EP9ISw/high.mp4",
+		},
+	],
+	sxNGWuwoGi53uzPQ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/kw32x2AdDAyDAnKf900upiBpZL3zpI02K4tKuy73lCQ78/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/kw32x2AdDAyDAnKf900upiBpZL3zpI02K4tKuy73lCQ78/high.mp4",
+		},
+	],
+	"4SNNzLGB30i_svEv": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/BabGnM6V6WkdcloSzkM01wmzkk9sLZebDef6yj029qkWQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/BabGnM6V6WkdcloSzkM01wmzkk9sLZebDef6yj029qkWQ/high.mp4",
+		},
+	],
+	b5GMOO29lfyvLAIH: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/GjX00B11ldg2lr2GLW7ur2FyIpe65qKhzj695JDmYdpY/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/GjX00B11ldg2lr2GLW7ur2FyIpe65qKhzj695JDmYdpY/high.mp4",
+		},
+	],
+	"91e92912-d281-4769-a85f-f7960fba7781": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/LgLPxsNnqxmMCnP01HxPUii1aDLC006ZuAu1uBpRuLndg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/LgLPxsNnqxmMCnP01HxPUii1aDLC006ZuAu1uBpRuLndg/high.mp4",
+		},
+	],
+	"fXjy6W7tGL2O-kaB": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/BWTo9bZGsRozpfRMOXSLcgvR01k9TKxlt01ZWJ7Q4ypDo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/BWTo9bZGsRozpfRMOXSLcgvR01k9TKxlt01ZWJ7Q4ypDo/high.mp4",
+		},
+	],
+	"0yBVwuQwNsQ3JKng": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/3L3C2ZkhWOVYuL01BaWbuhUT95H8kkwea24l02qTjZ02ec/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/3L3C2ZkhWOVYuL01BaWbuhUT95H8kkwea24l02qTjZ02ec/high.mp4",
+		},
+	],
+	"7KpeHFV0c18pWx0c": [
+		{
+			angle: "FRONT",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/7rJRvyQZ/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/7rJRvyQZ.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/sTY27zVZ/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/sTY27zVZ.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl: "https://cdn.jwplayer.com/v2/media/Qr3FvkkS/poster.jpg",
+			videoUrl: "https://cdn.jwplayer.com/manifests/Qr3FvkkS.m3u8",
+		},
+	],
+	fC_qGwvsTQFRD7Yz: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/GZGqsItDCZGYDW33BqzVR2n7nW5FcIKNqLaOQvWg6qQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/GZGqsItDCZGYDW33BqzVR2n7nW5FcIKNqLaOQvWg6qQ/high.mp4",
+		},
+	],
+	"4zUD8GNoHcRFbuzM": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01ceiJWf3KL1027tfmKDRn3UrTDYzdTn00dsHK8wFbdQSE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01ceiJWf3KL1027tfmKDRn3UrTDYzdTn00dsHK8wFbdQSE/high.mp4",
+		},
+	],
+	wq7KZjMBqkMKXICc: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/jDeGpMNs01iYFN45xs9P3jsEIChmGi0022kGs00yhT801oE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/jDeGpMNs01iYFN45xs9P3jsEIChmGi0022kGs00yhT801oE/high.mp4",
+		},
+	],
+	"46nKrULukv55x-ro": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/9J9D73HfsrzaLjECzv9pb5eAd8S1vg7WK1RmZ1m37xw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/9J9D73HfsrzaLjECzv9pb5eAd8S1vg7WK1RmZ1m37xw/high.mp4",
+		},
+	],
+	"f524875e-9c31-4102-99fc-7b4505e10ea5": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/VO63P101hgyIzOHeM2rfa80100hL8b3Xfg2ryzGtYHjZps/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/VO63P101hgyIzOHeM2rfa80100hL8b3Xfg2ryzGtYHjZps/high.mp4",
+		},
+	],
+	qO01vy4Ba1tYOdlT: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/PfGTj7Jtm00k8KMA02qEC01mWUK7nOwV5Uc8CIXFB01nE7E/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/PfGTj7Jtm00k8KMA02qEC01mWUK7nOwV5Uc8CIXFB01nE7E/high.mp4",
+		},
+	],
+	iAlBEVYGhzdWuyC8: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/h4BV02GCaRwzS7ITspD8jDj8OxZOn3XIS58SX99yS00Gs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/h4BV02GCaRwzS7ITspD8jDj8OxZOn3XIS58SX99yS00Gs/high.mp4",
+		},
+	],
+	L0Q3A8j4yzWCbFT5: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/2501B9KomvcdPmcc7ChIGSVclpKT00QY3eZiQp601rRYGk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/2501B9KomvcdPmcc7ChIGSVclpKT00QY3eZiQp601rRYGk/high.mp4",
+		},
+	],
+	n307ugHNg9TDrO8D: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/TKvQ4cQtxCBZJVAOgwTgRAbhrFzRA502OelEYq4xDeso/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/TKvQ4cQtxCBZJVAOgwTgRAbhrFzRA502OelEYq4xDeso/high.mp4",
+		},
+	],
+	cOaTQ1ljsuUom_cn: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/VhqKJa3sCzX3wpyuYcEw36f01XF9pPJEJQROQjpuSGXc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/VhqKJa3sCzX3wpyuYcEw36f01XF9pPJEJQROQjpuSGXc/high.mp4",
+		},
+	],
+	NTtSMyHmJmTE7iQ5: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/yTwQ9zKobBPqh5OAgyyu3cx301oZ008EVSyo015jpVxKDo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/yTwQ9zKobBPqh5OAgyyu3cx301oZ008EVSyo015jpVxKDo/high.mp4",
+		},
+	],
+	"vI7FQn2KAPJxBS-n": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/oMYGorH2znakLwR9NS427NFeohemZtlWHWR9X49jjvk/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/oMYGorH2znakLwR9NS427NFeohemZtlWHWR9X49jjvk/high.mp4",
+		},
+	],
+	"a1f4e3d7-8ab4-442d-ba06-8dfd9c11e248": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/qvFolS001ra57CBGqT7urXr02d6YNBmx02n01OWY8KUk2No/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/qvFolS001ra57CBGqT7urXr02d6YNBmx02n01OWY8KUk2No/high.mp4",
+		},
+	],
+	"6hCTlg47HzDa8KMH": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/EJeaj96qfmGvScZMsz32m6kJVmD7Zw4xL02Q5rOCweW4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/EJeaj96qfmGvScZMsz32m6kJVmD7Zw4xL02Q5rOCweW4/high.mp4",
+		},
+	],
+	"d99a9738-3828-42a6-815e-459c1f825ff9": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ElV9KCh00e6caVDnRGFmAxGBuv02MY7UNpR8mc013M3a01Q/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ElV9KCh00e6caVDnRGFmAxGBuv02MY7UNpR8mc013M3a01Q/high.mp4",
+		},
+	],
+	"2QMNEX5fOg-yvtZj": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/27AdZJ2NYnMLa021xkSfPbBd96ZlVrsDYakTQzfUNBvE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/27AdZJ2NYnMLa021xkSfPbBd96ZlVrsDYakTQzfUNBvE/high.mp4",
+		},
+	],
+	"0-tIvRECyssMov48": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3BGWUUYgtPMBBpVDwVTQfrBOEJAys45GmO7nK9zMHww/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3BGWUUYgtPMBBpVDwVTQfrBOEJAys45GmO7nK9zMHww/high.mp4",
+		},
+	],
+	"63RCSAdVrlM9duzB": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/qVBihKVDOCcab9212J7bScdbVuZEiSQzT5p01XFS8rjA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/qVBihKVDOCcab9212J7bScdbVuZEiSQzT5p01XFS8rjA/high.mp4",
+		},
+	],
+	"0Oh0_lqI38McSWPi": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/wFCtZUq00V9xWSOcp8015xn6ROFcFsJmOKB7qIRBhMRy4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/wFCtZUq00V9xWSOcp8015xn6ROFcFsJmOKB7qIRBhMRy4/high.mp4",
+		},
+	],
+	xnbdoyEux011kWzD: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/FklaKK74yAYvOAwjkOaM9QeBPFSSLOivgRSCnqE2AAM/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/FklaKK74yAYvOAwjkOaM9QeBPFSSLOivgRSCnqE2AAM/high.mp4",
+		},
+	],
+	q_tsQBgzlUhVBraK: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ZVFzUnFdaY5G401jI02LHOxSlcKh9YVGkZ3gvHRt8PpC00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ZVFzUnFdaY5G401jI02LHOxSlcKh9YVGkZ3gvHRt8PpC00/high.mp4",
+		},
+	],
+	EoGrn0BZRVtKl8sH: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/0045XNsglb92IL02MrCfaznr302VjQK3OQXMbbP6OeV01as/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/0045XNsglb92IL02MrCfaznr302VjQK3OQXMbbP6OeV01as/high.mp4",
+		},
+	],
+	FmExLcwG_aL35qZQ: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/PB2jkj5gQu6hSN02buB3Z4wSOvalQPo9kXu00vHoNGJ01A/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/PB2jkj5gQu6hSN02buB3Z4wSOvalQPo9kXu00vHoNGJ01A/high.mp4",
+		},
+	],
+	shp7LbPRawwkU2Ct: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Cg5pti7xmNcCpLNNg3eKAXYFy9oKDBSEgKy7tFeZns00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Cg5pti7xmNcCpLNNg3eKAXYFy9oKDBSEgKy7tFeZns00/high.mp4",
+		},
+	],
+	"a6da0305-9a19-4314-85d7-0275cd5c99ce": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/ml6oJYDUCfleYGDP65uDKMn00tHlxPjQJ401plLhQRRa4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/ml6oJYDUCfleYGDP65uDKMn00tHlxPjQJ401plLhQRRa4/high.mp4",
+		},
+	],
+	bFiC9iuNTVSZp0v9: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/auY2fDiupXnczpjgii02ZcWkNDsqIsI1Fxp4d76AxGUU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/auY2fDiupXnczpjgii02ZcWkNDsqIsI1Fxp4d76AxGUU/high.mp4",
+		},
+	],
+	"l-XYYcr1wOlMnbr3": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/mQi9WavvBx3KMOedGEkqIjJ2MrcXHVTWmPZ5UCiX2d4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/mQi9WavvBx3KMOedGEkqIjJ2MrcXHVTWmPZ5UCiX2d4/high.mp4",
+		},
+	],
+	I6HAxWzI9ZrdIS2v: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/xVa1eOeHQLkjVAm021UePMTGyOWFilZhE1w2iIHJVCTs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/xVa1eOeHQLkjVAm021UePMTGyOWFilZhE1w2iIHJVCTs/high.mp4",
+		},
+	],
+	WK8z78u6e_ebgXco: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/I7T23O2thHeGv5jPzsuVgbwPzhIuD7qnTF00s4Y3Ey700/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/I7T23O2thHeGv5jPzsuVgbwPzhIuD7qnTF00s4Y3Ey700/high.mp4",
+		},
+	],
+	kGipmvnqsTQp37D3: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/tvUrzoO9eE2VvUAJTbTIQLtTEpYkIdnYO8t00DT1IDbc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/tvUrzoO9eE2VvUAJTbTIQLtTEpYkIdnYO8t00DT1IDbc/high.mp4",
+		},
+	],
+	_id7xcXvZ0WJ173d: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/oW7i9CXLj3OQl7JkH7jxNI5aV2sZtfWS7If2IlatL9s/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/oW7i9CXLj3OQl7JkH7jxNI5aV2sZtfWS7If2IlatL9s/high.mp4",
+		},
+	],
+	"df475766-0c7a-45a1-8212-9ebacf9f69cc": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/01hOBjCo5BVH2p7RDUyZGXeJgwq01IeFbtNcqljwEQey8/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/01hOBjCo5BVH2p7RDUyZGXeJgwq01IeFbtNcqljwEQey8/high.mp4",
+		},
+	],
+	"fIVIgFH6UKrNX-DI": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/XqMrgenilqHKg6Nq02s5Jj6lmiR02B1tmhRGrleGqtfo00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/XqMrgenilqHKg6Nq02s5Jj6lmiR02B1tmhRGrleGqtfo00/high.mp4",
+		},
+	],
+	"777a17b2-3c89-43b9-8083-3e977465f4f1": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/blInarY00wRgRcpvY1UeoN2bfad00pHc0237TaNMq98JkI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/blInarY00wRgRcpvY1UeoN2bfad00pHc0237TaNMq98JkI/high.mp4",
+		},
+	],
+	nxOOrX_rqICx37Ck: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/P1kEOm412TaSnlQeZ02yeDbV01qpv01gwpcNXYOaMf9hdQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/P1kEOm412TaSnlQeZ02yeDbV01qpv01gwpcNXYOaMf9hdQ/high.mp4",
+		},
+	],
+	"2c46a233-e244-4ef1-9d58-7f9756b66b17": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/kAcqx34ySlWvIL0102tvBdh7ziCoel5obJvVyVxj53yx00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/kAcqx34ySlWvIL0102tvBdh7ziCoel5obJvVyVxj53yx00/high.mp4",
+		},
+	],
+	"j5I0gGo62Enu3-1G": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/IlzXnxtGOpX01c6OtkpydAa5b6NOaIhQh2pXu5xidy400/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/IlzXnxtGOpX01c6OtkpydAa5b6NOaIhQh2pXu5xidy400/high.mp4",
+		},
+	],
+	YhHbs1xQZAJ_r9s2: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/C02bbZomVcWI4dMuSY5Oiy5FdaSQ8iDaRn9024gP39Uw4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/C02bbZomVcWI4dMuSY5Oiy5FdaSQ8iDaRn9024gP39Uw4/high.mp4",
+		},
+	],
+	"Lsc31Al-HcGX8nzG": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/SRmWFc4gMHj4n7WXyTlTgEnbFUUNNUwS4ZApsXmULzU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/SRmWFc4gMHj4n7WXyTlTgEnbFUUNNUwS4ZApsXmULzU/high.mp4",
+		},
+	],
+	"05d704f1-71c4-461e-b7e0-ba2cd9b3d8a3": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/tl8wqm1IsF7025PfzkE2lOMQOg4mJPB3IFgwVKfKJWfc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/tl8wqm1IsF7025PfzkE2lOMQOg4mJPB3IFgwVKfKJWfc/high.mp4",
+		},
+	],
+	uM1tv2msElnNoyCW: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/LFxyj00A66g63H01bq9CCXuMR8tbCRwSNMYVT6vF701dUc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/LFxyj00A66g63H01bq9CCXuMR8tbCRwSNMYVT6vF701dUc/high.mp4",
+		},
+	],
+	"KvFDpZk01y-puixj": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/dqJctChqgHTtNqoO00YtrQM12im001v2Thl2TDSSLL5dc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/dqJctChqgHTtNqoO00YtrQM12im001v2Thl2TDSSLL5dc/high.mp4",
+		},
+	],
+	"0cc73224-1bc9-4fe5-acb2-6d4ae44b1e5e": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/buYfd2iCnz02eZpp3LabcBvR4KUYOxqqBVGn7dDdU9Ho/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/buYfd2iCnz02eZpp3LabcBvR4KUYOxqqBVGn7dDdU9Ho/high.mp4",
+		},
+	],
+	"4de6152d-5724-423b-a4c6-6bc1e53b3b5d": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/aC5vikRTIYdLrLpVyiD3IsJUp8p3Xl73GZHdgD4iRAs/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/aC5vikRTIYdLrLpVyiD3IsJUp8p3Xl73GZHdgD4iRAs/high.mp4",
+		},
+	],
+	Edxi6ebsRFimTfmm: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/NtZaEWA5l8auunIkNnHF01MY7uW4TvhlIFU4ZKHY59PE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/NtZaEWA5l8auunIkNnHF01MY7uW4TvhlIFU4ZKHY59PE/high.mp4",
+		},
+	],
+	YkG1gsqDzXM_ma1s: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/CahUsLaMznxa2X1C8C9YVpa1yc0201MFVzcWH5aqUIwmg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/CahUsLaMznxa2X1C8C9YVpa1yc0201MFVzcWH5aqUIwmg/high.mp4",
+		},
+	],
+	GZqCuZGp0j1YMay7: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/QvQZ32ljqxWjPd9GVVkAQUeYrPRdpFyorvPSuIi302pQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/QvQZ32ljqxWjPd9GVVkAQUeYrPRdpFyorvPSuIi302pQ/high.mp4",
+		},
+	],
+	"7cNbjwbM68LMD1zm": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ZOartV2JNL00ss4CXOwPs01jgv3O5EFtlCRy2LM801y4LY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ZOartV2JNL00ss4CXOwPs01jgv3O5EFtlCRy2LM801y4LY/high.mp4",
+		},
+	],
+	eMXKtfHJkFBUYwmv: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/CD2iC4015YgaRsBbj7CFE026RoPmo7BZvAC00BaF01asDB4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/CD2iC4015YgaRsBbj7CFE026RoPmo7BZvAC00BaF01asDB4/high.mp4",
+		},
+	],
+	Day2H5olhshxManX: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/O6v31k6eOPhM00Dr020100OSPdB2YsJRpFn00aJmCNZJfQIU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/O6v31k6eOPhM00Dr020100OSPdB2YsJRpFn00aJmCNZJfQIU/high.mp4",
+		},
+	],
+	"2e776d93-ec48-440e-bd91-09f045444b86": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/pSDRqGzrt2CugNJ5z6KR87quxLWG1QY400FO0097iWxdQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/pSDRqGzrt2CugNJ5z6KR87quxLWG1QY400FO0097iWxdQ/high.mp4",
+		},
+	],
+	"UjIGHxCav-lS9B2I": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/QVadmC8j9TaGDgL9CmSqyY3aQ00WY2zOvsD1wTrVuWbQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/QVadmC8j9TaGDgL9CmSqyY3aQ00WY2zOvsD1wTrVuWbQ/high.mp4",
+		},
+	],
+	lpnNPw86Vud67vWQ: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/VZ5XaqcEV01O3U7J02y7Z7cWJlvIiyHtIjNWJFdQKAvYI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/VZ5XaqcEV01O3U7J02y7Z7cWJlvIiyHtIjNWJFdQKAvYI/high.mp4",
+		},
+	],
+	FTqSkLzs3YDdHDZp: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4jj701d7LXFggoEURv3n8zFYJwwv02vWxMZkAYE1Z9yps/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4jj701d7LXFggoEURv3n8zFYJwwv02vWxMZkAYE1Z9yps/high.mp4",
+		},
+	],
+	UBFwv3lY_NxDFxyl: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/EPPHDLAnUi0024o01OfFy01NXlPrweP97DCdI9yDgXeBdI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/EPPHDLAnUi0024o01OfFy01NXlPrweP97DCdI9yDgXeBdI/high.mp4",
+		},
+	],
+	"mce7nVs-x3IuV5B4": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/DtiEbDrRGwdGk00DlgVljCJOEK2wi00lw02UPfGRWh3flA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/DtiEbDrRGwdGk00DlgVljCJOEK2wi00lw02UPfGRWh3flA/high.mp4",
+		},
+	],
+	rek0xEgUeQ1XDOrB: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/jaN21Dr01XITLB4021MnkiosU318ikYqUmknwstUo9Ef4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/jaN21Dr01XITLB4021MnkiosU318ikYqUmknwstUo9Ef4.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/X6jpcULYgp002AQq00kYuGk5OSkxSY25DigrDyuGUQfWc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/X6jpcULYgp002AQq00kYuGk5OSkxSY25DigrDyuGUQfWc.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/B3b8roEnQ8K9yRXFmR1jovtkoiNgsQhopkJFciwbqeo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/B3b8roEnQ8K9yRXFmR1jovtkoiNgsQhopkJFciwbqeo.m3u8",
+		},
+	],
+	l8SH5y7rpXyMCwJj: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4gy7rWoq8LHYLnsCl4UUKWaXXN2YpmcKq2y8gyn3iqY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4gy7rWoq8LHYLnsCl4UUKWaXXN2YpmcKq2y8gyn3iqY/high.mp4",
+		},
+	],
+	"a_Viip-xwcvmhFYZ": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/erg3j9ixRU9k6fOWZCFoLskS1kFT01KP8D4CsEmR01SHY/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/erg3j9ixRU9k6fOWZCFoLskS1kFT01KP8D4CsEmR01SHY/high.mp4",
+		},
+	],
+	"9R_5XmjH0HFRESEp": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/5141wTjAKjjhq8ugOHLTgztARgej7oskI99EpRNWEyE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/5141wTjAKjjhq8ugOHLTgztARgej7oskI99EpRNWEyE/high.mp4",
+		},
+	],
+	"bbpzNlEcQt-lOE-3": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/hIR00av7dhtUdgFUzeSqjcaPD58mdNkIB3a8miLmuw01A/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/hIR00av7dhtUdgFUzeSqjcaPD58mdNkIB3a8miLmuw01A/high.mp4",
+		},
+	],
+	"499408ab-0925-4aad-a78c-3ea8af23e10c": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/FYS4jc01011O5NOMBjACe100m3wF00lLAc8pUkbTAXAz8lo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/FYS4jc01011O5NOMBjACe100m3wF00lLAc8pUkbTAXAz8lo/high.mp4",
+		},
+	],
+	QwsF6IvJyZYOfcIa: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/3eLI3C9SqWq6u8duu6aelp701rWHpKmCUNvGTtrZZARc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/3eLI3C9SqWq6u8duu6aelp701rWHpKmCUNvGTtrZZARc/high.mp4",
+		},
+	],
+	pyLiwJXDq4cyZC80: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1oS7MNSv6Ndvt5Zcnj2KsFDE01hypT00sTlvk8RSWcI1Y/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1oS7MNSv6Ndvt5Zcnj2KsFDE01hypT00sTlvk8RSWcI1Y/high.mp4",
+		},
+	],
+	_MrWIoBSj3TG4mwH: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/p95Afwrmwuq1tAeH8BLV8F02rCxeJlSXLTq8O7aSWCGE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/p95Afwrmwuq1tAeH8BLV8F02rCxeJlSXLTq8O7aSWCGE/high.mp4",
+		},
+	],
+	"aea9a7c6-e02f-46b5-8440-1b38eb5c0e7f": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/gtOnzjEpPgZJwKp00mB4u53F1P1A01ehibdP2eA1WUtCo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/gtOnzjEpPgZJwKp00mB4u53F1P1A01ehibdP2eA1WUtCo/high.mp4",
+		},
+	],
+	"HS1B9-gN0IArgAcl": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Px02KmDarg5Cm301pTxtRzsfoRHD5hZofLlVx9QfQ6GH8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Px02KmDarg5Cm301pTxtRzsfoRHD5hZofLlVx9QfQ6GH8/high.mp4",
+		},
+	],
+	"de57db79-9796-4c6b-b0b2-4487ea55db10": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/FuBcKoXcB9RfkNRg4c01H2zuy2IUHmy7L3UfVhgzSDSM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/FuBcKoXcB9RfkNRg4c01H2zuy2IUHmy7L3UfVhgzSDSM/high.mp4",
+		},
+	],
+	ErNIiRrsQiSS94Mr: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/NrDm4ljz00LsHdDRhDqNy6zXQEoQV02atcN44YTTrsNmQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/NrDm4ljz00LsHdDRhDqNy6zXQEoQV02atcN44YTTrsNmQ.m3u8",
+		},
+	],
+	PfDaDszTwYX2Kh0O: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/i02rO3bM8ZYaYlRzXfb81YO8fQJ3e93SB019epANKCz7g/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/i02rO3bM8ZYaYlRzXfb81YO8fQJ3e93SB019epANKCz7g/high.mp4",
+		},
+	],
+	qd08x4cngup1H1BO: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/k01wICpMcKbSGdIjcOeS00knrOmABlGXg3ayMnJvHUQLo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/k01wICpMcKbSGdIjcOeS00knrOmABlGXg3ayMnJvHUQLo.m3u8",
+		},
+	],
+	"2G-D8vn2pvW5wVMi": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/nx01rWkxIG5gEnLVVbz88JhN01y23HqDKKDf9hW021dZY00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/nx01rWkxIG5gEnLVVbz88JhN01y23HqDKKDf9hW021dZY00/high.mp4",
+		},
+	],
+	"ahexn5IsQx-d-aLy": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Y6rKNXoyQYWn00o75GTy3b6k5WEbebrpbwGHLQtiYXPg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Y6rKNXoyQYWn00o75GTy3b6k5WEbebrpbwGHLQtiYXPg/high.mp4",
+		},
+	],
+	IuVCdM4pnGdd6w8i: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/iksGgctcLHMKaiQdf00ScoUdKLjIJGb51dq7ER33fWh4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/iksGgctcLHMKaiQdf00ScoUdKLjIJGb51dq7ER33fWh4/high.mp4",
+		},
+	],
+	"1W_0cwjBVboBtCcY": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Oqleq1ndRm4ERLyD444id3BCRTLgLuq6BhIBvcjSnF4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Oqleq1ndRm4ERLyD444id3BCRTLgLuq6BhIBvcjSnF4/high.mp4",
+		},
+	],
+	"4bC9G_fnp_gz3Fvw": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/L8IfLuSV45cOiywIOIXLVDGl661EAc500KkMM1402DYn00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/L8IfLuSV45cOiywIOIXLVDGl661EAc500KkMM1402DYn00/high.mp4",
+		},
+	],
+	JdIQX_Biu8A3QsUU: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/k3e3Jcv00IBKCjma5X6XErFN3lMFRwS7vc00G02b8N6VNA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/k3e3Jcv00IBKCjma5X6XErFN3lMFRwS7vc00G02b8N6VNA/high.mp4",
+		},
+	],
+	s9YUIJ4xLcDDr9pS: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/plivS693bzDW1S4BBV7vTEcg45G01n8LzDijYDSX9PnE/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/plivS693bzDW1S4BBV7vTEcg45G01n8LzDijYDSX9PnE/high.mp4",
+		},
+	],
+	NmYpPDrf9XstKbEH: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/44iq6NE1yDiTTSGdH5U02FmPmV7pWSngdjnfZveebfjo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/44iq6NE1yDiTTSGdH5U02FmPmV7pWSngdjnfZveebfjo/high.mp4",
+		},
+	],
+	"a827a68f-c185-45bf-bbbf-9ca53c4cc132": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/1LtspvQg7EN9aZU2QQzdxODVjIkFrthkyBSxUDqceV00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/1LtspvQg7EN9aZU2QQzdxODVjIkFrthkyBSxUDqceV00/high.mp4",
+		},
+	],
+	"b258892d-58d5-4bfe-a8b4-3cb9e8298408": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4c1ahgb6ZKIwZUYrNZPzw1ylzjKHyo9I5xMYlEcLy018/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4c1ahgb6ZKIwZUYrNZPzw1ylzjKHyo9I5xMYlEcLy018/high.mp4",
+		},
+	],
+	"817f10d5-57b2-44be-b9f6-0ad647edd825": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/taJMp8NIMFSmkPCqmWp00FG01u5HOe2juE201caasjAfvo/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/taJMp8NIMFSmkPCqmWp00FG01u5HOe2juE201caasjAfvo/high.mp4",
+		},
+	],
+	"93f5a3ce-5d93-4b68-b001-f1fdf1d9ec90": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/xPzxHxkRLiUfLES4oW02aCgJrYHkMnpJZg00EZhIlT5sA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/xPzxHxkRLiUfLES4oW02aCgJrYHkMnpJZg00EZhIlT5sA/high.mp4",
+		},
+	],
+	"6PVJLGhvozpELKtc": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Q01dL0027007r8JbLWwegyW01DarNmENiyYrD3AF01wTcgRY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Q01dL0027007r8JbLWwegyW01DarNmENiyYrD3AF01wTcgRY/high.mp4",
+		},
+	],
+	"78e6d11d-cda2-49d6-aaf7-f3ea2255f1ae": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/G00QTwioELOTDYzjCFzgABkvVdC6gEV00pURoDgiooYrc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/G00QTwioELOTDYzjCFzgABkvVdC6gEV00pURoDgiooYrc/high.mp4",
+		},
+	],
+	CJWWuqMMu0_BvQ2R: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/FG027gts9dTqTRnAggWcpD3O3WHgj9VhBfLbLg02zVWnc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/FG027gts9dTqTRnAggWcpD3O3WHgj9VhBfLbLg02zVWnc/high.mp4",
+		},
+	],
+	"c555d400-cd2d-4439-af8d-d98140fef664": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/EUXuoyndxtSmVNqDZrqArwcVf8qE5pFSQAuqykswQO8/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/EUXuoyndxtSmVNqDZrqArwcVf8qE5pFSQAuqykswQO8/high.mp4",
+		},
+	],
+	"5f7ab6f4-06b7-413b-9d4a-1e7aeb615cb3": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/AhVuzk00TUzXmrLFedCOa51XqPAxJOJfKFbOLDZTq2to/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/AhVuzk00TUzXmrLFedCOa51XqPAxJOJfKFbOLDZTq2to/high.mp4",
+		},
+	],
+	_lhY8AZnh7IYX_l_: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/IOfn7Qplsbi3BNRmny02uRpwfWpZOJ6Vv9XhQxzWMTII/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/IOfn7Qplsbi3BNRmny02uRpwfWpZOJ6Vv9XhQxzWMTII/high.mp4",
+		},
+	],
+	JH1eQMPX24Aggl6o: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/ppePgaLdfZDJhSub00UVqsiArH0001w00oCtUKdSTQz3tME/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/ppePgaLdfZDJhSub00UVqsiArH0001w00oCtUKdSTQz3tME/high.mp4",
+		},
+	],
+	"Fh4p-rXSrLZ7MajT": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/M401yx1yRb41xrHnwVoDd9KJls83hCMARQgTBMqZ02Xzk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/M401yx1yRb41xrHnwVoDd9KJls83hCMARQgTBMqZ02Xzk/high.mp4",
+		},
+	],
+	"0L6wSUIpGi8G4fS8": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/UqwRlhda9bZsxgc9ii00tcjB00ErxNbr1mDU675qotAT8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/UqwRlhda9bZsxgc9ii00tcjB00ErxNbr1mDU675qotAT8/high.mp4",
+		},
+	],
+	"ecsCnRRC5buTy-0x": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/m5oEUrCvIrx4hOxNRe7ODe1JC7006Meom021wnIPOCzmI/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/m5oEUrCvIrx4hOxNRe7ODe1JC7006Meom021wnIPOCzmI/high.mp4",
+		},
+	],
+	s2_RiMfu2paVmxSg: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/3XDeuwK3KkYFGLhxR100mcfZoFdgkwrBC7CjRrPQC9hA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/3XDeuwK3KkYFGLhxR100mcfZoFdgkwrBC7CjRrPQC9hA/high.mp4",
+		},
+	],
+	"PjXBcvDnFVqkww-H": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/s8Wkpa3JxGkjziLM1DhF4ka1EXn5PEte2unNyh2ZZ4U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/s8Wkpa3JxGkjziLM1DhF4ka1EXn5PEte2unNyh2ZZ4U/high.mp4",
+		},
+	],
+	L5NB_9_KF9CHdWpE: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/01OHOAKak2BuZjaLR01A01zc1p01sVAmBIHwG4qx6UI4Gmw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/01OHOAKak2BuZjaLR01A01zc1p01sVAmBIHwG4qx6UI4Gmw/high.mp4",
+		},
+	],
+	YSMsQ1ArsUOs488E: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4b6pKAWdy2zGAxPG92RbsGBL2tPQ8psXQrKw4jfNomc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4b6pKAWdy2zGAxPG92RbsGBL2tPQ8psXQrKw4jfNomc/high.mp4",
+		},
+	],
+	"aOLnKMls1AKS-JE7": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/HvwT8l1CxLJYwB02US3C01ySN8NIr23SdAidQDwxwzN02U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/HvwT8l1CxLJYwB02US3C01ySN8NIr23SdAidQDwxwzN02U/high.mp4",
+		},
+	],
+	QXyK0ML4TD5tlPxl: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/4Vm8oaQdVk8VUcz9Ko5gWJqqyPnFm7WzDR51BDP6NiA/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/4Vm8oaQdVk8VUcz9Ko5gWJqqyPnFm7WzDR51BDP6NiA/high.mp4",
+		},
+	],
+	H1PNVQBZm4f9KXb3: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/SNeAxN9LmxZKYZRTYTeseHFg6GVTqhAFZkdUh2l5mbE/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/SNeAxN9LmxZKYZRTYTeseHFg6GVTqhAFZkdUh2l5mbE/high.mp4",
+		},
+	],
+	"260fca84-232f-4e9a-aa9c-afe34abacff3": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/GJqxsxdAlMVjT2aKGJto6yj9Mhbl2CUFR017M6L5b14k/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/GJqxsxdAlMVjT2aKGJto6yj9Mhbl2CUFR017M6L5b14k/high.mp4",
+		},
+	],
+	OQZaXBAEWO8Wk4Yt: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/yLk01lwvOWUgRIKjoRVeYaCJLkJgDI0171Jlbw9rgSKQQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yLk01lwvOWUgRIKjoRVeYaCJLkJgDI0171Jlbw9rgSKQQ/high.mp4",
+		},
+	],
+	yd_8huuaiTgyhhyA: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/upxB7rzhtMULSK5O3pOWlDlatIZcjoCTXAzwNaxoGDU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/upxB7rzhtMULSK5O3pOWlDlatIZcjoCTXAzwNaxoGDU.m3u8",
+		},
+	],
+	gGIzIbB5DSuzyKd5: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/3Z02ofZ02vfU02iknkfpyFvQ2165aQsjlV0200pUIoCUBNf4/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/3Z02ofZ02vfU02iknkfpyFvQ2165aQsjlV0200pUIoCUBNf4/high.mp4",
+		},
+	],
+	rSP8JKeoDxexC_Gu: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Gvc8yW8epV6HJNHCqArJNrhtfphV1pfjBkCMes801AO00/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Gvc8yW8epV6HJNHCqArJNrhtfphV1pfjBkCMes801AO00/high.mp4",
+		},
+	],
+	"YNf-y04K0ENtDNi0": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/Y02nimZEEVAhPzdesb1vFDbK1iBVhzy9nq025HDFzOouY/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/Y02nimZEEVAhPzdesb1vFDbK1iBVhzy9nq025HDFzOouY/high.mp4",
+		},
+	],
+	fs5XmqhpN9Mk9mnF: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/pxBoCyvUIO8PwamPTvcSmaseRWQzuKlzgc702xbE3l4w/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/pxBoCyvUIO8PwamPTvcSmaseRWQzuKlzgc702xbE3l4w/high.mp4",
+		},
+	],
+	IrPf7PCbwEcuJEG5: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/j8tvUCU9LR01wNPDooVAWu6D3xLrnQLNaAMbRkPC7Rcc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/j8tvUCU9LR01wNPDooVAWu6D3xLrnQLNaAMbRkPC7Rcc/high.mp4",
+		},
+	],
+	"85c0aa8d-d0e4-4ba0-a802-a557affd1116": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/P01DcAQK1N14R9QB42ZG00MQ1bzgVy01OdF5qqlkmQiGAQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/P01DcAQK1N14R9QB42ZG00MQ1bzgVy01OdF5qqlkmQiGAQ/high.mp4",
+		},
+	],
+	ulSq4f5g8O1DjESl: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/yQxA4dpHAJ00DzOgyttv3tlUR9PBGLGBDANovjPIh7rQ/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/yQxA4dpHAJ00DzOgyttv3tlUR9PBGLGBDANovjPIh7rQ/high.mp4",
+		},
+	],
+	BUxuV42l6oolZVde: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8.m3u8",
+		},
+	],
+	"9tm2G1W0uf8y-77f": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/6ff5Nk02t00RBVpRbJdyaaDj01701yv6TUL02ulD01ZbtZGF8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/6ff5Nk02t00RBVpRbJdyaaDj01701yv6TUL02ulD01ZbtZGF8/high.mp4",
+		},
+	],
+	"9KFcQvBQ1y4B4gC3": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/gvzR802wYrdQRZNVCXZ00g2e2faUy5kIW01a02Vrj02aktMk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/gvzR802wYrdQRZNVCXZ00g2e2faUy5kIW01a02Vrj02aktMk/high.mp4",
+		},
+	],
+	"513b8b5b-5315-4510-87c6-04df95a51053": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/S6DZQAjgAiZdNFSo4CzerdcjTGIRse37UHMZZd01IC3c/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/S6DZQAjgAiZdNFSo4CzerdcjTGIRse37UHMZZd01IC3c/high.mp4",
+		},
+	],
+	"6Q9E-cUbwO7mhAbG": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/2no9L52XyHsCxYCcfEWY5Hat9BWRX2K4zsLImDmTV00o/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/2no9L52XyHsCxYCcfEWY5Hat9BWRX2K4zsLImDmTV00o/high.mp4",
+		},
+	],
+	dolYIaKI1o1wn_Oh: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/qwhzacNiU00thJOB01Fiq1PhS8IAMXwRBwNOkARSU6AJI/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/qwhzacNiU00thJOB01Fiq1PhS8IAMXwRBwNOkARSU6AJI/high.mp4",
+		},
+	],
+	"7d141cfb-fdde-4320-8553-1e03f6b4e9bd": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/qQCBV4c15s9k6DnWiqFwbi2KLegIkUESMyRSCWEsvWg/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/qQCBV4c15s9k6DnWiqFwbi2KLegIkUESMyRSCWEsvWg/high.mp4",
+		},
+	],
+	ravxz3gHSUs8t6Ck: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/tthCgjythzE2GXHwcyhVqi8Rnq3MQxbqbKRw1SohzIc/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/tthCgjythzE2GXHwcyhVqi8Rnq3MQxbqbKRw1SohzIc/high.mp4",
+		},
+	],
+	ApnN1oyGDK05fAQS: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/iEaJBkHUkxr593DSQCpDF5u2bKZOySj3f8bJGF02srmo/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/iEaJBkHUkxr593DSQCpDF5u2bKZOySj3f8bJGF02srmo/high.mp4",
+		},
+	],
+	VH0wZk124BuuS99O: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/4SCZxms00jYn02JZY5UnycKsENUoOIjM200cgmSWv1RYE4/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/4SCZxms00jYn02JZY5UnycKsENUoOIjM200cgmSWv1RYE4.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/dFgYKfPeuvHlod9ng8lj302hGNpVABkqfju024dit5i9U/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/dFgYKfPeuvHlod9ng8lj302hGNpVABkqfju024dit5i9U.m3u8",
+		},
+		{
+			angle: "SIDE",
+			thumbnailUrl:
+				"https://image.mux.com/pRwyg5p4EP1sj9fX7aVq2VmMAoBAPMnHZdoZ7KWsmy8/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/pRwyg5p4EP1sj9fX7aVq2VmMAoBAPMnHZdoZ7KWsmy8.m3u8",
+		},
+	],
+	uHAiPY44IO7TgZdK: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/Lic00tf01QEOyIxKodb01dOteeUYteueEaUVRZh66il6mQ/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/Lic00tf01QEOyIxKodb01dOteeUYteueEaUVRZh66il6mQ/high.mp4",
+		},
+	],
+	"V0HUsN-fjhORkR8N": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/02XlHC2Lde9AXpJT4u6atpsr01fdS015RLg5L6iEMJ101qU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/02XlHC2Lde9AXpJT4u6atpsr01fdS015RLg5L6iEMJ101qU/high.mp4",
+		},
+	],
+	"8hbXFqffiMF_8D8R": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/BS3RbIOIm0038uaoortCLYs2eNtg9LmOqIKt0083TFV7s/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/BS3RbIOIm0038uaoortCLYs2eNtg9LmOqIKt0083TFV7s/high.mp4",
+		},
+	],
+	"X66uNUrW-S5ZoC6m": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/00YA38yJ5Juk1J1003iOLESusW8XzFcOhMDMF5dWGuZ34/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/00YA38yJ5Juk1J1003iOLESusW8XzFcOhMDMF5dWGuZ34/high.mp4",
+		},
+	],
+	RBxmDZFAONyv_ovt: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/02SZ02EPXfwnD5Bh7hkmoi5QWQrUnv7pZ4ApGhXMNaJc00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/02SZ02EPXfwnD5Bh7hkmoi5QWQrUnv7pZ4ApGhXMNaJc00/high.mp4",
+		},
+	],
+	DAdfpK3ekrgLllmx: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/MrIldAT6TiQ8VL1v01aD00b2udrQQOr1FjhoPTVPFIQmk/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/MrIldAT6TiQ8VL1v01aD00b2udrQQOr1FjhoPTVPFIQmk/high.mp4",
+		},
+	],
+	GRL8oT9WtaRKez73: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/QVhNdG01PR012tzA7d028SxmpkHMdQJsVDOB9es6Ml01mkU/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/QVhNdG01PR012tzA7d028SxmpkHMdQJsVDOB9es6Ml01mkU/high.mp4",
+		},
+	],
+	"zW-IfyPm-g0UPkCi": [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/TmR5R8pPLzUfUnkiscZQ01fMEJNWDzorx8ee029cQ7WB00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/TmR5R8pPLzUfUnkiscZQ01fMEJNWDzorx8ee029cQ7WB00.m3u8",
+		},
+	],
+	MR2bLPxMweqfJZhE: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/vq00Mktskxzk2OW96kEluV63J102w6QOMA8yI00JSQi1Dc/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/vq00Mktskxzk2OW96kEluV63J102w6QOMA8yI00JSQi1Dc/high.mp4",
+		},
+	],
+	f9uw1qCFUhNlrPoj: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/S02L67OuuTxXCZejFoPkyWIvUzu6iDrtEVtjzeEnvfJA/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/S02L67OuuTxXCZejFoPkyWIvUzu6iDrtEVtjzeEnvfJA.m3u8",
+		},
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/O00avnqA022ng3jKYWg00KF5rSw3i7j9m01W5AOjnRc6TUk/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/O00avnqA022ng3jKYWg00KF5rSw3i7j9m01W5AOjnRc6TUk.m3u8",
+		},
+	],
+	JgArpiAO2lQCWput: [
+		{
+			angle: "ISOMETRIC",
+			thumbnailUrl:
+				"https://image.mux.com/VNdmFraqa00ezHbnwyOhCmkR6r7t7r8HZtq5w02oQCYxw/thumbnail.webp",
+			videoUrl:
+				"https://stream.mux.com/VNdmFraqa00ezHbnwyOhCmkR6r7t7r8HZtq5w02oQCYxw/high.mp4",
+		},
+	],
+	QK0V6VzQMtdY8aWg: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01IGk01IWx5BP1vDqhKY016g01s00Nx8g1y50216jdl00DaWMM/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01IGk01IWx5BP1vDqhKY016g01s00Nx8g1y50216jdl00DaWMM/high.mp4",
+		},
+	],
+	pQ1R9GSmQ_Bkri40: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/CrNwwNWwCOiTSsXNZl01PHbduYuBS6C35NgaXQb00IXqs/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/CrNwwNWwCOiTSsXNZl01PHbduYuBS6C35NgaXQb00IXqs/high.mp4",
+		},
+	],
+	ljmgYw_wMHGzXSTY: [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/01VnCwDG02S26CKdz9QqZTHJBDW6011QMPoztb2OyjXLEw/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/01VnCwDG02S26CKdz9QqZTHJBDW6011QMPoztb2OyjXLEw/high.mp4",
+		},
+	],
+	"7R8bNkUpYu95YDms": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/sAwhg2lJ00iBpdNPi6PqNau8WCFi00YvTyS027mGS6Ezf00/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/sAwhg2lJ00iBpdNPi6PqNau8WCFi00YvTyS027mGS6Ezf00/high.mp4",
+		},
+	],
+	"6pv-zwP4QxiDWcgV": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/eg33fyuKqEW00L0000x9ciMYi02ADNB11p9eLuY00owRDA700/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/eg33fyuKqEW00L0000x9ciMYi02ADNB11p9eLuY00owRDA700/high.mp4",
+		},
+	],
+	"bGY-qHuQ4SSqd2lB": [
+		{
+			angle: "FRONT",
+			thumbnailUrl:
+				"https://image.mux.com/foTF4aLTj6ACRKXSkmbhp15G74BrhCSNYlYb02BRg028o/thumbnail.jpg",
+			videoUrl:
+				"https://stream.mux.com/foTF4aLTj6ACRKXSkmbhp15G74BrhCSNYlYb02BRg028o/high.mp4",
+		},
+	],
+} as const;

--- a/src/lib/exercise-demo-media.ts
+++ b/src/lib/exercise-demo-media.ts
@@ -1,4 +1,4 @@
-import exerciseDumpRaw from "../../supabase/seed-data/exercise_dump.json?raw";
+import { EXERCISE_DEMO_MEDIA } from "@/lib/exercise-demo-media-manifest";
 
 export interface ExerciseDemoMedia {
 	angle: string | null;
@@ -6,79 +6,15 @@ export interface ExerciseDemoMedia {
 	videoUrl: string;
 }
 
-interface RawExerciseDumpItem {
-	id?: unknown;
-	videos?: unknown;
-}
+type ExerciseDemoMediaManifest = Record<string, readonly ExerciseDemoMedia[]>;
 
-interface RawExerciseVideo {
-	angle?: unknown;
-	thumbnail?: unknown;
-	video?: unknown;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
-
-function parseExerciseDump(raw: string): RawExerciseDumpItem[] {
-	try {
-		const parsed: unknown = JSON.parse(raw);
-		return Array.isArray(parsed) ? parsed.filter(isRecord) : [];
-	} catch {
-		return [];
-	}
-}
-
-function normalizeVideo(video: unknown): ExerciseDemoMedia | null {
-	if (!isRecord(video)) return null;
-
-	const rawVideo = video as RawExerciseVideo;
-	if (
-		typeof rawVideo.video !== "string" ||
-		typeof rawVideo.thumbnail !== "string"
-	) {
-		return null;
-	}
-
-	return {
-		angle: typeof rawVideo.angle === "string" ? rawVideo.angle : null,
-		thumbnailUrl: rawVideo.thumbnail,
-		videoUrl: rawVideo.video,
-	};
-}
-
-function buildExerciseMediaIndex(
-	exerciseDump: RawExerciseDumpItem[],
-): Map<string, ExerciseDemoMedia[]> {
-	const mediaByExerciseId = new Map<string, ExerciseDemoMedia[]>();
-
-	for (const exercise of exerciseDump) {
-		if (typeof exercise.id !== "string" || !Array.isArray(exercise.videos)) {
-			continue;
-		}
-
-		const media = exercise.videos
-			.map((video) => normalizeVideo(video))
-			.filter((video): video is ExerciseDemoMedia => video !== null);
-
-		if (media.length > 0) {
-			mediaByExerciseId.set(exercise.id, media);
-		}
-	}
-
-	return mediaByExerciseId;
-}
-
-const mediaByExerciseId = buildExerciseMediaIndex(
-	parseExerciseDump(exerciseDumpRaw),
-);
+const mediaByExerciseId = EXERCISE_DEMO_MEDIA as ExerciseDemoMediaManifest;
 
 export function getExerciseDemoMedia(
 	exerciseId: string | null | undefined,
 ): ExerciseDemoMedia[] {
 	if (!exerciseId) return [];
-	return mediaByExerciseId.get(exerciseId) ?? [];
+	return [...(mediaByExerciseId[exerciseId] ?? [])];
 }
 
 export function getPrimaryExerciseDemoMedia(

--- a/src/lib/exercise-demo-media.ts
+++ b/src/lib/exercise-demo-media.ts
@@ -1,0 +1,88 @@
+import exerciseDumpRaw from "../../supabase/seed-data/exercise_dump.json?raw";
+
+export interface ExerciseDemoMedia {
+	angle: string | null;
+	thumbnailUrl: string;
+	videoUrl: string;
+}
+
+interface RawExerciseDumpItem {
+	id?: unknown;
+	videos?: unknown;
+}
+
+interface RawExerciseVideo {
+	angle?: unknown;
+	thumbnail?: unknown;
+	video?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseExerciseDump(raw: string): RawExerciseDumpItem[] {
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed.filter(isRecord) : [];
+	} catch {
+		return [];
+	}
+}
+
+function normalizeVideo(video: unknown): ExerciseDemoMedia | null {
+	if (!isRecord(video)) return null;
+
+	const rawVideo = video as RawExerciseVideo;
+	if (
+		typeof rawVideo.video !== "string" ||
+		typeof rawVideo.thumbnail !== "string"
+	) {
+		return null;
+	}
+
+	return {
+		angle: typeof rawVideo.angle === "string" ? rawVideo.angle : null,
+		thumbnailUrl: rawVideo.thumbnail,
+		videoUrl: rawVideo.video,
+	};
+}
+
+function buildExerciseMediaIndex(
+	exerciseDump: RawExerciseDumpItem[],
+): Map<string, ExerciseDemoMedia[]> {
+	const mediaByExerciseId = new Map<string, ExerciseDemoMedia[]>();
+
+	for (const exercise of exerciseDump) {
+		if (typeof exercise.id !== "string" || !Array.isArray(exercise.videos)) {
+			continue;
+		}
+
+		const media = exercise.videos
+			.map((video) => normalizeVideo(video))
+			.filter((video): video is ExerciseDemoMedia => video !== null);
+
+		if (media.length > 0) {
+			mediaByExerciseId.set(exercise.id, media);
+		}
+	}
+
+	return mediaByExerciseId;
+}
+
+const mediaByExerciseId = buildExerciseMediaIndex(
+	parseExerciseDump(exerciseDumpRaw),
+);
+
+export function getExerciseDemoMedia(
+	exerciseId: string | null | undefined,
+): ExerciseDemoMedia[] {
+	if (!exerciseId) return [];
+	return mediaByExerciseId.get(exerciseId) ?? [];
+}
+
+export function getPrimaryExerciseDemoMedia(
+	exerciseId: string | null | undefined,
+): ExerciseDemoMedia | null {
+	return getExerciseDemoMedia(exerciseId)[0] ?? null;
+}

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,6 +1,7 @@
 // Canonical source for insight generation rules.
 // IMPORTANT: The Edge Function at supabase/functions/generate-insights/index.ts
 // duplicates these rules. Changes here must be synced there.
+import { convertWeight, formatWeight, type WeightUnit } from "@/lib/units";
 
 export interface TrainingInsight {
 	id: string;
@@ -25,11 +26,19 @@ export interface InsightInput {
 
 const STREAK_MILESTONES = [7, 14, 21, 30];
 
+function roundWeightMetric(valueKg: number, unit: WeightUnit): number {
+	const converted = convertWeight(valueKg, unit);
+	return Number(converted.toFixed(unit === "lbs" ? 1 : 0));
+}
+
 /**
  * Applies rule-based logic to an InsightInput and returns a list of
  * TrainingInsight objects. Pure function — no async, no side effects.
  */
-export function generateInsights(input: InsightInput): TrainingInsight[] {
+export function generateInsights(
+	input: InsightInput,
+	unit: WeightUnit = "kg",
+): TrainingInsight[] {
 	const insights: TrainingInsight[] = [];
 
 	// ── Volume Trend ──────────────────────────────────────────────────────────
@@ -124,19 +133,26 @@ export function generateInsights(input: InsightInput): TrainingInsight[] {
 	for (const pr of input.recentPRs) {
 		const delta =
 			pr.previousValue !== undefined ? pr.value - pr.previousValue : undefined;
+		const formattedValue = formatWeight(pr.value, unit);
+		const formattedDelta =
+			delta !== undefined ? formatWeight(delta, unit) : undefined;
+		const formattedPrevious =
+			pr.previousValue !== undefined
+				? formatWeight(pr.previousValue, unit)
+				: undefined;
 		insights.push({
 			id: `pr-${pr.exercise.toLowerCase().replace(/\s+/g, "-")}`,
 			type: "achievement",
 			title: `New PR: ${pr.exercise}`,
 			description:
-				delta !== undefined
-					? `You set a personal record on ${pr.exercise} — ${pr.value} lbs (up ${delta} lbs from ${pr.previousValue} lbs).`
-					: `You set a personal record on ${pr.exercise} — ${pr.value} lbs.`,
+				delta !== undefined && formattedDelta && formattedPrevious
+					? `You set a personal record on ${pr.exercise} — ${formattedValue} (up ${formattedDelta} from ${formattedPrevious}).`
+					: `You set a personal record on ${pr.exercise} — ${formattedValue}.`,
 			metric: {
 				name: pr.exercise,
-				value: pr.value,
-				unit: "lbs",
-				delta,
+				value: roundWeightMetric(pr.value, unit),
+				unit,
+				delta: delta !== undefined ? roundWeightMetric(delta, unit) : undefined,
 			},
 		});
 	}

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -7,6 +7,16 @@ function safeNumber(value: number | null | undefined): number {
 	return value;
 }
 
+function trimTrailingZeros(value: string): string {
+	return value.replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+}
+
+export function normalizeWeightUnit(
+	unit: string | null | undefined,
+): WeightUnit {
+	return unit === "lbs" ? "lbs" : "kg";
+}
+
 export function convertWeight(
 	valueKg: number | null | undefined,
 	unit: WeightUnit,
@@ -30,6 +40,29 @@ export function toKg(valueLbs: number | null | undefined): number {
 	return safeNumber(valueLbs) / KG_TO_LBS;
 }
 
+export function weightInputValue(
+	valueKg: number | null | undefined,
+	unit: WeightUnit,
+): string {
+	if (valueKg == null || Number.isNaN(valueKg)) return "";
+	const converted = convertWeight(valueKg, unit);
+	return trimTrailingZeros(converted.toFixed(1));
+}
+
+export function weightInputToKg(
+	value: string | number | null | undefined,
+	unit: WeightUnit,
+): number {
+	const parsed =
+		typeof value === "number"
+			? value
+			: typeof value === "string" && value.trim() !== ""
+				? Number(value)
+				: Number.NaN;
+	if (!Number.isFinite(parsed)) return 0;
+	return unit === "lbs" ? parsed / KG_TO_LBS : parsed;
+}
+
 export function formatVolume(
 	valueKg: number | null | undefined,
 	unit: WeightUnit,
@@ -51,4 +84,46 @@ export function formatVolume(
 
 export function getUnitLabel(unit: WeightUnit): WeightUnit {
 	return unit;
+}
+
+export function isWeightUnit(unit: unknown): unit is WeightUnit {
+	return unit === "kg" || unit === "lbs";
+}
+
+export function convertWeightFromUnit(
+	value: number | null | undefined,
+	fromUnit: string | null | undefined,
+	toUnit: WeightUnit,
+): number {
+	const sourceValue = safeNumber(value);
+	if (fromUnit === "lbs") {
+		const valueKg = sourceValue / KG_TO_LBS;
+		return toUnit === "lbs" ? sourceValue : valueKg;
+	}
+	return convertWeight(sourceValue, toUnit);
+}
+
+export function formatWeightMetric(
+	valueKg: number | null | undefined,
+	unit: WeightUnit,
+): string {
+	return formatWeight(valueKg, unit);
+}
+
+export function formatVolumeMetric(
+	valueKg: number | null | undefined,
+	unit: WeightUnit,
+): string {
+	return formatVolume(valueKg, unit);
+}
+
+export function formatLeaderboardValue(
+	valueKg: number,
+	metric: string,
+	unit: WeightUnit,
+): string {
+	if (metric.toLowerCase().includes("volume")) {
+		return formatVolume(valueKg, unit);
+	}
+	return valueKg.toLocaleString();
 }

--- a/src/queries/__tests__/exercises.test.ts
+++ b/src/queries/__tests__/exercises.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const catalogRow = {
+	id: "BUxuV42l6oolZVde",
+	name: "Tricep Pushdown",
+	display_name: "Tricep Pushdown",
+	description: null,
+	muscle_group: "ARMS",
+	muscle_groups: ["ARMS"],
+	muscles: ["triceps"],
+	equipment: ["SHORT_BAR"],
+	movement: "tricep_extension",
+	sidedness: "bilateral",
+	grip: "pronated",
+	grip_width: null,
+	default_cable_config: "DOUBLE",
+	min_rep_range: 5,
+	popularity: 0,
+	aliases: [],
+	thumbnail_url:
+		"https://image.mux.com/XMK02bqNtt76JAbEvjknvG69J01KKPVYaDp6FWOPV9La8/thumbnail.jpg",
+	archived: true,
+	is_custom: false,
+};
+
+type AwaitableQuery = Promise<{ data: unknown; error: unknown }> & {
+	select: ReturnType<typeof vi.fn>;
+	order: ReturnType<typeof vi.fn>;
+	eq: ReturnType<typeof vi.fn>;
+	overlaps: ReturnType<typeof vi.fn>;
+	or: ReturnType<typeof vi.fn>;
+	maybeSingle: ReturnType<typeof vi.fn>;
+};
+
+function buildAwaitableQuery(terminal: { data: unknown; error: unknown }) {
+	const query = Promise.resolve(terminal) as AwaitableQuery;
+
+	query.select = vi.fn(() => query);
+	query.order = vi.fn(() => query);
+	query.eq = vi.fn(() => query);
+	query.overlaps = vi.fn(() => query);
+	query.or = vi.fn(() => query);
+	query.maybeSingle = vi.fn(() => Promise.resolve(terminal));
+
+	return query;
+}
+
+let query: ReturnType<typeof buildAwaitableQuery>;
+const fromFn = vi.fn(() => query);
+
+vi.mock("@/lib/supabase", () => ({
+	supabase: { from: (...args: unknown[]) => fromFn(...args) },
+}));
+
+describe("fetchExerciseCatalog", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		query = buildAwaitableQuery({ data: [catalogRow], error: null });
+	});
+
+	it("filters archived exercises by default", async () => {
+		const { fetchExerciseCatalog } = await import("../exercises");
+
+		await fetchExerciseCatalog();
+
+		expect(fromFn).toHaveBeenCalledWith("exercise_catalog");
+		expect(query.eq).toHaveBeenCalledWith("archived", false);
+	});
+
+	it("omits the archived filter when includeArchived is true", async () => {
+		const { fetchExerciseCatalog } = await import("../exercises");
+
+		const result = await fetchExerciseCatalog({ includeArchived: true });
+
+		expect(query.eq).not.toHaveBeenCalledWith("archived", false);
+		expect(result[0]?.id).toBe("BUxuV42l6oolZVde");
+	});
+});

--- a/supabase/functions/compute-rankings/index.ts
+++ b/supabase/functions/compute-rankings/index.ts
@@ -70,7 +70,7 @@ type SupabaseAnyClient = SupabaseClient<any, 'public', any>;
 // =============================================================================
 
 const WEEKLY_METRICS = [
-  { metric: 'total_volume_kg', label: 'Total Volume (kg)' },
+  { metric: 'total_volume_kg', label: 'Total Volume' },
   { metric: 'total_workouts', label: 'Workouts Completed' },
   { metric: 'pr_count', label: 'Phase-Aware Personal Records' },
   { metric: 'current_streak', label: 'Current Streak' },

--- a/supabase/functions/generate-insights/index.ts
+++ b/supabase/functions/generate-insights/index.ts
@@ -57,8 +57,13 @@ function formatWeight(valueKg: number, unit: WeightUnit): string {
 
 function formatVolume(valueKg: number, unit: WeightUnit): string {
   const converted = convertWeight(valueKg, unit);
-  if (converted >= 1000) {
-    return `${(converted / 1000).toFixed(1)}K ${unit}`;
+  const absValue = Math.abs(converted);
+
+  if (absValue >= 1_000_000) {
+    return `${(converted / 1_000_000).toFixed(1)}M ${unit}`;
+  }
+  if (absValue >= 1_000) {
+    return `${(converted / 1_000).toFixed(1)}K ${unit}`;
   }
   return unit === 'lbs'
     ? `${converted.toFixed(1)} lbs`

--- a/supabase/functions/generate-insights/index.ts
+++ b/supabase/functions/generate-insights/index.ts
@@ -24,6 +24,7 @@ interface InsightInput {
   recentPRs: Array<{
     exercise: string;
     displayName: string;
+    recordType: string | null;
     value: number;
     previousValue?: number;
   }>;
@@ -34,6 +35,40 @@ interface InsightInput {
 // ── Insight rule engine (duplicate of src/lib/insights.ts) ───────────────────
 
 const STREAK_MILESTONES = [7, 14, 21, 30];
+const KG_TO_LBS = 2.20462;
+const WEIGHT_MULTIPLIER = 2;
+
+type WeightUnit = 'kg' | 'lbs';
+
+function normalizeWeightUnit(unit: unknown): WeightUnit {
+  return unit === 'lbs' ? 'lbs' : 'kg';
+}
+
+function convertWeight(valueKg: number, unit: WeightUnit): number {
+  return unit === 'lbs' ? valueKg * KG_TO_LBS : valueKg;
+}
+
+function formatWeight(valueKg: number, unit: WeightUnit): string {
+  const converted = convertWeight(valueKg, unit);
+  return unit === 'lbs'
+    ? `${converted.toFixed(1)} lbs`
+    : `${Math.round(converted)} kg`;
+}
+
+function formatVolume(valueKg: number, unit: WeightUnit): string {
+  const converted = convertWeight(valueKg, unit);
+  if (converted >= 1000) {
+    return `${(converted / 1000).toFixed(1)}K ${unit}`;
+  }
+  return unit === 'lbs'
+    ? `${converted.toFixed(1)} lbs`
+    : `${Math.round(converted)} kg`;
+}
+
+function roundWeightMetric(valueKg: number, unit: WeightUnit): number {
+  const converted = convertWeight(valueKg, unit);
+  return Number(converted.toFixed(unit === 'lbs' ? 1 : 0));
+}
 
 function formatWorkoutPhase(phase: string | null | undefined): string {
   switch ((phase ?? 'COMBINED').toUpperCase()) {
@@ -71,7 +106,10 @@ function formatPersonalRecordName(
     : `${exercise} ${formattedPhase} ${formattedType}`;
 }
 
-function generateInsights(input: InsightInput): TrainingInsight[] {
+function generateInsights(
+  input: InsightInput,
+  unit: WeightUnit = 'kg'
+): TrainingInsight[] {
   const insights: TrainingInsight[] = [];
 
   // ── Volume Trend ────────────────────────────────────────────────────────────
@@ -165,19 +203,33 @@ function generateInsights(input: InsightInput): TrainingInsight[] {
   for (const pr of input.recentPRs) {
     const delta =
       pr.previousValue !== undefined ? pr.value - pr.previousValue : undefined;
+    const isVolumeRecord = (pr.recordType ?? '').toUpperCase() === 'MAX_VOLUME';
+    const formattedValue = isVolumeRecord
+      ? formatVolume(pr.value, unit)
+      : formatWeight(pr.value, unit);
+    const formattedDelta = delta !== undefined
+      ? isVolumeRecord
+        ? formatVolume(delta, unit)
+        : formatWeight(delta, unit)
+      : undefined;
+    const formattedPrevious = pr.previousValue !== undefined
+      ? isVolumeRecord
+        ? formatVolume(pr.previousValue, unit)
+        : formatWeight(pr.previousValue, unit)
+      : undefined;
     insights.push({
       id: `pr-${pr.displayName.toLowerCase().replace(/\s+/g, '-')}`,
       type: 'achievement',
       title: `New PR: ${pr.displayName}`,
       description:
-        delta !== undefined
-          ? `You set a personal record on ${pr.displayName} — ${pr.value} lbs (up ${delta} lbs from ${pr.previousValue} lbs).`
-          : `You set a personal record on ${pr.displayName} — ${pr.value} lbs.`,
+        delta !== undefined && formattedDelta && formattedPrevious
+          ? `You set a personal record on ${pr.displayName} — ${formattedValue} (up ${formattedDelta} from ${formattedPrevious}).`
+          : `You set a personal record on ${pr.displayName} — ${formattedValue}.`,
       metric: {
         name: pr.displayName,
-        value: pr.value,
-        unit: 'lbs',
-        delta,
+        value: roundWeightMetric(pr.value, unit),
+        unit,
+        delta: delta !== undefined ? roundWeightMetric(delta, unit) : undefined,
       },
     });
   }
@@ -326,6 +378,18 @@ Deno.serve(async (req) => {
     const currentStart = new Date(now.getTime() - periodDays * 86400_000);
     const previousStart = new Date(currentStart.getTime() - periodDays * 86400_000);
 
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('weight_unit')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (profileError) {
+      console.warn('Failed to fetch profile weight unit; defaulting to kg:', profileError);
+    }
+
+    const weightUnit = normalizeWeightUnit(profile?.weight_unit);
+
     // ── 1. Fetch workout sessions (current + previous period) ─────────────────
     const { data: allSessions, error: sessionsError } = await supabaseAdmin
       .from('workout_sessions')
@@ -405,8 +469,12 @@ Deno.serve(async (req) => {
         r.record_type,
         r.workout_phase
       ),
-      value: r.value,
-      previousValue: r.previous_value ?? undefined,
+      recordType: r.record_type,
+      value: r.value * WEIGHT_MULTIPLIER,
+      previousValue:
+        r.previous_value !== null && r.previous_value !== undefined
+          ? r.previous_value * WEIGHT_MULTIPLIER
+          : undefined,
     }));
 
     // ── 4. Plateau detection (exercise_progress: 1RM flat for 3+ weeks) ───────
@@ -535,7 +603,7 @@ Deno.serve(async (req) => {
       trainingLoadScore,
     };
 
-    const insights = generateInsights(insightInput);
+    const insights = generateInsights(insightInput, weightUnit);
 
     // ── 8. Persist: delete old, insert new ────────────────────────────────────
     const { error: deleteError } = await supabaseAdmin


### PR DESCRIPTION
## Summary
- Added a shared preferred-weight-unit hook and formatting helpers so authenticated UI can render kg or lbs consistently
- Updated leaderboard, goals, challenges, analytics, comparison, biomech, community previews, cycle builder, and routine builder surfaces to display weight values in the user’s preferred unit
- Normalized insight generation and render-time metric mapping so stored and generated PR text no longer hard-codes pounds
- Kept persisted values canonical in kg and preserved provider/import-export unit handling

## Testing
- Added and updated unit coverage for conversion, formatting, round trips, and insight text/metric rendering
- Added UI regression coverage for community routine previews and insight feed metric display
- Verified with the project’s unit test suite and Playwright UI tests