### PR TITLE
feat(1rm): display velocity-estimated 1RM distinctly from rep-based estimate (#517)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,13 +215,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -240,21 +240,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -271,14 +271,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -301,14 +301,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -375,9 +375,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -399,29 +399,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -524,9 +524,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -549,27 +549,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1723,33 +1723,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1757,14 +1757,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2184,9 +2184,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2201,9 +2201,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -2218,9 +2218,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -2320,9 +2320,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -2337,9 +2337,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -2354,9 +2354,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -2371,9 +2371,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -2388,9 +2388,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2422,9 +2422,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2439,9 +2439,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -2456,9 +2456,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -2507,9 +2507,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2524,9 +2524,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -2541,9 +2541,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -2558,9 +2558,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -2575,9 +2575,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -2592,9 +2592,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -2609,9 +2609,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -8271,9 +8271,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8284,32 +8284,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -12234,9 +12234,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12465,13 +12465,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/src/app/components/ExerciseProgress.tsx
+++ b/src/app/components/ExerciseProgress.tsx
@@ -278,7 +278,11 @@ export function ExerciseProgress({
 	const velocity1RM = useMemo(() => {
 		for (let i = filteredData.length - 1; i >= 0; i--) {
 			const v = filteredData[i].velocity_estimated_1rm_kg;
-			if (v != null) return convertWeight(v, unit);
+			if (v != null) {
+				// Round to 1 decimal to match the rep-based stat (computeTrend rounds
+				// current the same way); avoids long lbs decimal trails.
+				return Math.round(convertWeight(v, unit) * 10) / 10;
+			}
 		}
 		return null;
 	}, [filteredData, unit]);

--- a/src/app/components/ExerciseProgress.tsx
+++ b/src/app/components/ExerciseProgress.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Minus, TrendingDown, TrendingUp } from "lucide-react";
+import { Info, Minus, TrendingDown, TrendingUp } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -22,6 +22,12 @@ import {
 } from "@/app/components/ui/select";
 import { Skeleton } from "@/app/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/app/components/ui/tabs";
+import {
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+	Tooltip as UiTooltip,
+} from "@/app/components/ui/tooltip";
 import { estimateOneRepMax } from "@/lib/biomechanics";
 import { PHOENIX } from "@/lib/colors";
 import { convertWeight, getUnitLabel } from "@/lib/units";
@@ -91,20 +97,76 @@ function DirectionIcon({ direction }: { direction: "up" | "down" | "flat" }) {
 	return <Minus className="w-4 h-4 text-muted-foreground" />;
 }
 
+// Distinct hue for the velocity (VBT) estimate so it never reads as the same
+// metric as the green rep-based estimate.
+const VELOCITY_COLOR = "#8B7CF6";
+
+const VELOCITY_HELP =
+	"Velocity-based (VBT) estimate from cable speed (mean concentric velocity) captured by the trainer — distinct from the rep-based formula estimate.";
+
+/** Small info icon with a hover/focus tooltip. Reuses the shared Radix tooltip. */
+function InfoTooltip({ text }: { text: string }) {
+	return (
+		<TooltipProvider delayDuration={150}>
+			<UiTooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="More info"
+						className="text-muted-foreground hover:text-white focus:outline-none"
+					>
+						<Info className="w-3.5 h-3.5" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-xs text-xs">{text}</TooltipContent>
+			</UiTooltip>
+		</TooltipProvider>
+	);
+}
+
+/**
+ * Current-value stat for the velocity-based (VBT) 1RM. Rendered only when a
+ * value is present, visually distinct from the rep-based estimate.
+ */
+function VelocityStatCard({ value, unit }: { value: number; unit: string }) {
+	return (
+		<Card className="p-4 bg-surface-2 border-secondary">
+			<div className="flex items-center gap-1 mb-1">
+				<span className="text-sm text-muted-foreground">
+					Velocity 1RM (VBT)
+				</span>
+				<InfoTooltip text={VELOCITY_HELP} />
+			</div>
+			<div
+				className="text-4xl font-bold tabular-nums"
+				style={{ color: VELOCITY_COLOR }}
+			>
+				{value} {unit}
+			</div>
+			<div className="mt-2 text-xs text-muted-foreground">Latest estimate</div>
+		</Card>
+	);
+}
+
 function StatCard({
 	label,
 	stat,
 	color,
 	unit,
+	info,
 }: {
 	label: string;
 	stat: TrendStat;
 	color: string;
 	unit: string;
+	info?: string;
 }) {
 	return (
 		<Card className="p-4 bg-surface-2 border-secondary">
-			<div className="text-sm text-muted-foreground mb-1">{label}</div>
+			<div className="flex items-center gap-1 mb-1">
+				<span className="text-sm text-muted-foreground">{label}</span>
+				{info && <InfoTooltip text={info} />}
+			</div>
 			<div className="text-4xl font-bold tabular-nums" style={{ color }}>
 				{stat.current} {unit}
 			</div>
@@ -209,6 +271,18 @@ export function ExerciseProgress({
 		[chartData],
 	);
 
+	// Velocity-based (VBT) 1RM is a rolling CURRENT value (not as-of-session), so
+	// we surface the most-recent non-null reading as a single current-value stat
+	// rather than a trend series. Hidden entirely when there is no VBT data.
+	// Already x2 (per-cable → total) via the schema; convertWeight only does kg↔lbs.
+	const velocity1RM = useMemo(() => {
+		for (let i = filteredData.length - 1; i >= 0; i--) {
+			const v = filteredData[i].velocity_estimated_1rm_kg;
+			if (v != null) return convertWeight(v, unit);
+		}
+		return null;
+	}, [filteredData, unit]);
+
 	if (exercisesPending) {
 		return (
 			<div className="space-y-6">
@@ -290,7 +364,9 @@ export function ExerciseProgress({
 				<>
 					{/* Summary stats */}
 					<motion.div
-						className="grid grid-cols-1 sm:grid-cols-3 gap-4"
+						className={`grid grid-cols-1 sm:grid-cols-3 gap-4${
+							velocity1RM != null ? " lg:grid-cols-4" : ""
+						}`}
 						initial={{ opacity: 0, y: 10 }}
 						animate={{ opacity: 1, y: 0 }}
 					>
@@ -307,11 +383,15 @@ export function ExerciseProgress({
 							unit={getUnitLabel(unit)}
 						/>
 						<StatCard
-							label="Overall Est. 1RM"
+							label="Rep-based 1RM (formula)"
 							stat={oneRmTrend}
 							color={PHOENIX.forgeGreen}
 							unit={getUnitLabel(unit)}
+							info="Estimated from weight × reps via a formula (Brzycki / Epley)."
 						/>
+						{velocity1RM != null && (
+							<VelocityStatCard value={velocity1RM} unit={getUnitLabel(unit)} />
+						)}
 					</motion.div>
 
 					{/* Three trend chart panels */}

--- a/src/app/components/analytics/ExerciseDeepDive.tsx
+++ b/src/app/components/analytics/ExerciseDeepDive.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { Info } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
 	Area,
@@ -9,6 +10,12 @@ import {
 	YAxis,
 } from "recharts";
 import { Card } from "@/app/components/ui/card";
+import {
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+	Tooltip as UiTooltip,
+} from "@/app/components/ui/tooltip";
 import { getExerciseProfile } from "@/lib/exercise-muscles";
 import { convertWeight, formatWeight, type WeightUnit } from "@/lib/units";
 import { formatWorkoutPhase, WORKOUT_PHASES } from "@/lib/workout-phases";
@@ -73,18 +80,50 @@ function computeDelta(values: number[]): number | null {
 // Sub-components
 // ---------------------------------------------------------------------------
 
+// Velocity (VBT) accent + help copy, kept distinct from the rep-based estimate.
+const VELOCITY_VALUE_CLASS = "text-[#8B7CF6]";
+const REP_BASED_HELP =
+	"Estimated from weight × reps via a formula (Brzycki / Epley).";
+const VELOCITY_HELP =
+	"Velocity-based (VBT) estimate from cable speed (mean concentric velocity) captured by the trainer — distinct from the rep-based formula estimate.";
+
+/** Small info icon with a hover/focus tooltip. Reuses the shared Radix tooltip. */
+function InfoTooltip({ text }: { text: string }) {
+	return (
+		<TooltipProvider delayDuration={150}>
+			<UiTooltip>
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label="More info"
+						className="text-muted-foreground hover:text-white focus:outline-none"
+					>
+						<Info className="w-3 h-3" />
+					</button>
+				</TooltipTrigger>
+				<TooltipContent className="max-w-xs text-xs">{text}</TooltipContent>
+			</UiTooltip>
+		</TooltipProvider>
+	);
+}
+
 function StatCard({
 	label,
 	value,
 	valueClass,
+	info,
 }: {
 	label: string;
 	value: string | number;
 	valueClass?: string;
+	info?: string;
 }) {
 	return (
 		<div className="bg-surface-2 rounded-lg p-3 flex flex-col gap-1">
-			<span className="text-[11px] text-muted-foreground">{label}</span>
+			<span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+				{label}
+				{info && <InfoTooltip text={info} />}
+			</span>
 			<span
 				className={`text-sm font-semibold tabular-nums ${valueClass ?? "text-white"}`}
 			>
@@ -148,6 +187,16 @@ export function ExerciseDeepDive({
 		filteredProgress.length > 0
 			? filteredProgress[filteredProgress.length - 1].estimated_1rm_kg
 			: null;
+
+	// Velocity-based (VBT) 1RM: most-recent non-null reading (rolling current
+	// value, not a trend). Null when this exercise has no VBT history → hidden.
+	const currentVelocity1RM = useMemo(() => {
+		for (let i = filteredProgress.length - 1; i >= 0; i--) {
+			const v = filteredProgress[i].velocity_estimated_1rm_kg;
+			if (v != null) return v;
+		}
+		return null;
+	}, [filteredProgress]);
 
 	const prsByPhaseInPeriod = useMemo(() => {
 		const counts = new Map(WORKOUT_PHASES.map((phase) => [phase, 0]));
@@ -394,13 +443,27 @@ export function ExerciseDeepDive({
 					</div>
 
 					{/* Stats Row */}
-					<div className="grid grid-cols-4 gap-2" data-testid="stats-row">
+					<div
+						className={`grid gap-2 ${
+							currentVelocity1RM != null ? "grid-cols-5" : "grid-cols-4"
+						}`}
+						data-testid="stats-row"
+					>
 						<StatCard
-							label="Current 1RM"
+							label="Rep-based 1RM"
 							value={
 								currentOneRM != null ? formatWeight(currentOneRM, unit) : "—"
 							}
+							info={REP_BASED_HELP}
 						/>
+						{currentVelocity1RM != null && (
+							<StatCard
+								label="Velocity 1RM (VBT)"
+								value={formatWeight(currentVelocity1RM, unit)}
+								valueClass={VELOCITY_VALUE_CLASS}
+								info={VELOCITY_HELP}
+							/>
+						)}
 						<StatCard
 							label="Period Change"
 							value={delta !== null ? `${delta > 0 ? "+" : ""}${delta}%` : "—"}

--- a/src/lib/__tests__/sync-exercise-progress.test.ts
+++ b/src/lib/__tests__/sync-exercise-progress.test.ts
@@ -56,6 +56,39 @@ describe("buildExerciseProgressRows", () => {
 		expect(rows[0].estimated_1rm_kg).toBe(67.5);
 	});
 
+	it("carries velocity_estimated_1rm_kg verbatim and null when absent", () => {
+		const rows = buildExerciseProgressRows(
+			[
+				{
+					id: "s1",
+					startedAt: "2026-06-27T00:00:00.000Z",
+					exercises: [
+						{
+							name: "Bench",
+							exerciseId: "ex1",
+							estimatedOneRepMaxKg: 100,
+							velocityEstimatedOneRepMaxKg: 92,
+							sets: [{ weightKg: 80, actualReps: 5 }],
+						},
+						{
+							name: "Row",
+							exerciseId: "ex2",
+							estimatedOneRepMaxKg: 90,
+							// no velocity estimate
+							sets: [{ weightKg: 60, actualReps: 5 }],
+						},
+					],
+				},
+			],
+			USER_ID,
+			"default",
+		);
+		expect(rows[0].velocity_estimated_1rm_kg).toBe(92);
+		expect(rows[1].velocity_estimated_1rm_kg).toBeNull();
+		// Rep-based estimate is untouched by the velocity field.
+		expect(rows[0].estimated_1rm_kg).toBe(100);
+	});
+
 	it("skips exercises with no sets", () => {
 		const rows = buildExerciseProgressRows(
 			[

--- a/src/lib/__tests__/sync-push-schema.test.ts
+++ b/src/lib/__tests__/sync-push-schema.test.ts
@@ -595,6 +595,59 @@ describe("pushPayloadSchema", () => {
 		);
 	});
 
+	it("parses velocityEstimatedOneRepMaxKg distinctly from the rep-based estimate", () => {
+		const parsed = pushPayloadSchema.parse({
+			deviceId: "dev-1",
+			platform: "android",
+			sessions: [
+				{
+					id: "11111111-1111-1111-1111-111111111111",
+					userId: "u1",
+					startedAt: "2026-04-20T12:00:00.000Z",
+					exercises: [
+						{
+							id: "22222222-2222-2222-2222-222222222222",
+							sessionId: "11111111-1111-1111-1111-111111111111",
+							name: "Squat",
+							estimatedOneRepMaxKg: 133.33,
+							velocityEstimatedOneRepMaxKg: 142.5,
+							sets: [],
+						},
+					],
+				},
+			],
+		});
+		const exercise = parsed.sessions[0].exercises[0];
+		expect(exercise.velocityEstimatedOneRepMaxKg).toBeCloseTo(142.5);
+		// Rep-based estimate is preserved independently.
+		expect(exercise.estimatedOneRepMaxKg).toBeCloseTo(133.33);
+	});
+
+	it("leaves velocityEstimatedOneRepMaxKg undefined when the field is absent (builder coalesces to null)", () => {
+		const parsed = pushPayloadSchema.parse({
+			deviceId: "dev-1",
+			platform: "android",
+			sessions: [
+				{
+					id: "11111111-1111-1111-1111-111111111111",
+					userId: "u1",
+					startedAt: "2026-04-20T12:00:00.000Z",
+					exercises: [
+						{
+							id: "22222222-2222-2222-2222-222222222222",
+							sessionId: "11111111-1111-1111-1111-111111111111",
+							name: "Squat",
+							sets: [],
+						},
+					],
+				},
+			],
+		});
+		expect(
+			parsed.sessions[0].exercises[0].velocityEstimatedOneRepMaxKg,
+		).toBeUndefined();
+	});
+
 	it("reports routines that claim exercises but omit the routine exercise projection", () => {
 		const routineId = "77777777-7777-4777-8777-777777777777";
 		const parsed = pushPayloadSchema.parse({

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -368,6 +368,7 @@ export type Database = {
 					set_count: number;
 					total_volume_kg: number;
 					user_id: string;
+					velocity_estimated_1rm_kg: number | null;
 				};
 				Insert: {
 					estimated_1rm_kg?: number;
@@ -381,6 +382,7 @@ export type Database = {
 					set_count?: number;
 					total_volume_kg?: number;
 					user_id: string;
+					velocity_estimated_1rm_kg?: number | null;
 				};
 				Update: {
 					estimated_1rm_kg?: number;
@@ -394,6 +396,7 @@ export type Database = {
 					set_count?: number;
 					total_volume_kg?: number;
 					user_id?: string;
+					velocity_estimated_1rm_kg?: number | null;
 				};
 				Relationships: [
 					{

--- a/src/schemas/telemetry.ts
+++ b/src/schemas/telemetry.ts
@@ -6,6 +6,17 @@ const weightTransform = z
 	.number()
 	.transform((perCable) => perCable * WEIGHT_MULTIPLIER);
 
+// Nullable per-cable weight: applies the same x2 display multiplier, but
+// preserves null/absent (legacy rows with no velocity-based 1RM) as null so the
+// UI can hide the metric entirely.
+const nullableWeightTransform = z
+	.number()
+	.nullable()
+	.optional()
+	.transform((perCable) =>
+		perCable == null ? null : perCable * WEIGHT_MULTIPLIER,
+	);
+
 // --- Telemetry Point ---
 
 // Cable canonical wire format: "A" | "B" (BLE convention, mobile authoritative).
@@ -54,6 +65,9 @@ export const exerciseProgressSchema = z.object({
 	max_weight_kg: weightTransform,
 	total_volume_kg: weightTransform,
 	estimated_1rm_kg: weightTransform,
+	// Velocity-based (VBT) 1RM — distinct from the rep-based estimated_1rm_kg.
+	// Nullable; null when the row predates VBT capture. Issue #517 Phase 6.
+	velocity_estimated_1rm_kg: nullableWeightTransform,
 	max_reps: z.number(),
 	set_count: z.number(),
 });

--- a/supabase/functions/_shared/exerciseProgressRows.ts
+++ b/supabase/functions/_shared/exerciseProgressRows.ts
@@ -19,6 +19,13 @@ export interface ProgressExerciseInput {
 	name: string;
 	exerciseId?: string | null;
 	estimatedOneRepMaxKg?: number | null;
+	/**
+	 * Velocity-based (VBT) estimated 1RM (per-cable kg), computed on-device by the
+	 * mobile app from BLE mean concentric velocity. SEPARATE from the rep-based
+	 * estimatedOneRepMaxKg; stored verbatim (no recompute, no fallback) and null
+	 * when absent. Issue #517 Phase 6.
+	 */
+	velocityEstimatedOneRepMaxKg?: number | null;
 	sets: ProgressSetInput[];
 }
 
@@ -38,6 +45,7 @@ export interface ExerciseProgressRow {
 	max_weight_kg: number;
 	total_volume_kg: number;
 	estimated_1rm_kg: number;
+	velocity_estimated_1rm_kg: number | null;
 	max_reps: number;
 	set_count: number;
 }
@@ -92,6 +100,10 @@ export function buildExerciseProgressRows(
 				max_weight_kg: maxWeight,
 				total_volume_kg: totalVolume,
 				estimated_1rm_kg: Math.round(estimated1rm * 100) / 100,
+				// Velocity-based estimate stored verbatim — never recomputed, no
+				// fallback. Null when the mobile payload omits it (legacy / no
+				// passing VBT estimate). Distinct from estimated_1rm_kg above.
+				velocity_estimated_1rm_kg: exercise.velocityEstimatedOneRepMaxKg ?? null,
 				max_reps: maxReps,
 				set_count: setCount,
 			});

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -131,6 +131,10 @@ const exerciseSchema = z.object({
 	// Mobile-provided canonical estimated 1RM (per-cable kg). Optional for
 	// backward compat; absent → server recomputes (see exerciseProgressRows).
 	estimatedOneRepMaxKg: nullableField(z.number()),
+	// Velocity-based (VBT) estimated 1RM (per-cable kg). Brand-new, optional,
+	// stored verbatim alongside estimatedOneRepMaxKg (never recomputed). Absent
+	// on legacy payloads → null column. Issue #517 Phase 6.
+	velocityEstimatedOneRepMaxKg: nullableField(z.number()),
 	sets: arrayOf(setSchema).default([]),
 });
 

--- a/supabase/migrations/20260627000000_add_velocity_estimated_1rm_kg.sql
+++ b/supabase/migrations/20260627000000_add_velocity_estimated_1rm_kg.sql
@@ -1,0 +1,10 @@
+-- Issue #517 Phase 6: velocity-based (VBT) estimated 1RM display.
+--
+-- Add a brand-new, nullable, additive column alongside the existing rep-based
+-- estimated_1rm_kg. The mobile app is authoritative for this value (computed
+-- on-device from BLE mean concentric velocity); the portal stores it verbatim
+-- and never recomputes. Per-cable kg, like estimated_1rm_kg (portal applies the
+-- x2 display multiplier in the UI). Legacy rows/payloads without it stay NULL
+-- and simply show no velocity metric — estimated_1rm_kg is never touched.
+ALTER TABLE public.exercise_progress
+  ADD COLUMN IF NOT EXISTS velocity_estimated_1rm_kg numeric;


### PR DESCRIPTION
## Phase 6 (portal half) — velocity-1RM display

Portal side of the cross-repo Phase 6 work for #517. Stores the mobile-computed velocity-based (VBT) 1RM and surfaces it as a metric **clearly distinct** from the existing rep-based (Brzycki/Epley) estimate, so users never conflate the two. Display/analytics only — **no** routine-weight changes.

> Companion mobile PR: 9thLevelSoftware/Project-Phoenix-MP#599 (ships `velocityEstimatedOneRepMaxKg` on the exercise sync DTO).

### What changed
- **Migration** `20260627000000_add_velocity_estimated_1rm_kg.sql` — nullable, additive `exercise_progress.velocity_estimated_1rm_kg`. Never touches `estimated_1rm_kg`.
- **Push path** (`pushPayloadSchema` + `exerciseProgressRows` builder) carries `velocityEstimatedOneRepMaxKg` verbatim into the new column — no recompute, no fallback, null when absent. The existing `exercise_progress` insert ships the full row, so the column flows automatically. (`mobile-sync-pull` does not return `exercise_progress`, so there's no pull echo.)
- **Schema** (`telemetry.ts`) parses the column via a null-safe ×2 transform (mirrors `estimated_1rm_kg` per-cable→display).
- **UI** (`ExerciseProgress`, `ExerciseDeepDive`): relabel the rep-based stat to "Rep-based 1RM (formula)" and add a distinct violet **"Velocity 1RM (VBT)"** current-value stat (hidden when null), with tooltips explaining rep-based vs velocity-based.
- No velocity **trend series** — `exercise_progress` is per-session but the velocity value is a rolling current value, so it's shown as a current-value stat only (deferred per design).

### ⚠️ Ops steps required before this is live
1. **Apply the migration**, then run `npm run gen:types` to regenerate `database.types.ts` canonically (it's hand-edited here so typecheck passes pre-apply).
2. **Deploy** `mobile-sync-push` (consumes the `_shared` schema/builder changes).

### Verification
- `npm test` — 1299 passed / 16 skipped.
- `npm run typecheck` — clean. `npx biome check` — clean.

### Out of scope (separate spec)
Scaling-basis parity (portal routine builder resolving `% of estimated-1RM`) — parity-critical weight math, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)