### PR TITLE
fix(sync): preserve training cycle template ids

### DIFF
--- a/src/lib/__tests__/sync-push-schema.test.ts
+++ b/src/lib/__tests__/sync-push-schema.test.ts
@@ -680,6 +680,32 @@ describe("pushPayloadSchema", () => {
 
 		expect(findPushPayloadIncompleteRoutines(parsed)).toEqual([routineId]);
 	});
+
+	it("preserves cycle templateId strings through validation", () => {
+		const parsed = pushPayloadSchema.parse({
+			deviceId: "d1",
+			platform: "android",
+			cycles: [
+				{
+					id: "12345678-1234-4234-8234-1234567890ab",
+					userId: "u1",
+					name: "Template Cycle",
+					templateId: "template_531",
+					days: [],
+				},
+				{
+					id: "22345678-1234-4234-8234-1234567890ab",
+					userId: "u1",
+					name: "Local Cycle",
+					templateId: null,
+					days: [],
+				},
+			],
+		});
+
+		expect(parsed.cycles[0]?.templateId).toBe("template_531");
+		expect(parsed.cycles[1]?.templateId).toBeNull();
+	});
 });
 
 describe("formatPushPayloadError", () => {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1710,6 +1710,7 @@ export type Database = {
 					rest_days: number;
 					started_at: string | null;
 					status: string;
+					template_id: string | null;
 					updated_at: string;
 					user_id: string;
 					workout_days: number;
@@ -1727,6 +1728,7 @@ export type Database = {
 					rest_days?: number;
 					started_at?: string | null;
 					status?: string;
+					template_id?: string | null;
 					updated_at?: string;
 					user_id: string;
 					workout_days?: number;
@@ -1744,6 +1746,7 @@ export type Database = {
 					rest_days?: number;
 					started_at?: string | null;
 					status?: string;
+					template_id?: string | null;
 					updated_at?: string;
 					user_id?: string;
 					workout_days?: number;
@@ -2301,6 +2304,7 @@ export type Database = {
 					p_cursor_id?: string;
 					p_cursor_updated_at?: string;
 					p_known_ids?: string[];
+					p_last_sync_at?: string;
 					p_limit?: number;
 					p_profile_id?: string;
 					p_user_id: string;
@@ -2318,6 +2322,7 @@ export type Database = {
 					rest_days: number;
 					started_at: string;
 					status: string;
+					template_id: string;
 					updated_at: string;
 					user_id: string;
 					workout_days: number;

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -2322,7 +2322,7 @@ export type Database = {
 					rest_days: number;
 					started_at: string;
 					status: string;
-					template_id: string;
+					template_id: string | null;
 					updated_at: string;
 					user_id: string;
 					workout_days: number;

--- a/src/schemas/__tests__/transforms.test.ts
+++ b/src/schemas/__tests__/transforms.test.ts
@@ -5,6 +5,7 @@ import {
 	personalRecordSchema,
 	routineExerciseSchema,
 	setSchema,
+	trainingCycleSchema,
 	workoutSessionSchema,
 } from "../transforms";
 
@@ -425,5 +426,27 @@ describe("gamificationStatsSchema weight handling", () => {
 		const result = gamificationStatsSchema.parse(validStats);
 		// Current behavior: no transform applied
 		expect(result.total_volume_kg).toBe(500000);
+	});
+});
+
+describe("trainingCycleSchema", () => {
+	it("preserves template_id so sync-loaded template cycles keep their identity", () => {
+		const result = trainingCycleSchema.parse({
+			id: UUID,
+			user_id: UUID2,
+			name: "Template Cycle",
+			description: null,
+			duration_weeks: 4,
+			current_week: 1,
+			status: "draft",
+			workout_days: 4,
+			rest_days: 3,
+			started_at: null,
+			last_used_at: null,
+			local_profile_id: null,
+			template_id: "template_531",
+		});
+
+		expect(result.template_id).toBe("template_531");
 	});
 });

--- a/src/schemas/transforms.ts
+++ b/src/schemas/transforms.ts
@@ -206,6 +206,7 @@ export const trainingCycleSchema = z.object({
 	started_at: nullableOptionalDate,
 	last_used_at: nullableDate,
 	local_profile_id: z.string().nullable().optional(),
+	template_id: z.string().nullable().optional(),
 });
 
 export const trainingCycleListSchema = z.array(trainingCycleSchema);

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -321,6 +321,7 @@ const cycleSchema = z.object({
 	updatedAt: nullableDatetime(),
 	progressionSettings: nullableField(z.string()),
 	deloadSettings: nullableField(z.string()),
+	templateId: nullableField(z.string()),
 	days: arrayOf(cycleDaySchema).default([]),
 });
 

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -901,6 +901,7 @@ Deno.serve(async (req) => {
           lastUsedAt: c.last_used_at,
           progressionSettings: c.progression_settings != null ? JSON.stringify(c.progression_settings) : null,
           deloadSettings: c.deload_settings != null ? JSON.stringify(c.deload_settings) : null,
+          templateId: c.template_id ?? null,
           days: cDays.map((d) => ({
             id: d.id,
             cycleId: d.cycle_id,

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -2096,18 +2096,22 @@ Deno.serve(async (req) => {
           .filter((row) => row.template_id == null)
           .map((row) => row.id);
         if (cycleIdsMissingTemplateId.length > 0) {
-          const { data: existingCycles, error: existingCyclesErr } = await supabase
-            .from('training_cycles')
-            .select('id, template_id')
-            .eq('user_id', userId)
-            .in('id', cycleIdsMissingTemplateId);
-          if (existingCyclesErr) {
-            throw new Error(`training_cycles template_id probe failed: ${existingCyclesErr.message}`);
-          }
           const existingTemplateIds = new Map<string, string>();
-          for (const row of existingCycles ?? []) {
-            if (typeof row.id === 'string' && typeof row.template_id === 'string') {
-              existingTemplateIds.set(row.id, row.template_id);
+          const chunkSize = 100;
+          for (let i = 0; i < cycleIdsMissingTemplateId.length; i += chunkSize) {
+            const chunk = cycleIdsMissingTemplateId.slice(i, i + chunkSize);
+            const { data: existingCycles, error: existingCyclesErr } = await supabase
+              .from('training_cycles')
+              .select('id, template_id')
+              .eq('user_id', userId)
+              .in('id', chunk);
+            if (existingCyclesErr) {
+              throw new Error(`training_cycles template_id probe failed: ${existingCyclesErr.message}`);
+            }
+            for (const row of existingCycles ?? []) {
+              if (typeof row.id === 'string' && typeof row.template_id === 'string') {
+                existingTemplateIds.set(row.id, row.template_id);
+              }
             }
           }
           for (const row of cycleRows) {

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -609,6 +609,7 @@ interface CycleDto {
   updatedAt?: string | null;
   progressionSettings: string | null;
   deloadSettings: string | null;
+  templateId?: string | null;
   days: CycleDayDto[];
 }
 
@@ -2059,6 +2060,7 @@ Deno.serve(async (req) => {
         last_used_at: c.lastUsedAt,
         progression_settings: safeJsonParse(c.progressionSettings),
         deload_settings: safeJsonParse(c.deloadSettings),
+        template_id: c.templateId ?? null,
         updated_at: c.updatedAt ?? null,
       }));
 
@@ -2088,6 +2090,33 @@ Deno.serve(async (req) => {
         }
         cyclesUpserted = acceptedCycleIds.size;
       } else {
+        // Legacy server-wins upsert still needs to preserve an existing
+        // template_id when older mobile builds omit or null the field.
+        const cycleIdsMissingTemplateId = cycleRows
+          .filter((row) => row.template_id == null)
+          .map((row) => row.id);
+        if (cycleIdsMissingTemplateId.length > 0) {
+          const { data: existingCycles, error: existingCyclesErr } = await supabase
+            .from('training_cycles')
+            .select('id, template_id')
+            .eq('user_id', userId)
+            .in('id', cycleIdsMissingTemplateId);
+          if (existingCyclesErr) {
+            throw new Error(`training_cycles template_id probe failed: ${existingCyclesErr.message}`);
+          }
+          const existingTemplateIds = new Map<string, string>();
+          for (const row of existingCycles ?? []) {
+            if (typeof row.id === 'string' && typeof row.template_id === 'string') {
+              existingTemplateIds.set(row.id, row.template_id);
+            }
+          }
+          for (const row of cycleRows) {
+            if (row.template_id == null) {
+              row.template_id = existingTemplateIds.get(row.id) ?? null;
+            }
+          }
+        }
+
         const { error: cycErr } = await supabase
           .from('training_cycles')
           .upsert(cycleRows, { onConflict: 'id' });

--- a/supabase/migrations/20260707120000_add_template_id_to_training_cycles.sql
+++ b/supabase/migrations/20260707120000_add_template_id_to_training_cycles.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.training_cycles
+  ADD COLUMN IF NOT EXISTS template_id TEXT;

--- a/supabase/migrations/20260707130000_update_lww_rpc_template_id.sql
+++ b/supabase/migrations/20260707130000_update_lww_rpc_template_id.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION public.upsert_training_cycle_lww(p_rows jsonb)
+RETURNS TABLE(id text, accepted boolean, server_updated_at timestamptz)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  rec record;
+  existing_ts timestamptz;
+BEGIN
+  FOR rec IN
+    SELECT * FROM jsonb_populate_recordset(NULL::public.training_cycles, p_rows)
+  LOOP
+    SELECT c.updated_at INTO existing_ts
+      FROM public.training_cycles c
+      WHERE c.id = rec.id;
+
+    IF existing_ts IS NULL OR existing_ts <= rec.updated_at THEN
+      INSERT INTO public.training_cycles AS c (
+        id, user_id, local_profile_id, name, description, duration_weeks,
+        workout_days, rest_days, current_week, status, started_at,
+        last_used_at, progression_settings, deload_settings, template_id,
+        updated_at
+      ) VALUES (
+        rec.id, rec.user_id, rec.local_profile_id, rec.name, rec.description,
+        rec.duration_weeks, rec.workout_days, rec.rest_days, rec.current_week,
+        rec.status, rec.started_at, rec.last_used_at, rec.progression_settings,
+        rec.deload_settings, rec.template_id, COALESCE(rec.updated_at, NOW())
+      )
+      ON CONFLICT (id) DO UPDATE SET
+        name                 = EXCLUDED.name,
+        description          = EXCLUDED.description,
+        duration_weeks       = EXCLUDED.duration_weeks,
+        workout_days         = EXCLUDED.workout_days,
+        rest_days            = EXCLUDED.rest_days,
+        current_week         = EXCLUDED.current_week,
+        status               = EXCLUDED.status,
+        started_at           = EXCLUDED.started_at,
+        last_used_at         = EXCLUDED.last_used_at,
+        progression_settings = EXCLUDED.progression_settings,
+        deload_settings      = EXCLUDED.deload_settings,
+        template_id          = COALESCE(EXCLUDED.template_id, c.template_id),
+        updated_at           = EXCLUDED.updated_at
+      WHERE c.updated_at <= EXCLUDED.updated_at;
+
+      RETURN QUERY SELECT rec.id::text, TRUE, COALESCE(rec.updated_at, NOW());
+    ELSE
+      RETURN QUERY SELECT rec.id::text, FALSE, existing_ts;
+    END IF;
+  END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260707130000_update_lww_rpc_template_id.sql
+++ b/supabase/migrations/20260707130000_update_lww_rpc_template_id.sql
@@ -24,8 +24,12 @@ BEGIN
         updated_at
       ) VALUES (
         rec.id, rec.user_id, rec.local_profile_id, rec.name, rec.description,
-        rec.duration_weeks, rec.workout_days, rec.rest_days, rec.current_week,
-        rec.status, rec.started_at, rec.last_used_at, rec.progression_settings,
+        COALESCE(rec.duration_weeks, 4),
+        COALESCE(rec.workout_days, 0),
+        COALESCE(rec.rest_days, 0),
+        COALESCE(rec.current_week, 1),
+        COALESCE(rec.status, 'draft'),
+        rec.started_at, rec.last_used_at, rec.progression_settings,
         rec.deload_settings, rec.template_id, COALESCE(rec.updated_at, NOW())
       )
       ON CONFLICT (id) DO UPDATE SET

--- a/supabase/migrations/20260707130000_update_lww_rpc_template_id.sql
+++ b/supabase/migrations/20260707130000_update_lww_rpc_template_id.sql
@@ -4,6 +4,7 @@ LANGUAGE plpgsql
 SECURITY INVOKER
 SET search_path = public
 AS $$
+#variable_conflict use_column
 DECLARE
   rec record;
   existing_ts timestamptz;

--- a/supabase/migrations/20260707140000_update_pull_rpc_template_id.sql
+++ b/supabase/migrations/20260707140000_update_pull_rpc_template_id.sql
@@ -53,6 +53,7 @@ BEGIN
         tc.local_profile_id
     FROM training_cycles tc
     WHERE tc.user_id = p_user_id
+      -- Return entities that are NEW (not in known IDs) or STALE (updated since last sync)
       AND (
           array_length(p_known_ids, 1) IS NULL
           OR tc.id != ALL(p_known_ids)
@@ -62,7 +63,7 @@ BEGIN
           p_profile_id IS NULL
           OR (p_profile_id = 'default' AND tc.local_profile_id IS NULL)
           OR tc.local_profile_id = p_profile_id
-          OR tc.local_profile_id IS NULL
+          -- Removed: OR tc.local_profile_id IS NULL  (H-18: caused cross-profile bleed)
       )
       AND (
           p_cursor_updated_at IS NULL

--- a/supabase/migrations/20260707140000_update_pull_rpc_template_id.sql
+++ b/supabase/migrations/20260707140000_update_pull_rpc_template_id.sql
@@ -77,3 +77,9 @@ $$;
 
 COMMENT ON FUNCTION get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) IS
 'Fetches training cycles not in the provided ID list OR updated since last sync. Uses POST body via RPC to bypass URL length limits.';
+
+-- Reapply the security scan lockdown because CREATE FUNCTION grants EXECUTE to PUBLIC by default.
+REVOKE ALL ON FUNCTION public.get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) FROM anon;
+REVOKE ALL ON FUNCTION public.get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) TO service_role;

--- a/supabase/migrations/20260707140000_update_pull_rpc_template_id.sql
+++ b/supabase/migrations/20260707140000_update_pull_rpc_template_id.sql
@@ -1,0 +1,78 @@
+DROP FUNCTION IF EXISTS get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT);
+DROP FUNCTION IF EXISTS get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ);
+
+CREATE FUNCTION get_cycles_excluding_ids(
+    p_user_id UUID,
+    p_known_ids UUID[] DEFAULT '{}',
+    p_profile_id TEXT DEFAULT NULL,
+    p_cursor_updated_at TIMESTAMPTZ DEFAULT NULL,
+    p_cursor_id UUID DEFAULT NULL,
+    p_limit INT DEFAULT 76,
+    p_last_sync_at TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    id UUID,
+    user_id UUID,
+    name TEXT,
+    description TEXT,
+    duration_weeks INT,
+    workout_days INT,
+    rest_days INT,
+    current_week INT,
+    status TEXT,
+    started_at TIMESTAMPTZ,
+    last_used_at TIMESTAMPTZ,
+    progression_settings JSONB,
+    deload_settings JSONB,
+    template_id TEXT,
+    updated_at TIMESTAMPTZ,
+    local_profile_id TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        tc.id,
+        tc.user_id,
+        tc.name,
+        tc.description,
+        tc.duration_weeks,
+        tc.workout_days,
+        tc.rest_days,
+        tc.current_week,
+        tc.status,
+        tc.started_at,
+        tc.last_used_at,
+        tc.progression_settings,
+        tc.deload_settings,
+        tc.template_id,
+        tc.updated_at,
+        tc.local_profile_id
+    FROM training_cycles tc
+    WHERE tc.user_id = p_user_id
+      AND (
+          array_length(p_known_ids, 1) IS NULL
+          OR tc.id != ALL(p_known_ids)
+          OR (p_last_sync_at IS NOT NULL AND tc.updated_at > p_last_sync_at)
+      )
+      AND (
+          p_profile_id IS NULL
+          OR (p_profile_id = 'default' AND tc.local_profile_id IS NULL)
+          OR tc.local_profile_id = p_profile_id
+          OR tc.local_profile_id IS NULL
+      )
+      AND (
+          p_cursor_updated_at IS NULL
+          OR tc.updated_at > p_cursor_updated_at
+          OR (tc.updated_at = p_cursor_updated_at AND tc.id > p_cursor_id)
+      )
+    ORDER BY tc.updated_at ASC, tc.id ASC
+    LIMIT p_limit;
+END;
+$$;
+
+COMMENT ON FUNCTION get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) IS
+'Fetches training cycles not in the provided ID list OR updated since last sync. Uses POST body via RPC to bypass URL length limits.';

--- a/tests/sync/helpers/edge-function-harness.ts
+++ b/tests/sync/helpers/edge-function-harness.ts
@@ -259,6 +259,7 @@ export interface CycleDto {
 	lastUsedAt: string | null;
 	progressionSettings?: string | null;
 	deloadSettings?: string | null;
+	templateId?: string | null;
 	days: CycleDayDto[];
 }
 

--- a/tests/sync/training-cycle-template-id.test.ts
+++ b/tests/sync/training-cycle-template-id.test.ts
@@ -45,6 +45,21 @@ describe("Training cycle template_id migration safeguards", () => {
 		);
 	});
 
+	it("preserves LWW insert defaults for training cycle NOT NULL fields", () => {
+		const body = extractTrainingCycleLwwBody(readMigration(LWW_RPC_MIGRATION));
+		const expectedDefaults = [
+			/COALESCE\s*\(\s*rec\.duration_weeks\s*,\s*4\s*\)/i,
+			/COALESCE\s*\(\s*rec\.workout_days\s*,\s*0\s*\)/i,
+			/COALESCE\s*\(\s*rec\.rest_days\s*,\s*0\s*\)/i,
+			/COALESCE\s*\(\s*rec\.current_week\s*,\s*1\s*\)/i,
+			/COALESCE\s*\(\s*rec\.status\s*,\s*'draft'\s*\)/i,
+		];
+
+		for (const expectedDefault of expectedDefaults) {
+			expect(body).toMatch(expectedDefault);
+		}
+	});
+
 	it("locks the recreated cycle pull RPC down to service_role", () => {
 		const sql = readMigration(PULL_RPC_MIGRATION);
 

--- a/tests/sync/training-cycle-template-id.test.ts
+++ b/tests/sync/training-cycle-template-id.test.ts
@@ -19,12 +19,17 @@ const LWW_RPC_MIGRATION = "20260707130000_update_lww_rpc_template_id.sql";
 const PULL_RPC_MIGRATION = "20260707140000_update_pull_rpc_template_id.sql";
 const CYCLE_PULL_SIGNATURE =
 	"public.get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ)";
+const MOBILE_SYNC_PUSH_SOURCE = "supabase/functions/mobile-sync-push/index.ts";
 
 function readMigration(filename: string): string {
 	return readFileSync(
 		join(process.cwd(), "supabase", "migrations", filename),
 		"utf8",
 	);
+}
+
+function readSource(filename: string): string {
+	return readFileSync(join(process.cwd(), filename), "utf8");
 }
 
 function extractTrainingCycleLwwBody(sql: string): string {
@@ -79,6 +84,20 @@ describe("Training cycle template_id migration safeguards", () => {
 });
 
 describe("Training cycle template_id push handling", () => {
+	it("chunks the legacy template_id preservation probe before PostgREST in filters", () => {
+		const source = readSource(MOBILE_SYNC_PUSH_SOURCE);
+		const lookupBlock = source.slice(
+			source.indexOf("const cycleIdsMissingTemplateId ="),
+			source.indexOf("const { error: cycErr } = await supabase"),
+		);
+
+		expect(lookupBlock).toContain("const chunkSize = 100;");
+		expect(lookupBlock).toMatch(
+			/for\s*\(\s*let\s+i\s*=\s*0;\s*i\s*<\s*cycleIdsMissingTemplateId\.length;\s*i\s*\+=\s*chunkSize\s*\)/,
+		);
+		expect(lookupBlock).toContain(".in('id', chunk)");
+	});
+
 	liveIt(
 		"preserves an existing training_cycles.template_id when SYNC_LWW_ENABLED=false and mobile pushes templateId null",
 		async () => {

--- a/tests/sync/training-cycle-template-id.test.ts
+++ b/tests/sync/training-cycle-template-id.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect } from "vitest";
+import {
+	callPushEndpoint,
+	createMinimalPushPayload,
+	type CycleDto,
+} from "./helpers/edge-function-harness";
+import {
+	createTrackedTestUser,
+	getServiceClient,
+	liveIt,
+	setupSyncTests,
+} from "./setup";
+
+setupSyncTests();
+
+describe("Training cycle template_id push handling", () => {
+	liveIt(
+		"preserves an existing training_cycles.template_id when SYNC_LWW_ENABLED=false and mobile pushes templateId null",
+		async () => {
+			const testUser = await createTrackedTestUser();
+			const serviceClient = getServiceClient();
+			const cycleId = crypto.randomUUID();
+			const startedAt = new Date("2026-07-07T12:00:00.000Z").toISOString();
+			const existingTemplateId = "template_531";
+			const subscriptionEndsAt = new Date("2027-07-07T12:00:00.000Z").toISOString();
+
+			const { error: subscriptionError } = await serviceClient.from("subscriptions").insert({
+				user_id: testUser.id,
+				tier: "EMBER",
+				status: "active",
+				current_period_end: subscriptionEndsAt,
+			});
+			expect(subscriptionError).toBeNull();
+
+			const seedCycle: CycleDto = {
+				id: cycleId,
+				userId: testUser.id,
+				name: "Existing Template Cycle",
+				description: "Seed row for legacy non-LWW preservation",
+				durationWeeks: 4,
+				workoutDays: 4,
+				restDays: 3,
+				currentWeek: 1,
+				status: "active",
+				startedAt,
+				lastUsedAt: startedAt,
+				progressionSettings: null,
+				deloadSettings: null,
+				templateId: existingTemplateId,
+				days: [],
+			};
+			const seedPushResult = await callPushEndpoint(
+				createMinimalPushPayload(testUser.id, { cycles: [seedCycle] }),
+				testUser.accessToken,
+			);
+			expect(seedPushResult.success).toBe(true);
+
+			const cycle: CycleDto = {
+				id: cycleId,
+				userId: testUser.id,
+				name: "Updated Template Cycle",
+				description: "Incoming payload omits template identity",
+				durationWeeks: 6,
+				workoutDays: 5,
+				restDays: 2,
+				currentWeek: 2,
+				status: "active",
+				startedAt,
+				lastUsedAt: startedAt,
+				progressionSettings: null,
+				deloadSettings: null,
+				templateId: null,
+				days: [],
+			};
+
+			const pushResult = await callPushEndpoint(
+				createMinimalPushPayload(testUser.id, { cycles: [cycle] }),
+				testUser.accessToken,
+			);
+			expect(pushResult.success).toBe(true);
+
+			const { data: storedCycle, error: fetchError } = await serviceClient
+				.from("training_cycles")
+				.select("id, name, duration_weeks, template_id")
+				.eq("id", cycleId)
+				.single();
+			expect(fetchError).toBeNull();
+			expect(storedCycle).toMatchObject({
+				id: cycleId,
+				name: "Updated Template Cycle",
+				duration_weeks: 6,
+				template_id: existingTemplateId,
+			});
+		},
+	);
+});

--- a/tests/sync/training-cycle-template-id.test.ts
+++ b/tests/sync/training-cycle-template-id.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 import {
 	callPushEndpoint,
 	createMinimalPushPayload,
@@ -13,6 +15,54 @@ import {
 
 setupSyncTests();
 
+const LWW_RPC_MIGRATION = "20260707130000_update_lww_rpc_template_id.sql";
+const PULL_RPC_MIGRATION = "20260707140000_update_pull_rpc_template_id.sql";
+const CYCLE_PULL_SIGNATURE =
+	"public.get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ)";
+
+function readMigration(filename: string): string {
+	return readFileSync(
+		join(process.cwd(), "supabase", "migrations", filename),
+		"utf8",
+	);
+}
+
+function extractTrainingCycleLwwBody(sql: string): string {
+	const match = sql.match(
+		/CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.upsert_training_cycle_lww\s*\([\s\S]*?AS\s+\$\$([\s\S]*?)\$\$;/i,
+	);
+	expect(match).not.toBeNull();
+	return match?.[1] ?? "";
+}
+
+describe("Training cycle template_id migration safeguards", () => {
+	it("keeps the LWW function conflict pragma while preserving existing template_id values", () => {
+		const body = extractTrainingCycleLwwBody(readMigration(LWW_RPC_MIGRATION));
+
+		expect(body).toMatch(/#variable_conflict\s+use_column/);
+		expect(body).toMatch(
+			/template_id\s*=\s*COALESCE\s*\(\s*EXCLUDED\.template_id\s*,\s*c\.template_id\s*\)/i,
+		);
+	});
+
+	it("locks the recreated cycle pull RPC down to service_role", () => {
+		const sql = readMigration(PULL_RPC_MIGRATION);
+
+		expect(sql).toContain(
+			`REVOKE ALL ON FUNCTION ${CYCLE_PULL_SIGNATURE} FROM PUBLIC;`,
+		);
+		expect(sql).toContain(
+			`REVOKE ALL ON FUNCTION ${CYCLE_PULL_SIGNATURE} FROM anon;`,
+		);
+		expect(sql).toContain(
+			`REVOKE ALL ON FUNCTION ${CYCLE_PULL_SIGNATURE} FROM authenticated;`,
+		);
+		expect(sql).toContain(
+			`GRANT EXECUTE ON FUNCTION ${CYCLE_PULL_SIGNATURE} TO service_role;`,
+		);
+	});
+});
+
 describe("Training cycle template_id push handling", () => {
 	liveIt(
 		"preserves an existing training_cycles.template_id when SYNC_LWW_ENABLED=false and mobile pushes templateId null",
@@ -22,14 +72,18 @@ describe("Training cycle template_id push handling", () => {
 			const cycleId = crypto.randomUUID();
 			const startedAt = new Date("2026-07-07T12:00:00.000Z").toISOString();
 			const existingTemplateId = "template_531";
-			const subscriptionEndsAt = new Date("2027-07-07T12:00:00.000Z").toISOString();
+			const subscriptionEndsAt = new Date(
+				"2027-07-07T12:00:00.000Z",
+			).toISOString();
 
-			const { error: subscriptionError } = await serviceClient.from("subscriptions").insert({
-				user_id: testUser.id,
-				tier: "EMBER",
-				status: "active",
-				current_period_end: subscriptionEndsAt,
-			});
+			const { error: subscriptionError } = await serviceClient
+				.from("subscriptions")
+				.insert({
+					user_id: testUser.id,
+					tier: "EMBER",
+					status: "active",
+					current_period_end: subscriptionEndsAt,
+				});
 			expect(subscriptionError).toBeNull();
 
 			const seedCycle: CycleDto = {


### PR DESCRIPTION
## Summary
- add `training_cycles.template_id` to portal schema/types and sync payloads
- preserve existing template IDs when mobile pushes null in both legacy and LWW paths
- update cycle pull RPCs to return template IDs while keeping profile isolation and service-role-only execution
- preserve prior LWW safety behavior: `#variable_conflict use_column` and NOT NULL insert defaults

## Verification
- `npm run typecheck`
- `npm run test:sync`
- `git diff --check`
- final code review pass found no blocking findings

## Rollout notes
- Apply the included Supabase migrations before relying on mobile template-cycle sync in production.
- Refs 9thLevelSoftware/Project-Phoenix-MP#632