### PR TITLE
fix(ci): add prod migration drift detector for issue #602

### DIFF
--- a/.github/workflows/prod-migration-drift.yml
+++ b/.github/workflows/prod-migration-drift.yml
@@ -1,0 +1,197 @@
+name: Prod Migration Drift
+
+# Detects the migration-drift class documented in:
+#   - CLAUDE.md -> "Migration Workflow Discipline" -> "CI coverage"
+#   - .phoenix-review/ci-cd-&-workflows.md -> Finding 4
+#   - Project Phoenix RCA for mobile cloud-sync issue #602 (cross-repo link:
+#     9thLevelSoftware/Project-Phoenix-MP#602)
+#
+# Background: the existing `.github/workflows/migrations.yml` clean-applies
+# every migration into a fresh local stack on PRs, but it intentionally does
+# not compare against the live production project. Migration
+# `20260627000000_add_velocity_estimated_1rm_kg.sql` shipped in `phoenix-portal`
+# main without ever being pushed to live Supabase, while the matching
+# `mobile-sync-push` Edge Function was redeployed afterwards. Live PostgREST
+# then rejected inserts with:
+#   Could not find the 'velocity_estimated_1rm_kg' column of 'exercise_progress'
+#   in the schema cache
+#
+# Scope and limits of THIS workflow (please read before merging):
+#   - This is a *detector* only. It does NOT gate or block the Edge Function
+#     deploy path. `.github/workflows/deploy-edge-functions.yml` continues to
+#     deploy independently of this workflow's result.
+#   - It runs on a daily schedule, on `workflow_dispatch`, and on `main` push
+#     only when this very file changes. It does NOT run on PRs (PR-side forks
+#     cannot reach the prod secrets required by `supabase migration list --linked`).
+#   - When it detects drift, it fails its own run and emits remediation steps.
+#     The drift is informational until a human operator pushes the missing
+#     migration via `supabase db push` (or equivalent). The user-visible
+#     issue #602 stays open until that operational push completes and the
+#     reporter path is verified.
+#   - This PR adds the detector only; it does NOT itself fix or close the
+#     live Supabase schema/cache state that drives the mobile sync error.
+#
+# Required repository secrets (production read-only from this job's POV):
+#   - SUPABASE_ACCESS_TOKEN      Personal access token from
+#                                https://supabase.com/dashboard/account/tokens
+#   - SUPABASE_PROD_PROJECT_REF  Project ref of the prod Supabase project
+#                                (the 20-char string in the dashboard URL)
+#   - SUPABASE_PROD_DB_PASSWORD  Database password for the prod project
+#                                (used only by `supabase migration list --linked`;
+#                                the CLI uses it transiently and does not write
+#                                it back to the project)
+
+on:
+  # Daily at 06:17 UTC so drift alerts surface ahead of any user-visible
+  # breakage window.
+  schedule:
+    - cron: "17 6 * * *"
+  # Manual run only. This job needs production Supabase credentials that
+  # should never be exposed to PR-side forks, so we deliberately do NOT
+  # run on pull_request.
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/prod-migration-drift.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-migration-drift-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  drift-check:
+    name: Detect unapplied migrations in prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: production
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        with:
+          version: 2.76.9
+
+      - name: Validate required secrets
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROD_PROJECT_REF: ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
+          SUPABASE_PROD_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DB_PASSWORD }}
+        run: |
+          missing=""
+          [ -z "$SUPABASE_ACCESS_TOKEN" ] && missing="$missing SUPABASE_ACCESS_TOKEN"
+          [ -z "$SUPABASE_PROD_PROJECT_REF" ] && missing="$missing SUPABASE_PROD_PROJECT_REF"
+          [ -z "$SUPABASE_PROD_DB_PASSWORD" ] && missing="$missing SUPABASE_PROD_DB_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required secrets:$missing. See the header comment in this workflow for provisioning steps."
+            exit 1
+          fi
+
+      - name: Link prod project (read-only)
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ secrets.SUPABASE_PROD_PROJECT_REF }}
+          DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DB_PASSWORD }}
+        run: |
+          # `supabase link` writes the project-ref + transient DB password to
+          # ~/.supabase/. The home dir is ephemeral on the runner, so this
+          # does not leak between jobs. Subsequent `migration list --linked`
+          # invocations reuse this link.
+          supabase link --project-ref "$PROJECT_REF" --password "$DB_PASSWORD"
+
+      - name: List local migrations
+        id: local
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          # `version` is the numeric prefix that
+          # `supabase/migrations/<version>_<name>.sql` uses. Emit just the
+          # version, one per line, sorted/unique. Matches
+          # `schema_migrations.version` exactly.
+          : > local_migrations.txt
+          for f in supabase/migrations/*.sql; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f")
+            version=$(echo "$base" | sed -E 's/^([0-9]+)_.*/\1/')
+            echo "$version" >> local_migrations.txt
+          done
+          sort -u -o local_migrations.txt local_migrations.txt
+          count=$(wc -l < local_migrations.txt | tr -d ' ')
+          echo "Local migration count: $count"
+          {
+            echo "versions<<EOF"
+            cat local_migrations.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: List prod-applied migrations
+        id: remote
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          # `--output-format json` is stable and avoids parsing the pretty
+          # table (whose layout differs across CLI versions). Each record
+          # carries a `version` field that matches the local file prefix.
+          #
+          # jq robustness: the CLI emits either a single JSON array
+          # (`json`) or one object per line (`stream-json` / NDJSON). The
+          # previous expression `'.[]? | select(.version != null) | .version'`
+          # errored on the object-input shape because `.[]?` does not iterate
+          # scalars. This filter normalizes either shape to an iterator over
+          # objects, then drops entries without a `version` field.
+          : > remote_migrations.txt
+          set -o pipefail
+          supabase migration list --linked --output-format json 2>/dev/null \
+            | jq -r 'if type == "array" then .[] else . end | select(.version? != null) | .version' \
+            >> remote_migrations.txt || {
+              echo "::error::Failed to query remote migrations. Check SUPABASE_ACCESS_TOKEN, SUPABASE_PROD_PROJECT_REF, SUPABASE_PROD_DB_PASSWORD, and that the project is linked."
+              exit 1
+            }
+          sort -u -o remote_migrations.txt remote_migrations.txt
+          count=$(wc -l < remote_migrations.txt | tr -d ' ')
+          echo "Remote applied count: $count"
+          {
+            echo "applied<<EOF"
+            cat remote_migrations.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report unapplied migrations
+        env:
+          LOCAL: ${{ steps.local.outputs.versions }}
+          APPLIED: ${{ steps.remote.outputs.applied }}
+        run: |
+          # Treat the remote list as the source of truth. Any local version
+          # not in the remote list is unapplied to prod. Drift like
+          # `20260627000000_add_velocity_estimated_1rm_kg.sql` shows up here.
+          # NOTE: this is a detection/reporting step only. It does not block
+          # any deploy path; the Edge Function deploy workflow is independent.
+          : > local_sorted.txt
+          : > applied_sorted.txt
+          echo "$LOCAL" | sort -u > local_sorted.txt
+          echo "$APPLIED" | sort -u > applied_sorted.txt
+
+          unapplied=$(comm -23 local_sorted.txt applied_sorted.txt)
+          if [ -z "$unapplied" ]; then
+            echo "No drift: every local migration is applied to prod."
+            exit 0
+          fi
+
+          echo "::error::Drift detected. The following local migrations are NOT applied to prod:"
+          echo "$unapplied" | sed 's/^/  - /'
+          echo ""
+          echo "To remediate, run locally (after supabase link):"
+          echo "  supabase db push --include-all"
+          echo "Or apply a single migration non-interactively:"
+          echo "  psql \"\$DATABASE_URL\" -f supabase/migrations/<version>_*.sql"
+          echo "After applying, reload the PostgREST schema if clients still report cache errors:"
+          echo "  NOTIFY pgrst, 'reload schema';"
+          echo ""
+          echo "Reminder: this detector does not gate Edge Function deploys. Issue"
+          echo "9thLevelSoftware/Project-Phoenix-MP#602 stays open until the migration"
+          echo "is applied AND the reporter's Android Sync Now path is verified."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,4 +219,4 @@ Non-negotiable rules to prevent schema drift (as discovered 2026-04-20 when 5 mi
 
 ### CI coverage
 - `.github/workflows/migrations.yml` — clean-applies every migration into a fresh Supabase stack on any PR that touches `supabase/migrations/`. Fails on file-vs-applied count mismatch.
-- Follow-up not yet wired: a scheduled `supabase db diff --linked --schema public` that alerts on prod drift. Requires `SUPABASE_ACCESS_TOKEN` + DB password secrets.
+- `.github/workflows/prod-migration-drift.yml` — daily `supabase migration list --linked` drift detector against the prod Supabase project. Fails its own run (and emits a remediation recipe) when any local migration is not applied to prod. Required secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROD_PROJECT_REF`, `SUPABASE_PROD_DB_PASSWORD`. **Detector only — does not gate `.github/workflows/deploy-edge-functions.yml` or any other deploy path.** The drift class this would surface is the one demonstrated by `9thLevelSoftware/Project-Phoenix-MP#602`, but pushing the missing migration and verifying the reporter path are separate operational steps owned by the human operator with prod DB credentials.


### PR DESCRIPTION
## Summary

Add a daily production migration-drift **detector** to `phoenix-portal`
so the exact failure class that broke cloud sync for mobile v0.9.2
(Android) gets surfaced as a CI alert instead of escaping until a user
hits Sync Now. The new workflow runs `supabase migration list --linked`
against the linked prod Supabase project and fails its own run when any
local migration is not applied to prod.

> **Scope honesty (please read before merging).** This PR is a
> **detector only**. It does **not** gate or block the Edge Function
> deploy path; `.github/workflows/deploy-edge-functions.yml` deploys
> independently. It does **not** push the missing migration to live
> Supabase — that is an operational step owned by the human operator
> with prod DB credentials. Until that push + PostgREST schema reload
> happen, the reporter's Android v0.9.2 Settings > Phoenix Portal >
> Sync Now path will continue to fail with the same PostgREST
> schema-cache error, and `9thLevelSoftware/Project-Phoenix-MP#602`
> stays open. This PR is the hardening that would have made that drift
> visible earlier; it is **not** the user-visible fix.

## Why this PR

Mobile cloud sync issue
**[9thLevelSoftware/Project-Phoenix-MP#602](https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/602)**
fails with:

> Sync error: exercise_progress insert failed: Could not find the
> 'velocity_estimated_1rm_kg' column of 'exercise_progress' in the
> schema cache

GPT-5.5 RCA root cause: migration
`supabase/migrations/20260627000000_add_velocity_estimated_1rm_kg.sql`
shipped in `phoenix-portal` main but was never pushed to the live
Supabase project `ilzlswmatadlnsuxatcv`. The deployed `mobile-sync-push`
Edge Function (v118) was redeployed **after** the migration was
authored, so the deployed code expected a column the live DB did not
have. PostgREST rejected the insert with the schema-cache message
above.

This PR does **not** modify the mobile DTO, the Edge Function row
builder, or the migration file (they are all correct per RCA). It only
adds the release/deploy guard the RCA flags as optional hardening,
mirroring the pre-existing portal review finding documented in
`.phoenix-review/ci-cd-&-workflows.md` (Finding 4) and the
"Follow-up not yet wired" line in `CLAUDE.md` → "Migration Workflow
Discipline".

## What changed

- **NEW** `.github/workflows/prod-migration-drift.yml`
  - `schedule` (cron `17 6 * * *`) + `workflow_dispatch` + `push` to
    `main` on the workflow file itself.
  - Uses `supabase/setup-cli@v1.6.0` with version `2.76.9` (matches the
    versions already pinned by `migrations.yml` and
    `deploy-edge-functions.yml`).
  - Validates `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROD_PROJECT_REF`,
    `SUPABASE_PROD_DB_PASSWORD` are present (fails fast otherwise).
  - `supabase link --project-ref ... --password ...` to a transient
    runner-local config dir.
  - Lists local migrations from `supabase/migrations/*.sql` filenames
    (extracts `<version>` prefix).
  - Lists prod-applied migrations via
    `supabase migration list --linked --output-format json | jq -r 'if type == "array" then .[] else . end | select(.version? != null) | .version'`.
    The jq filter handles both array and NDJSON/stream-json shapes and
    tolerates records without a `version` field. The pipeline runs
    under `set -o pipefail` so a failing remote query fails the step
    rather than silently producing an empty remote list.
  - `comm -23 local_sorted.txt applied_sorted.txt` to surface
    unapplied versions and `exit 1` with a remediation recipe when
    any are found.
  - `permissions: contents: read`, `environment: production`,
    `timeout-minutes: 15`, `cancel-in-progress: false`. Deliberately
    **no `pull_request` trigger** so PR-side forks cannot exfiltrate
    prod credentials.
- **MODIFIED** `CLAUDE.md` (1 line under "CI coverage")
  - Replaced the "Follow-up not yet wired" bullet with a description
    of the new workflow, its required secrets, and an explicit
    note that it is a **detector only**, not a deploy gate.

## Required repository secrets

The new workflow requires three production-scoped secrets. Add them at
`Settings → Secrets and variables → Actions`:

| Secret | Purpose |
| --- | --- |
| `SUPABASE_ACCESS_TOKEN` | Personal access token from <https://supabase.com/dashboard/account/tokens>. Already used by `deploy-edge-functions.yml`. |
| `SUPABASE_PROD_PROJECT_REF` | 20-char project ref of the prod Supabase project (e.g. `ilzlswmatadlnsuxatcv`). Already used by `deploy-edge-functions.yml`. |
| `SUPABASE_PROD_DB_PASSWORD` | Database password for the prod project. Used transiently by `supabase migration list --linked`. |

Until these are provisioned, the workflow's "Validate required secrets"
step will fail-fast with a clear `::error::` listing the missing names.

## RCA acceptance criteria status

Mirrors the GPT-5.5 RCA acceptance criteria for issue #602:

- [ ] Live Supabase `public.exercise_progress` includes nullable
      numeric column `velocity_estimated_1rm_kg`. **(Operational; not
      satisfied by this PR — requires `supabase db push` of
      `20260627000000_add_velocity_estimated_1rm_kg.sql` to prod
      project `ilzlswmatadlnsuxatcv`.)**
- [ ] A live `mobile-sync-push` request that includes an exercise
      with `velocityEstimatedOneRepMaxKg` inserts/updates progress
      without `PGRST204` / schema-cache errors. **(Operational; not
      satisfied by this PR.)**
- [ ] Reporter path succeeds on Android v0.9.2 (Settings > Phoenix
      Portal > Sync Now / Force Full Resync). **(Operational; not
      satisfied by this PR.)**
- [x] Existing rep-based `exercise_progress.estimated_1rm_kg`
      remains unchanged and continues to store the hybrid
      Brzycki/Epley estimate separately from the velocity estimate.
      *(Not modified by this PR; covered by the existing row-builder
      parity tests once dependencies are installed.)*
- [x] Portal row-builder regression coverage
      (`src/lib/__tests__/sync-exercise-progress.test.ts`) remains
      green once dependencies are installed. *(No code change in this
      PR affects row-builder behavior.)*
- [ ] **Release/deploy workflow prevents Edge Function code that
      references new DB columns from going live before the matching
      Supabase migration is applied.** *(This workflow is a detector
      that surfaces drift; it does **not** gate
      `.github/workflows/deploy-edge-functions.yml`. Wiring the actual
      deploy gate into the Edge Function deploy path is intentionally
      out of scope for this hardening PR — see "Future work" below.)*

## Future work (intentionally NOT in this PR)

- Wire the drift signal into the actual Edge Function deploy path
  (`deploy-edge-functions.yml`) so a hard failure aborts deploy when
  the prod Supabase schema is behind the repo's local migrations.
  That is a deploy-gate change with separate blast radius and is left
  as a follow-up.

## Out of scope (per RCA non-goals)

- Do not change the mobile payload contract.
- Do not collapse `velocity_estimated_1rm_kg` into `estimated_1rm_kg`.
- Do not treat this as a reporter-account-specific bug.
- Do not push the missing migration to prod from CI — that is an
  operational step owned by the human operator with prod DB
  credentials.

## Verification done locally

- YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- Drift-detection logic verified end-to-end with four synthetic cases:
  - (A) original #602 drift: local includes `20260627000000`, prod does
    not → surfaces `20260627000000`.
  - (B) fully clean: every local migration applied → "No drift".
  - (C) prod has rows not in local → not flagged (remote is source of
    truth).
  - (D) multiple unapplied → all reported.
- New jq filter verified against four input shapes: JSON array, NDJSON,
  single object, and empty array. Old expression `'.[]? | select(.version != null) | .version'`
  errors on NDJSON with `Cannot index string with string "version"`
  (jq exit 5); new expression
  `'if type == "array" then .[] else . end | select(.version? != null) | .version'`
  returns the expected versions with exit 0 on every shape and
  tolerates records without a `version` field.
- `set -o pipefail` added before the `supabase migration list | jq`
  pipeline.

CI verification will happen on the PR-side: this workflow does **not**
run on PRs (see "What changed" above), but `migrations.yml` will run
and re-validate the migrations folder is self-consistent.

## Manual run

After the secrets are provisioned and this PR merges to `main`:

1. Go to <https://github.com/9thLevelSoftware/phoenix-portal/actions/workflows/prod-migration-drift.yml>
2. Click "Run workflow" on `main`.
3. Expect a red run **for now** because
   `20260627000000_add_velocity_estimated_1rm_kg.sql` is still unapplied
   to prod. The remediation recipe is printed in the run log.
4. After `supabase db push --include-all` (or equivalent migration push)
   is performed by the human operator, the next run will be green.

## Repair notes (2026-06-28, repair card t_a1b1e78e)

GPT-5.5 merge-gate review flagged PR #81 as green but unsafe to merge
as written because the body and commit used the GitHub closing-keyword
form `Fixes owner/repo#602` for `9thLevelSoftware/Project-Phoenix-MP`,
which would auto-close the still-operational mobile issue on merge even
though this PR does not perform the live migration push or verify the
reporter path. This repair:

- Replaces all `Fixes owner/repo#602` references to
  `9thLevelSoftware/Project-Phoenix-MP#602` (cross-repo closing-keyword
  form) in the PR body and commit message with the non-closing form
  `Refs 9thLevelSoftware/Project-Phoenix-MP#602`.
- Adds an explicit "Scope honesty" callout and rewrites the
  acceptance criteria section so the hardening-only nature of this PR
  is unambiguous: the live Supabase migration push and reporter-path
  verification are operational steps owned by the human operator, and
  issue #602 stays open until they complete.
- Adds explicit "detector only, not a deploy gate" language to the
  workflow header, the workflow's drift-reporting step, the CLAUDE.md
  bullet, and the PR body. Wording that previously implied the
  workflow prevents Edge Function deploys is removed.
- Fixes the `supabase migration list --linked | jq` filter and adds
  `set -o pipefail` so an empty / failing remote query can no longer
  become a misleading "no drift" success. (See "Verification done
  locally" for the four-shape jq test.)

## Related

- Issue: https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/602
- RCA comment: https://github.com/9thLevelSoftware/Project-Phoenix-MP/issues/602#issuecomment-4825422229
- Recreation artifact: `/Users/christopherwilloughby/.hermes/phoenix-bug-recreations/issue-602/bug-recreation.md`
- Portal review finding: `.phoenix-review/ci-cd-&-workflows.md` → Finding 4

Refs 9thLevelSoftware/Project-Phoenix-MP#602
