### PR TITLE
feat: add profile preference sync storage

### DIFF
--- a/docs/profile-preferences-advisor-dispositions.md
+++ b/docs/profile-preferences-advisor-dispositions.md
@@ -1,0 +1,101 @@
+# Profile Preference Advisor Dispositions
+
+Captured 2026-07-15 at 20:50 EDT for branch `codex/profile-preferences-db` at
+`60b4412`. This record separates the feature-object result from unrelated
+baseline findings. It does not describe the local database or any remote
+environment as globally clean.
+
+## Outcome
+
+- New findings on `public.local_profile_preferences`,
+  `public.local_profile_preference_section_canonical`, or
+  `public.mutate_local_profile_preference_section`: **0** in the fresh local
+  advisor rerun.
+- Resolved target findings: **0**. No target finding required a fix.
+- Unrelated findings: the local lint error, all 104 local advisor warnings, and
+  all current production findings below are pre-existing and outside this
+  feature's migration/test/documentation file scope.
+- Production deployment boundary: read-only migration inventory returned 82
+  applied migrations and did not include
+  `20260715234034_profile_preferences`. Production advisor output therefore
+  records the current baseline only; it is not post-deployment verification of
+  the feature.
+
+## Local database lint
+
+Command: `npx --yes supabase@2.81.3 -o json db lint --local --fail-on warning`
+
+| Environment | Source/command | Finding ID | Severity | Object | Disposition or fix | Rerun result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Local | `supabase db lint --local --fail-on warning` | `plpgsql_check` / SQLSTATE `42703` | ERROR | `public.upsert_routine_lww` | Pre-existing and unrelated: the function references the absent `public.routines.created_at` column. Fixing the existing routine function/schema is outside the profile-preference files. | Fresh run exit `1`; the same single error remains. Neither new preference function was reported. |
+
+The nonzero lint exit is retained as a baseline concern; it is not converted
+into a clean result.
+
+## Local database advisors
+
+Command: `npx --yes supabase@2.81.3 -o json db advisors --local`
+
+| Environment | Source/command | Finding ID | Severity | Object | Disposition or fix | Rerun result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Local | `supabase db advisors --local` | [`auth_rls_initplan`](https://supabase.com/docs/guides/database/database-linter?lint=0003_auth_rls_initplan) (72 findings) | WARN | `public.challenge_participants`, `public.community_comments`, `public.community_votes`, `public.creator_follows`, `public.cycle_days`, `public.exercise_catalog`, `public.exercise_progress`, `public.exercise_signatures`, `public.external_activities`, `public.local_profiles`, `public.oauth_states`, `public.oauth_tokens`, `public.personal_records`, `public.profiles`, `public.rate_limit_tracking`, `public.routine_exercises`, `public.routines`, `public.saved_community_items`, `public.session_phase_statistics`, `public.shared_cycles`, `public.shared_routines`, `public.subscriptions`, `public.sync_queue`, `public.training_cycles`, `public.user_goals`, `public.user_insights`, `public.user_integrations`, `public.user_onboarding`, `public.vbt_assessments`, and `public.workout_sessions` | Pre-existing performance findings outside the target objects and feature file scope; no change in this PR. | Fresh rerun still reports 72 warnings. |
+| Local | `supabase db advisors --local` | [`multiple_permissive_policies`](https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies) (30 findings) | WARN | `public.local_profiles` and `public.profiles` | Pre-existing performance findings outside the target objects and feature file scope; no change in this PR. | Fresh rerun still reports 30 warnings. |
+| Local | `supabase db advisors --local` | [`duplicate_index`](https://supabase.com/docs/guides/database/database-linter?lint=0009_duplicate_index) (1 finding) | WARN | `public.user_onboarding` | Pre-existing performance finding outside the target objects and feature file scope; no change in this PR. | Fresh rerun still reports 1 warning. |
+| Local | `supabase db advisors --local` | [`function_search_path_mutable`](https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable) (1 finding) | WARN | `public._external_activities_bump_updated_at` | Pre-existing security finding outside the target objects and feature file scope; no change in this PR. | Fresh rerun still reports 1 warning. |
+| Local | `supabase db advisors --local` target-object filter | `target-object-scope` | NONE | `public.local_profile_preferences`, `public.local_profile_preference_section_canonical`, and `public.mutate_local_profile_preference_section` | No advisor fix required. The migration already defines both functions with an empty `search_path`, and no advisor row names any target object. | Exit `0`; 104 total pre-existing warnings and `TargetFindings=0`. |
+
+## Staging or preview baseline
+
+Read-only Supabase discovery listed one accessible project (`Project Phoenix`,
+ref `ilzlswmatadlnsuxatcv`) and only its default `main` branch. There was no
+distinct staging project, development branch, or PR preview available at the
+time of capture.
+
+| Environment | Source/command | Finding ID | Severity | Object | Disposition or fix | Rerun result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Staging/preview | Supabase `list_projects` and `list_branches` (read-only) | `baseline-unavailable` | N/A | N/A | No staging/preview environment exists in the accessible project inventory. No advisor evidence is invented or inferred. | Not run: there was no distinct environment to inspect. |
+
+An isolated migration preview remains required before merge if the PR does not
+provision one.
+
+## Production security baseline
+
+Source: read-only Supabase `get_advisors` for project
+`ilzlswmatadlnsuxatcv`, type `security`.
+
+| Environment | Source/command | Finding ID | Severity | Object | Disposition or fix | Rerun result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Production | Supabase `get_advisors(security)` (read-only) | [`security_definer_view`](https://supabase.com/docs/guides/database/database-linter?lint=0010_security_definer_view) (1 finding) | ERROR | `public.public_profiles` | **Pre-existing and out of scope.** This is a real production ERROR: the view is defined with the `SECURITY DEFINER` property. The profile-preference migration does not modify this view. | Current baseline still reports 1 ERROR; production is not globally clean. |
+| Production | Supabase `get_advisors(security)` (read-only) | [`function_search_path_mutable`](https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable) (10 findings) | WARN | `public._external_activities_bump_updated_at`, `public.detect_plateaus`, `public.get_acwr`, `public.get_exercise_trend`, `public.get_goal_progress_cached`, `public.get_muscle_distribution`, `public.get_volume_comparison`, `public.get_volume_rolling_avg`, `public.get_wearable_trends`, and `public.get_workout_streak` | **Pre-existing and out of scope.** None is a target preference function; no change in this PR. | Current baseline still reports 10 warnings. |
+| Production | Supabase `get_advisors(security)` (read-only) | [`anon_security_definer_function_executable`](https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable) (19 findings) | WARN | `public.check_comment_rate_limit`, `public.check_goal_limit`, `public.get_percentile_rank`, `public.get_profile_stats`, `public.get_routines_excluding_ids`, `public.get_sessions_excluding_ids`, `public.handle_new_user`, `public.import_shared_cycle`, `public.import_shared_routine`, `public.insert_routine_exercises_from_snapshot`, `public.refresh_community_benchmarks`, `public.refresh_hot_scores`, `public.rls_auto_enable`, `public.update_comment_count`, `public.update_leaderboard_events_updated_at`, `public.update_pr_count_on_record`, `public.update_profile_stats_on_workout`, `public.update_vote_count`, and `public.user_subscription_tier` | Pre-existing and out of the feature file scope. No change in this PR. | Current baseline still reports 19 warnings. |
+| Production | Supabase `get_advisors(security)` (read-only) | [`authenticated_security_definer_function_executable`](https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable) (19 findings) | WARN | The same 19 pre-existing functions listed in the preceding row | Pre-existing and out of the feature file scope. No change in this PR. | Current baseline still reports 19 warnings. |
+| Production | Supabase `get_advisors(security)` (read-only) | [`auth_leaked_password_protection`](https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection) (1 finding) | WARN | Supabase Auth | Pre-existing project configuration warning outside the migration/test file scope. No change in this PR. | Current baseline still reports 1 warning. |
+| Production | Supabase `get_advisors(security)` (read-only) | [`auth_insufficient_mfa_options`](https://supabase.com/docs/guides/auth/auth-mfa) (1 finding) | WARN | Supabase Auth | Pre-existing project configuration warning outside the migration/test file scope. No change in this PR. | Current baseline still reports 1 warning. |
+
+Production security total: 51 notices (1 ERROR and 50 WARN). This baseline is
+explicitly non-clean.
+
+## Production performance baseline
+
+Source: read-only Supabase `get_advisors` for project
+`ilzlswmatadlnsuxatcv`, type `performance`.
+
+| Environment | Source/command | Finding ID | Severity | Object | Disposition or fix | Rerun result |
+| --- | --- | --- | --- | --- | --- | --- |
+| Production | Supabase `get_advisors(performance)` (read-only) | [`auth_rls_initplan`](https://supabase.com/docs/guides/database/database-linter?lint=0003_auth_rls_initplan) (78 findings) | WARN | `public.challenge_participants`, `public.community_comments`, `public.community_votes`, `public.creator_follows`, `public.cycle_days`, `public.exercise_catalog`, `public.exercise_progress`, `public.exercise_signatures`, `public.external_activities`, `public.goal_snapshots`, `public.local_profiles`, `public.oauth_states`, `public.oauth_tokens`, `public.overload_suggestions`, `public.personal_records`, `public.profiles`, `public.rate_limit_tracking`, `public.routine_exercises`, `public.routines`, `public.saved_community_items`, `public.session_phase_statistics`, `public.shared_cycles`, `public.shared_routines`, `public.subscriptions`, `public.sync_queue`, `public.telemetry_analysis`, `public.training_cycles`, `public.user_goals`, `public.user_insights`, `public.user_integrations`, `public.user_onboarding`, `public.vbt_assessments`, `public.wearable_daily_summaries`, and `public.workout_sessions`; no `public.local_profile_preferences` finding | Pre-existing performance warnings outside the feature's target objects and file scope. No change in this PR. | Current baseline still reports 78 warnings. |
+| Production | Supabase `get_advisors(performance)` (read-only) | [`multiple_permissive_policies`](https://supabase.com/docs/guides/database/database-linter?lint=0006_multiple_permissive_policies) (36 findings) | WARN | `public.local_profiles` and `public.profiles` | Pre-existing performance warnings outside the target table. No change in this PR. | Current baseline still reports 36 warnings. |
+| Production | Supabase `get_advisors(performance)` (read-only) | [`duplicate_index`](https://supabase.com/docs/guides/database/database-linter?lint=0009_duplicate_index) (2 findings) | WARN | `public.local_profiles` and `public.user_onboarding` | Pre-existing performance warnings outside the target table. No change in this PR. | Current baseline still reports 2 warnings. |
+| Production | Supabase `get_advisors(performance)` (read-only) | [`unindexed_foreign_keys`](https://supabase.com/docs/guides/database/database-linter?lint=0001_unindexed_foreign_keys) (10 findings) | INFO | `public.challenge_participants`, `public.cycle_days`, `public.exercise_progress`, `public.goal_snapshots`, `public.oauth_states`, `public.personal_records`, `public.rate_limit_tracking`, `public.shared_cycles`, `public.shared_routines`, and `public.user_blocks` | Pre-existing performance information outside the target objects. No change in this PR. | Current baseline still reports 10 notices. |
+| Production | Supabase `get_advisors(performance)` (read-only) | [`unused_index`](https://supabase.com/docs/guides/database/database-linter?lint=0005_unused_index) (13 findings) | INFO | `public.community_comments`, `public.content_reports`, `public.exercise_catalog`, `public.saved_community_items`, `public.session_phase_statistics`, `public.sync_queue`, `public.telemetry_analysis`, `public.training_cycles`, `public.user_goals`, and `public.vbt_assessments` | Pre-existing performance information outside the target objects. No change in this PR. | Current baseline still reports 13 notices. |
+| Production | Supabase `get_advisors(performance)` (read-only) | [`auth_db_connections_absolute`](https://supabase.com/docs/guides/deployment/going-into-prod) (1 finding) | INFO | Supabase Auth | Pre-existing project configuration information outside the migration/test file scope. No change in this PR. | Current baseline still reports 1 notice. |
+
+Production performance total: 140 notices (116 WARN and 24 INFO). These
+pre-existing warnings/notices remain open and are not evidence of a globally
+clean environment.
+
+## PR disposition
+
+The feature adds no local advisor error or warning on the target table or
+functions. The unrelated baselines above remain visible for follow-up in their
+own scope. Edge Functions and the mobile release remain gated until the
+migration is deployed and verified in an isolated Supabase environment.

--- a/supabase/migrations/20260715234034_profile_preferences.sql
+++ b/supabase/migrations/20260715234034_profile_preferences.sql
@@ -78,13 +78,6 @@ CREATE TABLE IF NOT EXISTS public.local_profile_preferences(
         AND (weight_increment = -1 OR weight_increment > 0)
     ),
     CONSTRAINT local_profile_preferences_led_scheme_check CHECK (led_color_scheme_id >= 0),
-    CONSTRAINT local_profile_preferences_rack_object_check CHECK (
-        jsonb_typeof(equipment_rack) = 'object'
-        AND equipment_rack @> '{"version":1}'::jsonb
-        AND jsonb_typeof(equipment_rack -> 'items') = 'array'
-        AND NOT jsonb_path_exists(equipment_rack, '$.items[*] ? (@.weightKg < 0)')
-        AND octet_length(equipment_rack::text) <= 262144
-    ),
     CONSTRAINT local_profile_preferences_workout_object_check CHECK (
         jsonb_typeof(workout_preferences) = 'object'
         AND workout_preferences @> '{"version":1}'::jsonb
@@ -111,21 +104,43 @@ CREATE TABLE IF NOT EXISTS public.local_profile_preferences(
             )
         )
         AND octet_length(workout_preferences::text) <= 262144
-    ),
-    CONSTRAINT local_profile_preferences_led_object_check CHECK (
+    )
+);
+
+ALTER TABLE public.local_profile_preferences
+    DROP CONSTRAINT IF EXISTS local_profile_preferences_rack_object_check;
+ALTER TABLE public.local_profile_preferences
+    ADD CONSTRAINT local_profile_preferences_rack_object_check CHECK (
+        jsonb_typeof(equipment_rack) = 'object'
+        AND equipment_rack @> '{"version":1}'::jsonb
+        AND equipment_rack ? 'items'
+        AND jsonb_typeof(equipment_rack -> 'items') = 'array'
+        AND NOT jsonb_path_exists(equipment_rack, '$.items[*] ? (@.weightKg < 0)')
+        AND octet_length(equipment_rack::text) <= 262144
+    );
+
+ALTER TABLE public.local_profile_preferences
+    DROP CONSTRAINT IF EXISTS local_profile_preferences_led_object_check;
+ALTER TABLE public.local_profile_preferences
+    ADD CONSTRAINT local_profile_preferences_led_object_check CHECK (
         jsonb_typeof(led_preferences) = 'object'
         AND led_preferences @> '{"version":1}'::jsonb
+        AND led_preferences ? 'discoModeUnlocked'
         AND jsonb_typeof(led_preferences -> 'discoModeUnlocked') = 'boolean'
         AND octet_length(led_preferences::text) <= 262144
-    ),
-    CONSTRAINT local_profile_preferences_vbt_object_check CHECK (
+    );
+
+ALTER TABLE public.local_profile_preferences
+    DROP CONSTRAINT IF EXISTS local_profile_preferences_vbt_object_check;
+ALTER TABLE public.local_profile_preferences
+    ADD CONSTRAINT local_profile_preferences_vbt_object_check CHECK (
         jsonb_typeof(vbt_preferences) = 'object'
         AND vbt_preferences @> '{"version":1}'::jsonb
+        AND vbt_preferences ? 'velocityLossThresholdPercent'
         AND jsonb_typeof(vbt_preferences -> 'velocityLossThresholdPercent') = 'number'
         AND (vbt_preferences ->> 'velocityLossThresholdPercent')::integer BETWEEN 10 AND 50
         AND octet_length(vbt_preferences::text) <= 262144
-    )
-);
+    );
 
 DO $postcondition$
 DECLARE

--- a/supabase/migrations/20260715234034_profile_preferences.sql
+++ b/supabase/migrations/20260715234034_profile_preferences.sql
@@ -1,0 +1,535 @@
+BEGIN;
+
+DO $preflight$
+DECLARE
+    matching_key text[];
+BEGIN
+    IF to_regclass('public.local_profiles') IS NULL THEN
+        RAISE EXCEPTION 'profile preferences preflight: public.local_profiles does not exist';
+    END IF;
+
+    SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+      INTO matching_key
+      FROM pg_constraint constraint_row
+      CROSS JOIN LATERAL unnest(constraint_row.conkey)
+          WITH ORDINALITY AS key_column(attnum, ordinality)
+      JOIN pg_attribute attribute
+        ON attribute.attrelid = constraint_row.conrelid
+       AND attribute.attnum = key_column.attnum
+     WHERE constraint_row.conrelid = 'public.local_profiles'::regclass
+       AND constraint_row.contype IN ('p', 'u')
+     GROUP BY constraint_row.oid
+    HAVING array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+           = ARRAY['user_id', 'id']::text[]
+     LIMIT 1;
+
+    IF matching_key IS NULL THEN
+        RAISE EXCEPTION
+            'profile preferences preflight: expected unique local_profiles(user_id, id) parent key';
+    END IF;
+END
+$preflight$;
+
+CREATE TABLE IF NOT EXISTS public.local_profile_preferences(
+    user_id uuid NOT NULL,
+    local_profile_id text NOT NULL,
+    schema_version integer NOT NULL DEFAULT 1 CHECK (schema_version = 1),
+
+    body_weight_kg double precision NOT NULL DEFAULT 0,
+    weight_unit text NOT NULL DEFAULT 'LB',
+    weight_increment double precision NOT NULL DEFAULT -1,
+    core_revision bigint NOT NULL DEFAULT 0 CHECK (core_revision >= 0),
+    core_updated_at timestamptz NOT NULL DEFAULT now(),
+
+    equipment_rack jsonb NOT NULL DEFAULT '{"version":1,"items":[]}'::jsonb,
+    rack_revision bigint NOT NULL DEFAULT 0 CHECK (rack_revision >= 0),
+    rack_updated_at timestamptz NOT NULL DEFAULT now(),
+
+    workout_preferences jsonb NOT NULL DEFAULT '{"version":1}'::jsonb,
+    workout_revision bigint NOT NULL DEFAULT 0 CHECK (workout_revision >= 0),
+    workout_updated_at timestamptz NOT NULL DEFAULT now(),
+
+    led_color_scheme_id integer NOT NULL DEFAULT 0,
+    led_preferences jsonb NOT NULL DEFAULT '{"version":1,"discoModeUnlocked":false}'::jsonb,
+    led_revision bigint NOT NULL DEFAULT 0 CHECK (led_revision >= 0),
+    led_updated_at timestamptz NOT NULL DEFAULT now(),
+
+    vbt_enabled boolean NOT NULL DEFAULT true,
+    vbt_preferences jsonb NOT NULL DEFAULT '{"version":1,"velocityLossThresholdPercent":20,"autoEndOnVelocityLoss":false,"defaultScalingBasis":"MAX_WEIGHT_PR","verbalEncouragementEnabled":false,"vulgarModeEnabled":false,"vulgarTier":"STRONG","dominatrixModeUnlocked":false,"dominatrixModeActive":false}'::jsonb,
+    vbt_revision bigint NOT NULL DEFAULT 0 CHECK (vbt_revision >= 0),
+    vbt_updated_at timestamptz NOT NULL DEFAULT now(),
+
+    updated_at timestamptz GENERATED ALWAYS AS (
+        greatest(core_updated_at, rack_updated_at, workout_updated_at, led_updated_at, vbt_updated_at)
+    ) STORED,
+
+    CONSTRAINT local_profile_preferences_pkey PRIMARY KEY (user_id, local_profile_id),
+    CONSTRAINT local_profile_preferences_parent_fkey
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE CASCADE,
+    CONSTRAINT local_profile_preferences_body_weight_check CHECK (
+        body_weight_kg NOT IN ('NaN'::double precision, 'Infinity'::double precision, '-Infinity'::double precision)
+        AND (body_weight_kg = 0 OR body_weight_kg BETWEEN 20 AND 300)
+    ),
+    CONSTRAINT local_profile_preferences_weight_unit_check CHECK (weight_unit IN ('KG', 'LB')),
+    CONSTRAINT local_profile_preferences_weight_increment_check CHECK (
+        weight_increment NOT IN ('NaN'::double precision, 'Infinity'::double precision, '-Infinity'::double precision)
+        AND (weight_increment = -1 OR weight_increment > 0)
+    ),
+    CONSTRAINT local_profile_preferences_led_scheme_check CHECK (led_color_scheme_id >= 0),
+    CONSTRAINT local_profile_preferences_rack_object_check CHECK (
+        jsonb_typeof(equipment_rack) = 'object'
+        AND equipment_rack @> '{"version":1}'::jsonb
+        AND jsonb_typeof(equipment_rack -> 'items') = 'array'
+        AND NOT jsonb_path_exists(equipment_rack, '$.items[*] ? (@.weightKg < 0)')
+        AND octet_length(equipment_rack::text) <= 262144
+    ),
+    CONSTRAINT local_profile_preferences_workout_object_check CHECK (
+        jsonb_typeof(workout_preferences) = 'object'
+        AND workout_preferences @> '{"version":1}'::jsonb
+        AND (
+            NOT workout_preferences ? 'summaryCountdownSeconds'
+            OR (
+                jsonb_typeof(workout_preferences -> 'summaryCountdownSeconds') = 'number'
+                AND (workout_preferences ->> 'summaryCountdownSeconds')::integer
+                    IN (-1, 0, 5, 10, 15, 20, 25, 30)
+            )
+        )
+        AND (
+            NOT workout_preferences ? 'autoStartCountdownSeconds'
+            OR (
+                jsonb_typeof(workout_preferences -> 'autoStartCountdownSeconds') = 'number'
+                AND (workout_preferences ->> 'autoStartCountdownSeconds')::integer BETWEEN 2 AND 10
+            )
+        )
+        AND (
+            NOT workout_preferences ? 'defaultRoutineExerciseWeightPercentOfPR'
+            OR (
+                jsonb_typeof(workout_preferences -> 'defaultRoutineExerciseWeightPercentOfPR') = 'number'
+                AND (workout_preferences ->> 'defaultRoutineExerciseWeightPercentOfPR')::integer BETWEEN 50 AND 120
+            )
+        )
+        AND octet_length(workout_preferences::text) <= 262144
+    ),
+    CONSTRAINT local_profile_preferences_led_object_check CHECK (
+        jsonb_typeof(led_preferences) = 'object'
+        AND led_preferences @> '{"version":1}'::jsonb
+        AND jsonb_typeof(led_preferences -> 'discoModeUnlocked') = 'boolean'
+        AND octet_length(led_preferences::text) <= 262144
+    ),
+    CONSTRAINT local_profile_preferences_vbt_object_check CHECK (
+        jsonb_typeof(vbt_preferences) = 'object'
+        AND vbt_preferences @> '{"version":1}'::jsonb
+        AND jsonb_typeof(vbt_preferences -> 'velocityLossThresholdPercent') = 'number'
+        AND (vbt_preferences ->> 'velocityLossThresholdPercent')::integer BETWEEN 10 AND 50
+        AND octet_length(vbt_preferences::text) <= 262144
+    )
+);
+
+DO $postcondition$
+DECLARE
+    primary_key_columns text[];
+    parent_key_columns text[];
+    referenced_key_columns text[];
+    revision_column_count integer;
+BEGIN
+    SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+      INTO primary_key_columns
+      FROM pg_constraint constraint_row
+      CROSS JOIN LATERAL unnest(constraint_row.conkey)
+          WITH ORDINALITY AS key_column(attnum, ordinality)
+      JOIN pg_attribute attribute
+        ON attribute.attrelid = constraint_row.conrelid
+       AND attribute.attnum = key_column.attnum
+     WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+       AND constraint_row.contype = 'p'
+     GROUP BY constraint_row.oid
+     LIMIT 1;
+
+    IF primary_key_columns IS DISTINCT FROM ARRAY['user_id', 'local_profile_id']::text[] THEN
+        RAISE EXCEPTION
+            'profile preferences postcondition: expected primary key (user_id, local_profile_id)';
+    END IF;
+
+    SELECT
+        array_agg(child_attribute.attname::text ORDER BY child_key.ordinality),
+        array_agg(parent_attribute.attname::text ORDER BY child_key.ordinality)
+      INTO parent_key_columns, referenced_key_columns
+      FROM pg_constraint constraint_row
+      CROSS JOIN LATERAL unnest(constraint_row.conkey)
+          WITH ORDINALITY AS child_key(attnum, ordinality)
+      CROSS JOIN LATERAL unnest(constraint_row.confkey)
+          WITH ORDINALITY AS parent_key(attnum, ordinality)
+      JOIN pg_attribute child_attribute
+        ON child_attribute.attrelid = constraint_row.conrelid
+       AND child_attribute.attnum = child_key.attnum
+      JOIN pg_attribute parent_attribute
+        ON parent_attribute.attrelid = constraint_row.confrelid
+       AND parent_attribute.attnum = parent_key.attnum
+     WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+       AND constraint_row.contype = 'f'
+       AND constraint_row.confrelid = 'public.local_profiles'::regclass
+       AND constraint_row.confdeltype = 'c'
+       AND child_key.ordinality = parent_key.ordinality
+     GROUP BY constraint_row.oid
+    HAVING array_agg(child_attribute.attname::text ORDER BY child_key.ordinality)
+               = ARRAY['user_id', 'local_profile_id']::text[]
+       AND array_agg(parent_attribute.attname::text ORDER BY child_key.ordinality)
+               = ARRAY['user_id', 'id']::text[]
+     LIMIT 1;
+
+    IF parent_key_columns IS NULL OR referenced_key_columns IS NULL THEN
+        RAISE EXCEPTION
+            'profile preferences postcondition: expected cascading local_profiles parent foreign key';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint constraint_row
+          JOIN pg_attribute attribute
+            ON attribute.attrelid = constraint_row.conrelid
+           AND attribute.attnum = ANY (constraint_row.conkey)
+         WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+           AND constraint_row.contype = 'c'
+           AND attribute.attname = 'schema_version'
+           AND pg_get_constraintdef(constraint_row.oid) LIKE '%schema_version = 1%'
+    ) THEN
+        RAISE EXCEPTION
+            'profile preferences postcondition: expected schema_version = 1 check';
+    END IF;
+
+    SELECT count(*)
+      INTO revision_column_count
+      FROM pg_attribute attribute
+      JOIN pg_attrdef default_row
+        ON default_row.adrelid = attribute.attrelid
+       AND default_row.adnum = attribute.attnum
+     WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+       AND attribute.attname IN (
+           'core_revision',
+           'rack_revision',
+           'workout_revision',
+           'led_revision',
+           'vbt_revision'
+       )
+       AND NOT attribute.attisdropped
+       AND attribute.atttypid = 'pg_catalog.int8'::regtype
+       AND attribute.attnotnull
+       AND pg_get_expr(default_row.adbin, default_row.adrelid) = '0'
+       AND EXISTS (
+           SELECT 1
+             FROM pg_constraint constraint_row
+            WHERE constraint_row.conrelid = attribute.attrelid
+              AND constraint_row.contype = 'c'
+              AND attribute.attnum = ANY (constraint_row.conkey)
+              AND pg_get_constraintdef(constraint_row.oid) LIKE '%>= 0%'
+       );
+
+    IF revision_column_count <> 5 THEN
+        RAISE EXCEPTION
+            'profile preferences postcondition: expected five nonnegative bigint section revision columns';
+    END IF;
+END
+$postcondition$;
+
+CREATE OR REPLACE FUNCTION public.local_profile_preference_section_canonical(
+    p_row public.local_profile_preferences,
+    p_section text
+) RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $canonical$
+    SELECT jsonb_build_object(
+        'localProfileId', p_row.local_profile_id,
+        'section', p_section,
+        'documentVersion', CASE p_section
+            WHEN 'CORE' THEN 1
+            WHEN 'RACK' THEN (p_row.equipment_rack ->> 'version')::integer
+            WHEN 'WORKOUT' THEN (p_row.workout_preferences ->> 'version')::integer
+            WHEN 'LED' THEN (p_row.led_preferences ->> 'version')::integer
+            WHEN 'VBT' THEN (p_row.vbt_preferences ->> 'version')::integer
+        END,
+        'serverRevision', CASE p_section
+            WHEN 'CORE' THEN p_row.core_revision
+            WHEN 'RACK' THEN p_row.rack_revision
+            WHEN 'WORKOUT' THEN p_row.workout_revision
+            WHEN 'LED' THEN p_row.led_revision
+            WHEN 'VBT' THEN p_row.vbt_revision
+        END,
+        'serverUpdatedAt', to_char(
+            (CASE p_section
+                WHEN 'CORE' THEN p_row.core_updated_at
+                WHEN 'RACK' THEN p_row.rack_updated_at
+                WHEN 'WORKOUT' THEN p_row.workout_updated_at
+                WHEN 'LED' THEN p_row.led_updated_at
+                WHEN 'VBT' THEN p_row.vbt_updated_at
+            END) AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+        ),
+        'payload', CASE p_section
+            WHEN 'CORE' THEN jsonb_build_object(
+                'bodyWeightKg', p_row.body_weight_kg,
+                'weightUnit', p_row.weight_unit,
+                'weightIncrement', p_row.weight_increment
+            )
+            WHEN 'RACK' THEN p_row.equipment_rack
+            WHEN 'WORKOUT' THEN p_row.workout_preferences
+            WHEN 'LED' THEN jsonb_build_object(
+                'ledColorSchemeId', p_row.led_color_scheme_id,
+                'preferences', p_row.led_preferences
+            )
+            WHEN 'VBT' THEN jsonb_build_object(
+                'vbtEnabled', p_row.vbt_enabled,
+                'preferences', p_row.vbt_preferences
+            )
+        END
+    );
+$canonical$;
+
+CREATE OR REPLACE FUNCTION public.mutate_local_profile_preference_section(
+    p_user_id uuid,
+    p_local_profile_id text,
+    p_section text,
+    p_document_version integer,
+    p_base_revision bigint,
+    p_payload jsonb
+) RETURNS TABLE (
+    accepted boolean,
+    rejection_reason text,
+    server_revision bigint,
+    canonical_section jsonb
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $mutation$
+DECLARE
+    current_row public.local_profile_preferences%ROWTYPE;
+    current_revision bigint;
+BEGIN
+    IF p_section IS NULL OR p_section NOT IN ('CORE', 'RACK', 'WORKOUT', 'LED', 'VBT') THEN
+        RETURN QUERY SELECT false, 'UNSUPPORTED_SECTION', 0::bigint, NULL::jsonb;
+        RETURN;
+    END IF;
+    IF p_document_version IS NULL OR p_document_version <> 1 THEN
+        RETURN QUERY SELECT false, 'UNSUPPORTED_DOCUMENT_VERSION', 0::bigint, NULL::jsonb;
+        RETURN;
+    END IF;
+    IF p_base_revision IS NULL OR p_base_revision < 0
+       OR p_payload IS NULL OR jsonb_typeof(p_payload) <> 'object' THEN
+        RETURN QUERY SELECT false, 'VALIDATION_FAILED', 0::bigint, NULL::jsonb;
+        RETURN;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM public.local_profiles
+         WHERE user_id = p_user_id AND id = p_local_profile_id
+    ) THEN
+        RETURN QUERY SELECT false, 'UNKNOWN_PROFILE', 0::bigint, NULL::jsonb;
+        RETURN;
+    END IF;
+
+    CASE p_section
+        WHEN 'CORE' THEN
+            UPDATE public.local_profile_preferences
+               SET body_weight_kg = (p_payload ->> 'bodyWeightKg')::double precision,
+                   weight_unit = p_payload ->> 'weightUnit',
+                   weight_increment = (p_payload ->> 'weightIncrement')::double precision,
+                   core_revision = core_revision + 1,
+                   core_updated_at = clock_timestamp()
+             WHERE user_id = p_user_id
+               AND local_profile_id = p_local_profile_id
+               AND core_revision = p_base_revision
+            RETURNING * INTO current_row;
+        WHEN 'RACK' THEN
+            UPDATE public.local_profile_preferences
+               SET equipment_rack = p_payload,
+                   rack_revision = rack_revision + 1,
+                   rack_updated_at = clock_timestamp()
+             WHERE user_id = p_user_id
+               AND local_profile_id = p_local_profile_id
+               AND rack_revision = p_base_revision
+            RETURNING * INTO current_row;
+        WHEN 'WORKOUT' THEN
+            UPDATE public.local_profile_preferences
+               SET workout_preferences = p_payload,
+                   workout_revision = workout_revision + 1,
+                   workout_updated_at = clock_timestamp()
+             WHERE user_id = p_user_id
+               AND local_profile_id = p_local_profile_id
+               AND workout_revision = p_base_revision
+            RETURNING * INTO current_row;
+        WHEN 'LED' THEN
+            UPDATE public.local_profile_preferences
+               SET led_color_scheme_id = (p_payload ->> 'ledColorSchemeId')::integer,
+                   led_preferences = p_payload -> 'preferences',
+                   led_revision = led_revision + 1,
+                   led_updated_at = clock_timestamp()
+             WHERE user_id = p_user_id
+               AND local_profile_id = p_local_profile_id
+               AND led_revision = p_base_revision
+            RETURNING * INTO current_row;
+        WHEN 'VBT' THEN
+            UPDATE public.local_profile_preferences
+               SET vbt_enabled = (p_payload ->> 'vbtEnabled')::boolean,
+                   vbt_preferences = p_payload -> 'preferences',
+                   vbt_revision = vbt_revision + 1,
+                   vbt_updated_at = clock_timestamp()
+             WHERE user_id = p_user_id
+               AND local_profile_id = p_local_profile_id
+               AND vbt_revision = p_base_revision
+            RETURNING * INTO current_row;
+    END CASE;
+
+    IF FOUND THEN
+        canonical_section := public.local_profile_preference_section_canonical(current_row, p_section);
+        server_revision := (canonical_section ->> 'serverRevision')::bigint;
+        RETURN QUERY SELECT true, NULL::text, server_revision, canonical_section;
+        RETURN;
+    END IF;
+
+    IF p_base_revision = 0 THEN
+        INSERT INTO public.local_profile_preferences (
+            user_id, local_profile_id,
+            body_weight_kg, weight_unit, weight_increment, core_revision,
+            equipment_rack, rack_revision,
+            workout_preferences, workout_revision,
+            led_color_scheme_id, led_preferences, led_revision,
+            vbt_enabled, vbt_preferences, vbt_revision
+        ) VALUES (
+            p_user_id,
+            p_local_profile_id,
+            CASE WHEN p_section = 'CORE' THEN (p_payload ->> 'bodyWeightKg')::double precision ELSE 0 END,
+            CASE WHEN p_section = 'CORE' THEN p_payload ->> 'weightUnit' ELSE 'LB' END,
+            CASE WHEN p_section = 'CORE' THEN (p_payload ->> 'weightIncrement')::double precision ELSE -1 END,
+            CASE WHEN p_section = 'CORE' THEN 1 ELSE 0 END,
+            CASE WHEN p_section = 'RACK' THEN p_payload ELSE '{"version":1,"items":[]}'::jsonb END,
+            CASE WHEN p_section = 'RACK' THEN 1 ELSE 0 END,
+            CASE WHEN p_section = 'WORKOUT' THEN p_payload ELSE '{"version":1}'::jsonb END,
+            CASE WHEN p_section = 'WORKOUT' THEN 1 ELSE 0 END,
+            CASE WHEN p_section = 'LED' THEN (p_payload ->> 'ledColorSchemeId')::integer ELSE 0 END,
+            CASE WHEN p_section = 'LED' THEN p_payload -> 'preferences' ELSE '{"version":1,"discoModeUnlocked":false}'::jsonb END,
+            CASE WHEN p_section = 'LED' THEN 1 ELSE 0 END,
+            CASE WHEN p_section = 'VBT' THEN (p_payload ->> 'vbtEnabled')::boolean ELSE true END,
+            CASE WHEN p_section = 'VBT' THEN p_payload -> 'preferences' ELSE '{"version":1,"velocityLossThresholdPercent":20,"autoEndOnVelocityLoss":false,"defaultScalingBasis":"MAX_WEIGHT_PR","verbalEncouragementEnabled":false,"vulgarModeEnabled":false,"vulgarTier":"STRONG","dominatrixModeUnlocked":false,"dominatrixModeActive":false}'::jsonb END,
+            CASE WHEN p_section = 'VBT' THEN 1 ELSE 0 END
+        )
+        ON CONFLICT (user_id, local_profile_id) DO NOTHING
+        RETURNING * INTO current_row;
+
+        IF FOUND THEN
+            canonical_section := public.local_profile_preference_section_canonical(current_row, p_section);
+            server_revision := (canonical_section ->> 'serverRevision')::bigint;
+            RETURN QUERY SELECT true, NULL::text, server_revision, canonical_section;
+            RETURN;
+        END IF;
+
+        CASE p_section
+            WHEN 'CORE' THEN
+                UPDATE public.local_profile_preferences
+                   SET body_weight_kg = (p_payload ->> 'bodyWeightKg')::double precision,
+                       weight_unit = p_payload ->> 'weightUnit',
+                       weight_increment = (p_payload ->> 'weightIncrement')::double precision,
+                       core_revision = 1,
+                       core_updated_at = clock_timestamp()
+                 WHERE user_id = p_user_id AND local_profile_id = p_local_profile_id AND core_revision = 0
+                RETURNING * INTO current_row;
+            WHEN 'RACK' THEN
+                UPDATE public.local_profile_preferences
+                   SET equipment_rack = p_payload, rack_revision = 1, rack_updated_at = clock_timestamp()
+                 WHERE user_id = p_user_id AND local_profile_id = p_local_profile_id AND rack_revision = 0
+                RETURNING * INTO current_row;
+            WHEN 'WORKOUT' THEN
+                UPDATE public.local_profile_preferences
+                   SET workout_preferences = p_payload, workout_revision = 1, workout_updated_at = clock_timestamp()
+                 WHERE user_id = p_user_id AND local_profile_id = p_local_profile_id AND workout_revision = 0
+                RETURNING * INTO current_row;
+            WHEN 'LED' THEN
+                UPDATE public.local_profile_preferences
+                   SET led_color_scheme_id = (p_payload ->> 'ledColorSchemeId')::integer,
+                       led_preferences = p_payload -> 'preferences',
+                       led_revision = 1,
+                       led_updated_at = clock_timestamp()
+                 WHERE user_id = p_user_id AND local_profile_id = p_local_profile_id AND led_revision = 0
+                RETURNING * INTO current_row;
+            WHEN 'VBT' THEN
+                UPDATE public.local_profile_preferences
+                   SET vbt_enabled = (p_payload ->> 'vbtEnabled')::boolean,
+                       vbt_preferences = p_payload -> 'preferences',
+                       vbt_revision = 1,
+                       vbt_updated_at = clock_timestamp()
+                 WHERE user_id = p_user_id AND local_profile_id = p_local_profile_id AND vbt_revision = 0
+                RETURNING * INTO current_row;
+        END CASE;
+
+        IF FOUND THEN
+            canonical_section := public.local_profile_preference_section_canonical(current_row, p_section);
+            server_revision := (canonical_section ->> 'serverRevision')::bigint;
+            RETURN QUERY SELECT true, NULL::text, server_revision, canonical_section;
+            RETURN;
+        END IF;
+    END IF;
+
+    SELECT * INTO current_row
+      FROM public.local_profile_preferences
+     WHERE user_id = p_user_id AND local_profile_id = p_local_profile_id;
+
+    IF NOT FOUND THEN
+        RETURN QUERY SELECT false, 'REVISION_CONFLICT', 0::bigint, NULL::jsonb;
+        RETURN;
+    END IF;
+
+    canonical_section := public.local_profile_preference_section_canonical(current_row, p_section);
+    current_revision := (canonical_section ->> 'serverRevision')::bigint;
+    RETURN QUERY SELECT false, 'REVISION_CONFLICT', current_revision, canonical_section;
+END
+$mutation$;
+
+REVOKE ALL ON FUNCTION public.local_profile_preference_section_canonical(
+    public.local_profile_preferences, text
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.mutate_local_profile_preference_section(
+    uuid, text, text, integer, bigint, jsonb
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.local_profile_preference_section_canonical(
+    public.local_profile_preferences, text
+) TO service_role;
+GRANT EXECUTE ON FUNCTION public.mutate_local_profile_preference_section(
+    uuid, text, text, integer, bigint, jsonb
+) TO service_role;
+
+ALTER TABLE public.local_profile_preferences ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS local_profile_preferences_owner_select ON public.local_profile_preferences;
+CREATE POLICY local_profile_preferences_owner_select
+    ON public.local_profile_preferences
+    FOR SELECT TO authenticated
+    USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS local_profile_preferences_owner_insert ON public.local_profile_preferences;
+CREATE POLICY local_profile_preferences_owner_insert
+    ON public.local_profile_preferences
+    FOR INSERT TO authenticated
+    WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS local_profile_preferences_owner_update ON public.local_profile_preferences;
+CREATE POLICY local_profile_preferences_owner_update
+    ON public.local_profile_preferences
+    FOR UPDATE TO authenticated
+    USING ((select auth.uid()) = user_id)
+    WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS local_profile_preferences_owner_delete ON public.local_profile_preferences;
+CREATE POLICY local_profile_preferences_owner_delete
+    ON public.local_profile_preferences
+    FOR DELETE TO authenticated
+    USING ((select auth.uid()) = user_id);
+
+REVOKE ALL ON TABLE public.local_profile_preferences FROM PUBLIC;
+REVOKE ALL ON TABLE public.local_profile_preferences FROM anon;
+REVOKE ALL ON TABLE public.local_profile_preferences FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.local_profile_preferences TO service_role;
+
+COMMIT;

--- a/supabase/migrations/20260715234034_profile_preferences.sql
+++ b/supabase/migrations/20260715234034_profile_preferences.sql
@@ -132,7 +132,11 @@ DECLARE
     primary_key_columns text[];
     parent_key_columns text[];
     referenced_key_columns text[];
+    schema_version_check_count integer;
+    exact_schema_version_check_count integer;
     revision_column_count integer;
+    revision_check_count integer;
+    exact_revision_check_count integer;
 BEGIN
     SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
       INTO primary_key_columns
@@ -184,19 +188,29 @@ BEGIN
             'profile preferences postcondition: expected cascading local_profiles parent foreign key';
     END IF;
 
-    IF NOT EXISTS (
-        SELECT 1
-          FROM pg_constraint constraint_row
-          JOIN pg_attribute attribute
-            ON attribute.attrelid = constraint_row.conrelid
-           AND attribute.attnum = ANY (constraint_row.conkey)
-         WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
-           AND constraint_row.contype = 'c'
-           AND attribute.attname = 'schema_version'
-           AND pg_get_constraintdef(constraint_row.oid) LIKE '%schema_version = 1%'
-    ) THEN
+    SELECT
+        count(*),
+        count(*) FILTER (
+            WHERE constraint_row.conkey = ARRAY[attribute.attnum]::smallint[]
+              AND btrim(regexp_replace(
+                  pg_get_expr(constraint_row.conbin, constraint_row.conrelid, true),
+                  '[[:space:]]+',
+                  ' ',
+                  'g'
+              )) = 'schema_version = 1'
+        )
+      INTO schema_version_check_count, exact_schema_version_check_count
+      FROM pg_constraint constraint_row
+      JOIN pg_attribute attribute
+        ON attribute.attrelid = constraint_row.conrelid
+       AND attribute.attname = 'schema_version'
+       AND attribute.attnum = ANY (constraint_row.conkey)
+     WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+       AND constraint_row.contype = 'c';
+
+    IF schema_version_check_count <> 1 OR exact_schema_version_check_count <> 1 THEN
         RAISE EXCEPTION
-            'profile preferences postcondition: expected schema_version = 1 check';
+            'profile preferences postcondition: expected exactly one single-column schema_version = 1 check';
     END IF;
 
     SELECT count(*)
@@ -216,19 +230,58 @@ BEGIN
        AND NOT attribute.attisdropped
        AND attribute.atttypid = 'pg_catalog.int8'::regtype
        AND attribute.attnotnull
-       AND pg_get_expr(default_row.adbin, default_row.adrelid) = '0'
+       AND pg_get_expr(default_row.adbin, default_row.adrelid) = '0';
+
+    SELECT count(*)
+      INTO revision_check_count
+      FROM pg_constraint constraint_row
+     WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+       AND constraint_row.contype = 'c'
+       AND constraint_row.conkey && ARRAY(
+           SELECT attribute.attnum
+             FROM pg_attribute attribute
+            WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+              AND attribute.attname IN (
+                  'core_revision',
+                  'rack_revision',
+                  'workout_revision',
+                  'led_revision',
+                  'vbt_revision'
+              )
+              AND NOT attribute.attisdropped
+       );
+
+    SELECT count(*)
+      INTO exact_revision_check_count
+      FROM pg_attribute attribute
+     WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+       AND attribute.attname IN (
+           'core_revision',
+           'rack_revision',
+           'workout_revision',
+           'led_revision',
+           'vbt_revision'
+       )
+       AND NOT attribute.attisdropped
        AND EXISTS (
            SELECT 1
              FROM pg_constraint constraint_row
             WHERE constraint_row.conrelid = attribute.attrelid
               AND constraint_row.contype = 'c'
-              AND attribute.attnum = ANY (constraint_row.conkey)
-              AND pg_get_constraintdef(constraint_row.oid) LIKE '%>= 0%'
+              AND constraint_row.conkey = ARRAY[attribute.attnum]::smallint[]
+              AND btrim(regexp_replace(
+                  pg_get_expr(constraint_row.conbin, constraint_row.conrelid, true),
+                  '[[:space:]]+',
+                  ' ',
+                  'g'
+              )) = format('%I >= 0', attribute.attname)
        );
 
-    IF revision_column_count <> 5 THEN
+    IF revision_column_count <> 5
+       OR revision_check_count <> 5
+       OR exact_revision_check_count <> 5 THEN
         RAISE EXCEPTION
-            'profile preferences postcondition: expected five nonnegative bigint section revision columns';
+            'profile preferences postcondition: expected five independent single-column nonnegative bigint section revisions';
     END IF;
 END
 $postcondition$;

--- a/supabase/migrations/20260715234034_profile_preferences.sql
+++ b/supabase/migrations/20260715234034_profile_preferences.sql
@@ -384,6 +384,7 @@ BEGIN
         RETURN;
     END IF;
 
+    BEGIN
     CASE p_section
         WHEN 'CORE' THEN
             UPDATE public.local_profile_preferences
@@ -537,6 +538,14 @@ BEGIN
     canonical_section := public.local_profile_preference_section_canonical(current_row, p_section);
     current_revision := (canonical_section ->> 'serverRevision')::bigint;
     RETURN QUERY SELECT false, 'REVISION_CONFLICT', current_revision, canonical_section;
+    EXCEPTION
+        WHEN check_violation
+          OR not_null_violation
+          OR numeric_value_out_of_range
+          OR invalid_text_representation THEN
+            RETURN QUERY SELECT false, 'VALIDATION_FAILED', 0::bigint, NULL::jsonb;
+            RETURN;
+    END;
 END
 $mutation$;
 

--- a/supabase/tests/database/profile_preferences.test.sql
+++ b/supabase/tests/database/profile_preferences.test.sql
@@ -950,5 +950,94 @@ SELECT results_eq(
     'invalid section, version, payload, and unknown profile return explicit rejection rows'
 );
 
+CREATE TEMP TABLE malformed_preference_rejection_results (
+    case_name text NOT NULL,
+    accepted boolean,
+    rejection_reason text,
+    server_revision bigint,
+    canonical_section jsonb
+) ON COMMIT DROP;
+
+SELECT lives_ok(
+    $sql$
+        INSERT INTO malformed_preference_rejection_results
+        SELECT malformed_case.case_name, result.*
+        FROM (
+            VALUES
+                ('empty-core', 'CORE', 1::bigint, '{}'::jsonb),
+                ('empty-rack', 'RACK', 1::bigint, '{}'::jsonb),
+                ('empty-workout', 'WORKOUT', 2::bigint, '{}'::jsonb),
+                ('empty-led', 'LED', 1::bigint, '{}'::jsonb),
+                ('empty-vbt', 'VBT', 1::bigint, '{}'::jsonb),
+                (
+                    'invalid-core-number',
+                    'CORE',
+                    1::bigint,
+                    '{"bodyWeightKg":"heavy","weightUnit":"KG","weightIncrement":2.5}'::jsonb
+                ),
+                (
+                    'invalid-rack-items',
+                    'RACK',
+                    1::bigint,
+                    '{"version":1,"items":"not-an-array"}'::jsonb
+                ),
+                (
+                    'overflow-workout-countdown',
+                    'WORKOUT',
+                    2::bigint,
+                    '{"version":1,"summaryCountdownSeconds":999999999999999999999}'::jsonb
+                ),
+                (
+                    'invalid-led-scheme',
+                    'LED',
+                    1::bigint,
+                    '{"ledColorSchemeId":"bright","preferences":{"version":1,"discoModeUnlocked":false}}'::jsonb
+                ),
+                (
+                    'invalid-vbt-enabled',
+                    'VBT',
+                    1::bigint,
+                    '{"vbtEnabled":"sometimes","preferences":{"version":1,"velocityLossThresholdPercent":20}}'::jsonb
+                )
+        ) AS malformed_case(case_name, section_name, base_revision, payload)
+        CROSS JOIN LATERAL public.mutate_local_profile_preference_section(
+            '11111111-1111-4111-8111-111111111111'::uuid,
+            'all-sections',
+            malformed_case.section_name,
+            1,
+            malformed_case.base_revision,
+            malformed_case.payload
+        ) AS result
+    $sql$,
+    'malformed section objects return rejection rows without raising database exceptions'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            case_name COLLATE "C",
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            canonical_section
+        FROM malformed_preference_rejection_results
+        ORDER BY case_name
+    $sql$,
+    $values$
+        VALUES
+            ('empty-core'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('empty-led'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('empty-rack'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('empty-vbt'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('empty-workout'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('invalid-core-number'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('invalid-led-scheme'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('invalid-rack-items'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('invalid-vbt-enabled'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('overflow-workout-countdown'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb)
+    $values$,
+    'malformed section objects return the exact validation rejection contract'
+);
+
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/database/profile_preferences.test.sql
+++ b/supabase/tests/database/profile_preferences.test.sql
@@ -1039,5 +1039,114 @@ SELECT results_eq(
     'malformed section objects return the exact validation rejection contract'
 );
 
+CREATE TEMP TABLE required_nested_key_state_before ON COMMIT DROP AS
+SELECT
+    rack_revision,
+    equipment_rack,
+    led_revision,
+    led_preferences,
+    vbt_revision,
+    vbt_preferences
+FROM public.local_profile_preferences
+WHERE user_id = '11111111-1111-4111-8111-111111111111'::uuid
+  AND local_profile_id = 'all-sections';
+
+CREATE TEMP TABLE missing_required_key_results (
+    case_name text NOT NULL,
+    accepted boolean,
+    rejection_reason text,
+    server_revision bigint,
+    canonical_section jsonb
+) ON COMMIT DROP;
+
+INSERT INTO missing_required_key_results
+SELECT missing_key_case.case_name, result.*
+FROM (
+    VALUES
+        ('missing-rack-items', 'RACK', 1::bigint, '{"version":1}'::jsonb),
+        (
+            'missing-led-flag',
+            'LED',
+            1::bigint,
+            '{"ledColorSchemeId":3,"preferences":{"version":1}}'::jsonb
+        ),
+        (
+            'missing-vbt-threshold',
+            'VBT',
+            1::bigint,
+            '{"vbtEnabled":false,"preferences":{"version":1}}'::jsonb
+        )
+) AS missing_key_case(case_name, section_name, base_revision, payload)
+CROSS JOIN LATERAL public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    missing_key_case.section_name,
+    1,
+    missing_key_case.base_revision,
+    missing_key_case.payload
+) AS result;
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            case_name COLLATE "C",
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            canonical_section
+        FROM missing_required_key_results
+        ORDER BY case_name
+    $sql$,
+    $values$
+        VALUES
+            ('missing-led-flag'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('missing-rack-items'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('missing-vbt-threshold'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb)
+    $values$,
+    'missing required nested keys return the exact validation rejection contract'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            current_row.rack_revision = before_row.rack_revision,
+            current_row.equipment_rack = before_row.equipment_rack,
+            current_row.led_revision = before_row.led_revision,
+            current_row.led_preferences = before_row.led_preferences,
+            current_row.vbt_revision = before_row.vbt_revision,
+            current_row.vbt_preferences = before_row.vbt_preferences
+        FROM public.local_profile_preferences AS current_row
+        CROSS JOIN required_nested_key_state_before AS before_row
+        WHERE current_row.user_id = '11111111-1111-4111-8111-111111111111'::uuid
+          AND current_row.local_profile_id = 'all-sections'
+    $sql$,
+    $values$
+        VALUES (true, true, true, true, true, true)
+    $values$,
+    'missing required nested keys do not change stored payloads or revisions'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            canonical_section -> 'payload'
+        FROM public.mutate_local_profile_preference_section(
+            '11111111-1111-4111-8111-111111111111'::uuid,
+            'all-sections',
+            'WORKOUT',
+            1,
+            2,
+            '{"version":1}'::jsonb
+        )
+    $sql$,
+    $values$
+        VALUES (true, NULL::text COLLATE "C", 3::bigint, '{"version":1}'::jsonb)
+    $values$,
+    'WORKOUT fields remain optional when the required version is present'
+);
+
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/database/profile_preferences.test.sql
+++ b/supabase/tests/database/profile_preferences.test.sql
@@ -93,18 +93,39 @@ SELECT is(
 
 SELECT is(
     (
-        SELECT count(*)
-        FROM pg_constraint constraint_row
-        JOIN pg_attribute attribute
-          ON attribute.attrelid = constraint_row.conrelid
-         AND attribute.attnum = ANY (constraint_row.conkey)
-        WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
-          AND constraint_row.contype = 'c'
-          AND attribute.attname = 'schema_version'
-          AND pg_get_constraintdef(constraint_row.oid) LIKE '%schema_version = 1%'
+        SELECT jsonb_agg(
+            jsonb_build_object(
+                'name', check_row.constraint_name,
+                'columns', check_row.constraint_columns,
+                'expression', check_row.normalized_expression
+            )
+            ORDER BY check_row.constraint_name
+        )
+        FROM (
+            SELECT
+                constraint_row.conname::text AS constraint_name,
+                array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+                    AS constraint_columns,
+                btrim(regexp_replace(
+                    pg_get_expr(constraint_row.conbin, constraint_row.conrelid, true),
+                    '[[:space:]]+',
+                    ' ',
+                    'g'
+                )) AS normalized_expression
+            FROM pg_constraint constraint_row
+            CROSS JOIN LATERAL unnest(constraint_row.conkey)
+                WITH ORDINALITY AS key_column(attnum, ordinality)
+            JOIN pg_attribute attribute
+              ON attribute.attrelid = constraint_row.conrelid
+             AND attribute.attnum = key_column.attnum
+            WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+              AND constraint_row.contype = 'c'
+            GROUP BY constraint_row.oid
+            HAVING bool_or(attribute.attname = 'schema_version')
+        ) AS check_row
     ),
-    1::bigint,
-    'schema_version is constrained to version 1'
+    '[{"name":"local_profile_preferences_schema_version_check","columns":["schema_version"],"expression":"schema_version = 1"}]'::jsonb,
+    'schema_version has exactly one single-column version-1 check expression'
 );
 
 SELECT results_eq(
@@ -138,21 +159,48 @@ SELECT results_eq(
 
 SELECT is(
     (
-        SELECT count(DISTINCT attribute.attname)
-        FROM pg_constraint constraint_row
-        JOIN pg_attribute attribute
-          ON attribute.attrelid = constraint_row.conrelid
-         AND attribute.attnum = ANY (constraint_row.conkey)
-        WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
-          AND constraint_row.contype = 'c'
-          AND attribute.attname IN (
-              'core_revision', 'rack_revision', 'workout_revision',
-              'led_revision', 'vbt_revision'
-          )
-          AND pg_get_constraintdef(constraint_row.oid) LIKE '%>= 0%'
+        SELECT jsonb_agg(
+            jsonb_build_object(
+                'name', check_row.constraint_name,
+                'columns', check_row.constraint_columns,
+                'expression', check_row.normalized_expression
+            )
+            ORDER BY check_row.constraint_name
+        )
+        FROM (
+            SELECT
+                constraint_row.conname::text AS constraint_name,
+                array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+                    AS constraint_columns,
+                btrim(regexp_replace(
+                    pg_get_expr(constraint_row.conbin, constraint_row.conrelid, true),
+                    '[[:space:]]+',
+                    ' ',
+                    'g'
+                )) AS normalized_expression
+            FROM pg_constraint constraint_row
+            CROSS JOIN LATERAL unnest(constraint_row.conkey)
+                WITH ORDINALITY AS key_column(attnum, ordinality)
+            JOIN pg_attribute attribute
+              ON attribute.attrelid = constraint_row.conrelid
+             AND attribute.attnum = key_column.attnum
+            WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+              AND constraint_row.contype = 'c'
+            GROUP BY constraint_row.oid
+            HAVING bool_or(attribute.attname = ANY (ARRAY[
+                'core_revision', 'rack_revision', 'workout_revision',
+                'led_revision', 'vbt_revision'
+            ]::name[]))
+        ) AS check_row
     ),
-    5::bigint,
-    'each section revision has its own nonnegative check constraint'
+    '[
+        {"name":"local_profile_preferences_core_revision_check","columns":["core_revision"],"expression":"core_revision >= 0"},
+        {"name":"local_profile_preferences_led_revision_check","columns":["led_revision"],"expression":"led_revision >= 0"},
+        {"name":"local_profile_preferences_rack_revision_check","columns":["rack_revision"],"expression":"rack_revision >= 0"},
+        {"name":"local_profile_preferences_vbt_revision_check","columns":["vbt_revision"],"expression":"vbt_revision >= 0"},
+        {"name":"local_profile_preferences_workout_revision_check","columns":["workout_revision"],"expression":"workout_revision >= 0"}
+    ]'::jsonb,
+    'each revision has exactly one independent single-column nonnegative check expression'
 );
 
 SELECT results_eq(
@@ -502,10 +550,19 @@ SELECT set_config(
     true
 );
 
-SELECT is(
-    (SELECT count(*) FROM public.local_profile_preferences),
-    1::bigint,
-    'owner A can read only owner A preference rows'
+SELECT results_eq(
+    $sql$
+        SELECT user_id, local_profile_id COLLATE "C"
+        FROM public.local_profile_preferences
+        ORDER BY user_id, local_profile_id
+    $sql$,
+    $values$
+        VALUES (
+            '11111111-1111-4111-8111-111111111111'::uuid,
+            'shared'::text COLLATE "C"
+        )
+    $values$,
+    'owner A sees exactly owner A preference identity and no owner B row'
 );
 
 SELECT is(
@@ -641,6 +698,40 @@ SELECT results_eq(
     'all five sections accept base revision zero as server revision one'
 );
 
+SELECT results_eq(
+    $sql$
+        SELECT
+            section COLLATE "C",
+            canonical_section -> 'payload'
+        FROM preference_mutation_results
+        ORDER BY section
+    $sql$,
+    $values$
+        VALUES
+            (
+                'CORE'::text COLLATE "C",
+                '{"bodyWeightKg":82.5,"weightUnit":"KG","weightIncrement":2.5}'::jsonb
+            ),
+            (
+                'LED'::text COLLATE "C",
+                '{"ledColorSchemeId":3,"preferences":{"version":1,"discoModeUnlocked":true}}'::jsonb
+            ),
+            (
+                'RACK'::text COLLATE "C",
+                '{"version":1,"items":[{"id":"rack-1","weightKg":20}]}'::jsonb
+            ),
+            (
+                'VBT'::text COLLATE "C",
+                '{"vbtEnabled":false,"preferences":{"version":1,"velocityLossThresholdPercent":25,"autoEndOnVelocityLoss":true,"defaultScalingBasis":"MAX_WEIGHT_PR","verbalEncouragementEnabled":true,"vulgarModeEnabled":false,"vulgarTier":"STRONG","dominatrixModeUnlocked":false,"dominatrixModeActive":false}}'::jsonb
+            ),
+            (
+                'WORKOUT'::text COLLATE "C",
+                '{"version":1,"summaryCountdownSeconds":10,"autoStartCountdownSeconds":3,"defaultRoutineExerciseWeightPercentOfPR":75}'::jsonb
+            )
+    $values$,
+    'base-zero accepts return the exact canonical payload for every section'
+);
+
 SELECT is(
     (
         SELECT ARRAY[
@@ -718,6 +809,37 @@ SELECT results_eq(
         )
     $values$,
     'matching-base mutation returns the targeted canonical version-1 WORKOUT document'
+);
+
+SELECT is(
+    (
+        SELECT jsonb_build_object(
+            'CORE', jsonb_build_object(
+                'bodyWeightKg', body_weight_kg,
+                'weightUnit', weight_unit,
+                'weightIncrement', weight_increment
+            ),
+            'RACK', equipment_rack,
+            'LED', jsonb_build_object(
+                'ledColorSchemeId', led_color_scheme_id,
+                'preferences', led_preferences
+            ),
+            'VBT', jsonb_build_object(
+                'vbtEnabled', vbt_enabled,
+                'preferences', vbt_preferences
+            )
+        )
+        FROM public.local_profile_preferences
+        WHERE user_id = '11111111-1111-4111-8111-111111111111'::uuid
+          AND local_profile_id = 'all-sections'
+    ),
+    '{
+        "CORE":{"bodyWeightKg":82.5,"weightUnit":"KG","weightIncrement":2.5},
+        "RACK":{"version":1,"items":[{"id":"rack-1","weightKg":20}]},
+        "LED":{"ledColorSchemeId":3,"preferences":{"version":1,"discoModeUnlocked":true}},
+        "VBT":{"vbtEnabled":false,"preferences":{"version":1,"velocityLossThresholdPercent":25,"autoEndOnVelocityLoss":true,"defaultScalingBasis":"MAX_WEIGHT_PR","verbalEncouragementEnabled":true,"vulgarModeEnabled":false,"vulgarTier":"STRONG","dominatrixModeUnlocked":false,"dominatrixModeActive":false}}
+    }'::jsonb,
+    'matching WORKOUT mutation preserves exact CORE, RACK, LED, and VBT siblings'
 );
 
 TRUNCATE preference_mutation_results;

--- a/supabase/tests/database/profile_preferences.test.sql
+++ b/supabase/tests/database/profile_preferences.test.sql
@@ -1,0 +1,832 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+SET LOCAL search_path = public, extensions;
+
+SELECT no_plan();
+
+SELECT diag('database:exact-function-acls-and-no-client-dml');
+
+SELECT has_table(
+    'public',
+    'local_profile_preferences',
+    'profile preferences table exists'
+);
+
+SELECT is(
+    (
+        SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+        FROM pg_constraint constraint_row
+        CROSS JOIN LATERAL unnest(constraint_row.conkey)
+            WITH ORDINALITY AS key_column(attnum, ordinality)
+        JOIN pg_attribute attribute
+          ON attribute.attrelid = constraint_row.conrelid
+         AND attribute.attnum = key_column.attnum
+        WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+          AND constraint_row.contype = 'p'
+    ),
+    ARRAY['user_id', 'local_profile_id']::text[],
+    'table primary key is exactly (user_id, local_profile_id)'
+);
+
+SELECT is(
+    (
+        SELECT jsonb_build_object(
+            'childColumns', array_agg(child_attribute.attname::text ORDER BY child_key.ordinality),
+            'referencedSchema', referenced_namespace.nspname,
+            'referencedTable', referenced_table.relname,
+            'referencedColumns', array_agg(parent_attribute.attname::text ORDER BY child_key.ordinality),
+            'deleteAction', constraint_row.confdeltype
+        )
+        FROM pg_constraint constraint_row
+        CROSS JOIN LATERAL unnest(constraint_row.conkey)
+            WITH ORDINALITY AS child_key(attnum, ordinality)
+        CROSS JOIN LATERAL unnest(constraint_row.confkey)
+            WITH ORDINALITY AS parent_key(attnum, ordinality)
+        JOIN pg_attribute child_attribute
+          ON child_attribute.attrelid = constraint_row.conrelid
+         AND child_attribute.attnum = child_key.attnum
+        JOIN pg_class referenced_table
+          ON referenced_table.oid = constraint_row.confrelid
+        JOIN pg_namespace referenced_namespace
+          ON referenced_namespace.oid = referenced_table.relnamespace
+        JOIN pg_attribute parent_attribute
+          ON parent_attribute.attrelid = constraint_row.confrelid
+         AND parent_attribute.attnum = parent_key.attnum
+        WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+          AND constraint_row.contype = 'f'
+          AND child_key.ordinality = parent_key.ordinality
+        GROUP BY constraint_row.oid,
+                 referenced_namespace.nspname,
+                 referenced_table.relname,
+                 constraint_row.confdeltype
+    ),
+    '{"childColumns":["user_id","local_profile_id"],"referencedSchema":"public","referencedTable":"local_profiles","referencedColumns":["user_id","id"],"deleteAction":"c"}'::jsonb,
+    'table has exactly one composite local_profiles foreign key with ON DELETE CASCADE'
+);
+
+SELECT is(
+    (
+        SELECT format_type(attribute.atttypid, attribute.atttypmod)
+        FROM pg_attribute attribute
+        WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+          AND attribute.attname = 'schema_version'
+          AND NOT attribute.attisdropped
+    ),
+    'integer'::text,
+    'schema_version is integer'
+);
+
+SELECT is(
+    (
+        SELECT pg_get_expr(default_row.adbin, default_row.adrelid)
+        FROM pg_attribute attribute
+        JOIN pg_attrdef default_row
+          ON default_row.adrelid = attribute.attrelid
+         AND default_row.adnum = attribute.attnum
+        WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+          AND attribute.attname = 'schema_version'
+    ),
+    '1'::text,
+    'schema_version defaults to contract version 1'
+);
+
+SELECT is(
+    (
+        SELECT count(*)
+        FROM pg_constraint constraint_row
+        JOIN pg_attribute attribute
+          ON attribute.attrelid = constraint_row.conrelid
+         AND attribute.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute.attname = 'schema_version'
+          AND pg_get_constraintdef(constraint_row.oid) LIKE '%schema_version = 1%'
+    ),
+    1::bigint,
+    'schema_version is constrained to version 1'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            attribute.attname::text COLLATE "C",
+            format_type(attribute.atttypid, attribute.atttypmod)::text COLLATE "C",
+            attribute.attnotnull,
+            pg_get_expr(default_row.adbin, default_row.adrelid)::text COLLATE "C"
+        FROM pg_attribute attribute
+        JOIN pg_attrdef default_row
+          ON default_row.adrelid = attribute.attrelid
+         AND default_row.adnum = attribute.attnum
+        WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+          AND attribute.attname IN (
+              'core_revision', 'rack_revision', 'workout_revision',
+              'led_revision', 'vbt_revision'
+          )
+        ORDER BY attribute.attname
+    $sql$,
+    $values$
+        VALUES
+            ('core_revision'::text COLLATE "C", 'bigint'::text COLLATE "C", true, '0'::text COLLATE "C"),
+            ('led_revision'::text COLLATE "C", 'bigint'::text COLLATE "C", true, '0'::text COLLATE "C"),
+            ('rack_revision'::text COLLATE "C", 'bigint'::text COLLATE "C", true, '0'::text COLLATE "C"),
+            ('vbt_revision'::text COLLATE "C", 'bigint'::text COLLATE "C", true, '0'::text COLLATE "C"),
+            ('workout_revision'::text COLLATE "C", 'bigint'::text COLLATE "C", true, '0'::text COLLATE "C")
+    $values$,
+    'the five section revisions are independent non-null bigint counters defaulting to zero'
+);
+
+SELECT is(
+    (
+        SELECT count(DISTINCT attribute.attname)
+        FROM pg_constraint constraint_row
+        JOIN pg_attribute attribute
+          ON attribute.attrelid = constraint_row.conrelid
+         AND attribute.attnum = ANY (constraint_row.conkey)
+        WHERE constraint_row.conrelid = 'public.local_profile_preferences'::regclass
+          AND constraint_row.contype = 'c'
+          AND attribute.attname IN (
+              'core_revision', 'rack_revision', 'workout_revision',
+              'led_revision', 'vbt_revision'
+          )
+          AND pg_get_constraintdef(constraint_row.oid) LIKE '%>= 0%'
+    ),
+    5::bigint,
+    'each section revision has its own nonnegative check constraint'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            attribute.attname::text COLLATE "C",
+            format_type(attribute.atttypid, attribute.atttypmod)::text COLLATE "C",
+            attribute.attnotnull,
+            (default_row.oid IS NOT NULL) AS has_default
+        FROM pg_attribute attribute
+        LEFT JOIN pg_attrdef default_row
+          ON default_row.adrelid = attribute.attrelid
+         AND default_row.adnum = attribute.attnum
+        WHERE attribute.attrelid = 'public.local_profile_preferences'::regclass
+          AND attribute.attname IN (
+              'core_updated_at', 'rack_updated_at', 'workout_updated_at',
+              'led_updated_at', 'vbt_updated_at'
+          )
+        ORDER BY attribute.attname
+    $sql$,
+    $values$
+        VALUES
+            ('core_updated_at'::text COLLATE "C", 'timestamp with time zone'::text COLLATE "C", true, true),
+            ('led_updated_at'::text COLLATE "C", 'timestamp with time zone'::text COLLATE "C", true, true),
+            ('rack_updated_at'::text COLLATE "C", 'timestamp with time zone'::text COLLATE "C", true, true),
+            ('vbt_updated_at'::text COLLATE "C", 'timestamp with time zone'::text COLLATE "C", true, true),
+            ('workout_updated_at'::text COLLATE "C", 'timestamp with time zone'::text COLLATE "C", true, true)
+    $values$,
+    'all five sections have independent non-null timestamps with defaults'
+);
+
+SELECT is(
+    (
+        SELECT count(*)
+        FROM pg_proc procedure_row
+        JOIN pg_namespace namespace_row
+          ON namespace_row.oid = procedure_row.pronamespace
+        WHERE namespace_row.nspname = 'public'
+          AND procedure_row.proname = 'local_profile_preference_section_canonical'
+    ),
+    1::bigint,
+    'canonical section function has exactly one public overload'
+);
+
+SELECT is(
+    (
+        SELECT count(*)
+        FROM pg_proc procedure_row
+        JOIN pg_namespace namespace_row
+          ON namespace_row.oid = procedure_row.pronamespace
+        WHERE namespace_row.nspname = 'public'
+          AND procedure_row.proname = 'mutate_local_profile_preference_section'
+    ),
+    1::bigint,
+    'mutation function has exactly one public overload'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            procedure_row.proname::text COLLATE "C",
+            pg_get_userbyid(procedure_row.proowner)::text COLLATE "C",
+            procedure_row.provolatile::text COLLATE "C",
+            procedure_row.prosecdef,
+            procedure_row.proretset,
+            format_type(procedure_row.prorettype, NULL)::text COLLATE "C",
+            procedure_row.proconfig COLLATE "C"
+        FROM pg_proc procedure_row
+        WHERE procedure_row.oid IN (
+            'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'::regprocedure,
+            'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'::regprocedure
+        )
+        ORDER BY procedure_row.proname
+    $sql$,
+    $values$
+        VALUES
+            (
+                'local_profile_preference_section_canonical'::text COLLATE "C",
+                'postgres'::text COLLATE "C",
+                's'::text COLLATE "C",
+                false,
+                false,
+                'jsonb'::text COLLATE "C",
+                ARRAY['search_path=""']::text[] COLLATE "C"
+            ),
+            (
+                'mutate_local_profile_preference_section'::text COLLATE "C",
+                'postgres'::text COLLATE "C",
+                'v'::text COLLATE "C",
+                false,
+                true,
+                'record'::text COLLATE "C",
+                ARRAY['search_path=""']::text[] COLLATE "C"
+            )
+    $values$,
+    'functions have exact owners, volatility, SECURITY INVOKER, return modes, and empty search_path'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            procedure_row.proname::text COLLATE "C",
+            procedure_row.proargnames COLLATE "C",
+            procedure_row.proargmodes,
+            ARRAY(
+                SELECT format_type(argument_type, NULL)
+                FROM unnest(procedure_row.proallargtypes)
+                    WITH ORDINALITY AS argument(argument_type, ordinality)
+                WHERE ordinality > procedure_row.pronargs
+                ORDER BY ordinality
+            )::text[] COLLATE "C" AS output_types
+        FROM pg_proc procedure_row
+        WHERE procedure_row.oid =
+            'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'::regprocedure
+    $sql$,
+    $values$
+        VALUES (
+            'mutate_local_profile_preference_section'::text COLLATE "C",
+            ARRAY[
+                'p_user_id', 'p_local_profile_id', 'p_section',
+                'p_document_version', 'p_base_revision', 'p_payload',
+                'accepted', 'rejection_reason', 'server_revision', 'canonical_section'
+            ]::text[] COLLATE "C",
+            ARRAY['i', 'i', 'i', 'i', 'i', 'i', 't', 't', 't', 't']::"char"[],
+            ARRAY['boolean', 'text', 'bigint', 'jsonb']::text[] COLLATE "C"
+        )
+    $values$,
+    'mutation function has the exact named input and TABLE return shape'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            procedure_row.proname::text COLLATE "C" AS function_name,
+            CASE
+                WHEN access_row.grantee = 0 THEN 'PUBLIC'
+                ELSE pg_get_userbyid(access_row.grantee)
+            END::text COLLATE "C" AS grantee,
+            access_row.privilege_type::text COLLATE "C",
+            access_row.is_grantable
+        FROM pg_proc procedure_row
+        CROSS JOIN LATERAL aclexplode(
+            COALESCE(procedure_row.proacl, acldefault('f', procedure_row.proowner))
+        ) AS access_row
+        WHERE procedure_row.oid IN (
+            'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'::regprocedure,
+            'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'::regprocedure
+        )
+          AND access_row.grantee <> procedure_row.proowner
+        ORDER BY function_name, grantee, privilege_type
+    $sql$,
+    $values$
+        VALUES
+            (
+                'local_profile_preference_section_canonical'::text COLLATE "C",
+                'service_role'::text COLLATE "C",
+                'EXECUTE'::text COLLATE "C",
+                false
+            ),
+            (
+                'mutate_local_profile_preference_section'::text COLLATE "C",
+                'service_role'::text COLLATE "C",
+                'EXECUTE'::text COLLATE "C",
+                false
+            )
+    $values$,
+    'service_role is the only non-owner function executor'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            role_name::text COLLATE "C",
+            function_name::text COLLATE "C",
+            has_function_privilege(
+                role_name,
+                function_name,
+                'EXECUTE'
+            )
+        FROM (VALUES
+            ('anon', 'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'),
+            ('anon', 'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'),
+            ('authenticated', 'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'),
+            ('authenticated', 'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'),
+            ('service_role', 'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'),
+            ('service_role', 'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)')
+        ) AS expected_access(role_name, function_name)
+        ORDER BY role_name, function_name
+    $sql$,
+    $values$
+        VALUES
+            ('anon'::text COLLATE "C", 'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'::text COLLATE "C", false),
+            ('anon'::text COLLATE "C", 'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'::text COLLATE "C", false),
+            ('authenticated'::text COLLATE "C", 'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'::text COLLATE "C", false),
+            ('authenticated'::text COLLATE "C", 'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'::text COLLATE "C", false),
+            ('service_role'::text COLLATE "C", 'public.local_profile_preference_section_canonical(public.local_profile_preferences,text)'::text COLLATE "C", true),
+            ('service_role'::text COLLATE "C", 'public.mutate_local_profile_preference_section(uuid,text,text,integer,bigint,jsonb)'::text COLLATE "C", true)
+    $values$,
+    'anon and authenticated cannot execute either function while service_role can'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            CASE
+                WHEN access_row.grantee = 0 THEN 'PUBLIC'
+                ELSE pg_get_userbyid(access_row.grantee)
+            END::text COLLATE "C" AS grantee,
+            access_row.privilege_type::text COLLATE "C",
+            access_row.is_grantable
+        FROM pg_class table_row
+        CROSS JOIN LATERAL aclexplode(
+            COALESCE(table_row.relacl, acldefault('r', table_row.relowner))
+        ) AS access_row
+        WHERE table_row.oid = 'public.local_profile_preferences'::regclass
+          AND access_row.grantee <> table_row.relowner
+          AND access_row.privilege_type IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE')
+        ORDER BY grantee, privilege_type
+    $sql$,
+    $values$
+        VALUES
+            ('service_role'::text COLLATE "C", 'DELETE'::text COLLATE "C", false),
+            ('service_role'::text COLLATE "C", 'INSERT'::text COLLATE "C", false),
+            ('service_role'::text COLLATE "C", 'SELECT'::text COLLATE "C", false),
+            ('service_role'::text COLLATE "C", 'UPDATE'::text COLLATE "C", false)
+    $values$,
+    'service_role has exactly SELECT, INSERT, UPDATE, and DELETE as the only non-owner table DML'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            role_name::text COLLATE "C",
+            privilege_name::text COLLATE "C",
+            has_table_privilege(
+                role_name,
+                'public.local_profile_preferences',
+                privilege_name
+            )
+        FROM (VALUES ('anon'), ('authenticated')) AS roles(role_name)
+        CROSS JOIN (VALUES ('SELECT'), ('INSERT'), ('UPDATE'), ('DELETE')) AS privileges(privilege_name)
+        ORDER BY role_name, privilege_name
+    $sql$,
+    $values$
+        VALUES
+            ('anon'::text COLLATE "C", 'DELETE'::text COLLATE "C", false),
+            ('anon'::text COLLATE "C", 'INSERT'::text COLLATE "C", false),
+            ('anon'::text COLLATE "C", 'SELECT'::text COLLATE "C", false),
+            ('anon'::text COLLATE "C", 'UPDATE'::text COLLATE "C", false),
+            ('authenticated'::text COLLATE "C", 'DELETE'::text COLLATE "C", false),
+            ('authenticated'::text COLLATE "C", 'INSERT'::text COLLATE "C", false),
+            ('authenticated'::text COLLATE "C", 'SELECT'::text COLLATE "C", false),
+            ('authenticated'::text COLLATE "C", 'UPDATE'::text COLLATE "C", false)
+    $values$,
+    'anon and authenticated have no table DML privileges'
+);
+
+SELECT ok(
+    (
+        SELECT table_row.relrowsecurity
+        FROM pg_class table_row
+        WHERE table_row.oid = 'public.local_profile_preferences'::regclass
+    ),
+    'row level security is enabled'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            policyname::text COLLATE "C",
+            cmd::text COLLATE "C",
+            roles::text COLLATE "C",
+            (qual IS NOT NULL) AS has_using,
+            (with_check IS NOT NULL) AS has_with_check
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'local_profile_preferences'
+        ORDER BY policyname
+    $sql$,
+    $values$
+        VALUES
+            ('local_profile_preferences_owner_delete'::text COLLATE "C", 'DELETE'::text COLLATE "C", '{authenticated}'::text COLLATE "C", true, false),
+            ('local_profile_preferences_owner_insert'::text COLLATE "C", 'INSERT'::text COLLATE "C", '{authenticated}'::text COLLATE "C", false, true),
+            ('local_profile_preferences_owner_select'::text COLLATE "C", 'SELECT'::text COLLATE "C", '{authenticated}'::text COLLATE "C", true, false),
+            ('local_profile_preferences_owner_update'::text COLLATE "C", 'UPDATE'::text COLLATE "C", '{authenticated}'::text COLLATE "C", true, true)
+    $values$,
+    'the four authenticated owner policies have exact commands and checks'
+);
+
+SELECT diag('database:temporary-grant-owner-rls-and-cross-owner-user-id-protection');
+
+INSERT INTO auth.users (id, email)
+VALUES
+    ('11111111-1111-4111-8111-111111111111'::uuid, 'preferences-owner-a@example.test'),
+    ('22222222-2222-4222-8222-222222222222'::uuid, 'preferences-owner-b@example.test')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO public.local_profiles (user_id, id, name, device_id)
+VALUES
+    ('11111111-1111-4111-8111-111111111111'::uuid, 'shared', 'Owner A Shared', 'pgtap'),
+    ('22222222-2222-4222-8222-222222222222'::uuid, 'shared', 'Owner B Shared', 'pgtap'),
+    ('22222222-2222-4222-8222-222222222222'::uuid, 'owner-b-insert', 'Owner B Insert', 'pgtap'),
+    ('11111111-1111-4111-8111-111111111111'::uuid, 'all-sections', 'All Sections', 'pgtap')
+ON CONFLICT (user_id, id) DO NOTHING;
+
+INSERT INTO public.local_profile_preferences (user_id, local_profile_id)
+VALUES
+    ('11111111-1111-4111-8111-111111111111'::uuid, 'shared'),
+    ('22222222-2222-4222-8222-222222222222'::uuid, 'shared');
+
+CREATE OR REPLACE FUNCTION pg_temp.assert_sqlstate(
+    statement_sql text,
+    expected_sqlstate text,
+    assertion_description text
+) RETURNS text
+LANGUAGE plpgsql
+AS $assertion$
+BEGIN
+    EXECUTE statement_sql;
+    RETURN extensions.ok(false, assertion_description);
+EXCEPTION WHEN OTHERS THEN
+    RETURN extensions.is(SQLSTATE, expected_sqlstate, assertion_description);
+END
+$assertion$;
+
+CREATE OR REPLACE FUNCTION pg_temp.execute_row_count(statement_sql text)
+RETURNS bigint
+LANGUAGE plpgsql
+AS $execution$
+DECLARE
+    affected_rows bigint;
+BEGIN
+    EXECUTE statement_sql;
+    GET DIAGNOSTICS affected_rows = ROW_COUNT;
+    RETURN affected_rows;
+END
+$execution$;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON TABLE public.local_profile_preferences
+    TO authenticated;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+    'request.jwt.claims',
+    '{"sub":"11111111-1111-4111-8111-111111111111","role":"authenticated"}',
+    true
+);
+
+SELECT is(
+    (SELECT count(*) FROM public.local_profile_preferences),
+    1::bigint,
+    'owner A can read only owner A preference rows'
+);
+
+SELECT is(
+    pg_temp.execute_row_count($sql$
+        UPDATE public.local_profile_preferences
+           SET weight_unit = 'KG'
+         WHERE user_id = '22222222-2222-4222-8222-222222222222'::uuid
+    $sql$),
+    0::bigint,
+    'owner A cannot update owner B preference rows'
+);
+
+SELECT is(
+    pg_temp.execute_row_count($sql$
+        DELETE FROM public.local_profile_preferences
+         WHERE user_id = '22222222-2222-4222-8222-222222222222'::uuid
+    $sql$),
+    0::bigint,
+    'owner A cannot delete owner B preference rows'
+);
+
+SELECT pg_temp.assert_sqlstate(
+    $sql$
+        INSERT INTO public.local_profile_preferences (user_id, local_profile_id)
+        VALUES ('22222222-2222-4222-8222-222222222222'::uuid, 'owner-b-insert')
+    $sql$,
+    '42501',
+    'owner A cannot insert an owner B preference row'
+);
+
+SELECT pg_temp.assert_sqlstate(
+    $sql$
+        UPDATE public.local_profile_preferences
+           SET user_id = '22222222-2222-4222-8222-222222222222'::uuid
+         WHERE user_id = '11111111-1111-4111-8111-111111111111'::uuid
+           AND local_profile_id = 'shared'
+    $sql$,
+    '42501',
+    'owner UPDATE WITH CHECK rejects changing user_id from owner A to owner B'
+);
+
+RESET ROLE;
+REVOKE SELECT, INSERT, UPDATE, DELETE
+    ON TABLE public.local_profile_preferences
+    FROM authenticated;
+
+SELECT diag('database:base-revision-accept-and-stale-canonical-conflict');
+
+CREATE TEMP TABLE preference_mutation_results (
+    section text NOT NULL,
+    accepted boolean,
+    rejection_reason text,
+    server_revision bigint,
+    canonical_section jsonb
+) ON COMMIT DROP;
+
+INSERT INTO preference_mutation_results
+SELECT 'CORE', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'CORE',
+    1,
+    0,
+    '{"bodyWeightKg":82.5,"weightUnit":"KG","weightIncrement":2.5}'::jsonb
+) AS result;
+
+INSERT INTO preference_mutation_results
+SELECT 'RACK', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'RACK',
+    1,
+    0,
+    '{"version":1,"items":[{"id":"rack-1","weightKg":20}]}'::jsonb
+) AS result;
+
+INSERT INTO preference_mutation_results
+SELECT 'WORKOUT', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'WORKOUT',
+    1,
+    0,
+    '{"version":1,"summaryCountdownSeconds":10,"autoStartCountdownSeconds":3,"defaultRoutineExerciseWeightPercentOfPR":75}'::jsonb
+) AS result;
+
+INSERT INTO preference_mutation_results
+SELECT 'LED', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'LED',
+    1,
+    0,
+    '{"ledColorSchemeId":3,"preferences":{"version":1,"discoModeUnlocked":true}}'::jsonb
+) AS result;
+
+INSERT INTO preference_mutation_results
+SELECT 'VBT', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'VBT',
+    1,
+    0,
+    '{"vbtEnabled":false,"preferences":{"version":1,"velocityLossThresholdPercent":25,"autoEndOnVelocityLoss":true,"defaultScalingBasis":"MAX_WEIGHT_PR","verbalEncouragementEnabled":true,"vulgarModeEnabled":false,"vulgarTier":"STRONG","dominatrixModeUnlocked":false,"dominatrixModeActive":false}}'::jsonb
+) AS result;
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            section COLLATE "C",
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            (canonical_section ->> 'section') COLLATE "C",
+            (canonical_section ->> 'documentVersion')::integer,
+            (canonical_section ->> 'serverRevision')::bigint
+        FROM preference_mutation_results
+        ORDER BY section
+    $sql$,
+    $values$
+        VALUES
+            ('CORE'::text COLLATE "C", true, NULL::text COLLATE "C", 1::bigint, 'CORE'::text COLLATE "C", 1, 1::bigint),
+            ('LED'::text COLLATE "C", true, NULL::text COLLATE "C", 1::bigint, 'LED'::text COLLATE "C", 1, 1::bigint),
+            ('RACK'::text COLLATE "C", true, NULL::text COLLATE "C", 1::bigint, 'RACK'::text COLLATE "C", 1, 1::bigint),
+            ('VBT'::text COLLATE "C", true, NULL::text COLLATE "C", 1::bigint, 'VBT'::text COLLATE "C", 1, 1::bigint),
+            ('WORKOUT'::text COLLATE "C", true, NULL::text COLLATE "C", 1::bigint, 'WORKOUT'::text COLLATE "C", 1, 1::bigint)
+    $values$,
+    'all five sections accept base revision zero as server revision one'
+);
+
+SELECT is(
+    (
+        SELECT ARRAY[
+            core_revision,
+            rack_revision,
+            workout_revision,
+            led_revision,
+            vbt_revision
+        ]
+        FROM public.local_profile_preferences
+        WHERE user_id = '11111111-1111-4111-8111-111111111111'::uuid
+          AND local_profile_id = 'all-sections'
+    ),
+    ARRAY[1, 1, 1, 1, 1]::bigint[],
+    'accepting every base-zero section increments each independent revision once'
+);
+
+SELECT ok(
+    (
+        SELECT bool_and(
+            (canonical_section ->> 'localProfileId') = 'all-sections'
+            AND canonical_section ? 'serverUpdatedAt'
+            AND jsonb_typeof(canonical_section -> 'payload') = 'object'
+        )
+        FROM preference_mutation_results
+    ),
+    'every accepted mutation returns a complete canonical section envelope'
+);
+
+TRUNCATE preference_mutation_results;
+
+INSERT INTO preference_mutation_results
+SELECT 'WORKOUT', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'WORKOUT',
+    1,
+    1,
+    '{"version":1,"summaryCountdownSeconds":15,"autoStartCountdownSeconds":4,"defaultRoutineExerciseWeightPercentOfPR":85}'::jsonb
+) AS result;
+
+SELECT is(
+    (
+        SELECT ARRAY[
+            core_revision,
+            rack_revision,
+            workout_revision,
+            led_revision,
+            vbt_revision
+        ]
+        FROM public.local_profile_preferences
+        WHERE user_id = '11111111-1111-4111-8111-111111111111'::uuid
+          AND local_profile_id = 'all-sections'
+    ),
+    ARRAY[1, 1, 2, 1, 1]::bigint[],
+    'a matching base increments only the targeted section revision'
+);
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            canonical_section -> 'payload'
+        FROM preference_mutation_results
+    $sql$,
+    $values$
+        VALUES (
+            true,
+            NULL::text COLLATE "C",
+            2::bigint,
+            '{"version":1,"summaryCountdownSeconds":15,"autoStartCountdownSeconds":4,"defaultRoutineExerciseWeightPercentOfPR":85}'::jsonb
+        )
+    $values$,
+    'matching-base mutation returns the targeted canonical version-1 WORKOUT document'
+);
+
+TRUNCATE preference_mutation_results;
+
+INSERT INTO preference_mutation_results
+SELECT 'WORKOUT', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'WORKOUT',
+    1,
+    1,
+    '{"version":1,"summaryCountdownSeconds":5,"autoStartCountdownSeconds":2,"defaultRoutineExerciseWeightPercentOfPR":50}'::jsonb
+) AS result;
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            (canonical_section ->> 'section') COLLATE "C",
+            canonical_section -> 'payload'
+        FROM preference_mutation_results
+    $sql$,
+    $values$
+        VALUES (
+            false,
+            'REVISION_CONFLICT'::text COLLATE "C",
+            2::bigint,
+            'WORKOUT'::text COLLATE "C",
+            '{"version":1,"summaryCountdownSeconds":15,"autoStartCountdownSeconds":4,"defaultRoutineExerciseWeightPercentOfPR":85}'::jsonb
+        )
+    $values$,
+    'stale base returns REVISION_CONFLICT with the current canonical targeted section'
+);
+
+CREATE TEMP TABLE preference_rejection_results (
+    case_name text NOT NULL,
+    accepted boolean,
+    rejection_reason text,
+    server_revision bigint,
+    canonical_section jsonb
+) ON COMMIT DROP;
+
+INSERT INTO preference_rejection_results
+SELECT 'invalid-section', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'NOPE',
+    1,
+    0,
+    '{}'::jsonb
+) AS result;
+
+INSERT INTO preference_rejection_results
+SELECT 'invalid-version', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'CORE',
+    2,
+    0,
+    '{}'::jsonb
+) AS result;
+
+INSERT INTO preference_rejection_results
+SELECT 'invalid-payload', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'all-sections',
+    'CORE',
+    1,
+    0,
+    '[]'::jsonb
+) AS result;
+
+INSERT INTO preference_rejection_results
+SELECT 'unknown-profile', result.*
+FROM public.mutate_local_profile_preference_section(
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'missing-profile',
+    'CORE',
+    1,
+    0,
+    '{"bodyWeightKg":82.5,"weightUnit":"KG","weightIncrement":2.5}'::jsonb
+) AS result;
+
+SELECT results_eq(
+    $sql$
+        SELECT
+            case_name COLLATE "C",
+            accepted,
+            rejection_reason COLLATE "C",
+            server_revision,
+            canonical_section
+        FROM preference_rejection_results
+        ORDER BY case_name
+    $sql$,
+    $values$
+        VALUES
+            ('invalid-payload'::text COLLATE "C", false, 'VALIDATION_FAILED'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('invalid-section'::text COLLATE "C", false, 'UNSUPPORTED_SECTION'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('invalid-version'::text COLLATE "C", false, 'UNSUPPORTED_DOCUMENT_VERSION'::text COLLATE "C", 0::bigint, NULL::jsonb),
+            ('unknown-profile'::text COLLATE "C", false, 'UNKNOWN_PROFILE'::text COLLATE "C", 0::bigint, NULL::jsonb)
+    $values$,
+    'invalid section, version, payload, and unknown profile return explicit rejection rows'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Adds additive per-profile preference storage, canonical projection, and optimistic-concurrency mutation RPC. Includes pgTAP coverage for ACLs, RLS, revisions, conflicts, first-write races, malformed payload rejection, and fail-closed required JSON keys. Edge Functions and mobile release remain gated until this migration is deployed and verified.

## Details

- Adds the additive-only migration `supabase/migrations/20260715234034_profile_preferences.sql`; it does not remove or rewrite existing profile storage.
- Adds `supabase/tests/database/profile_preferences.test.sql` with 38 pgTAP assertions covering exact ACLs, RLS ownership and cross-owner protection, section revisions, canonical conflicts, payload validation, first-write behavior, malformed-object rejection across all five sections, and missing required nested keys.
- Maps only `check_violation`, `not_null_violation`, `numeric_value_out_of_range`, and `invalid_text_representation` raised inside the mutation subtransaction to `(false, 'VALIDATION_FAILED', 0, NULL)`. Revision conflicts and unrelated database errors retain their existing paths.
- Makes required nested-key checks fail closed for RACK `items`, LED `discoModeUnlocked`, and VBT `velocityLossThresholdPercent`; the migration uses replay-safe constraint replacement so an already-created table receives the corrected definitions. WORKOUT settings remain optional and valid wire shapes are unchanged.
- Records fresh advisor evidence in `docs/profile-preferences-advisor-dispositions.md`: zero local findings on `local_profile_preferences`, `local_profile_preference_section_canonical`, or `mutate_local_profile_preference_section`. Unrelated pre-existing local and production findings remain documented, including the production `public.public_profiles` `security_definer_view` ERROR; no environment is represented as globally clean.
- Keeps Edge Functions and the mobile release gated until the migration is deployed and verified in an isolated Supabase environment. No production migration or Supabase data/schema change was applied as part of this PR preparation.

## Validation

- TDD RED (malformed objects): an empty CORE object reached the unchanged UPDATE and raised SQLSTATE `23502` instead of returning a rejection row; pgTAP tests 34-35 failed.
- TDD RED (required nested keys): RACK `{"version":1}`, LED preferences `{"version":1}`, and VBT preferences `{"version":1}` were accepted; the result/state assertions failed, while the WORKOUT optional-field characterization passed.
- Fresh local reset: migration applied successfully; focused pgTAP passed 38/38, including exact `VALIDATION_FAILED` results and unchanged payload/revision assertions for the three missing-key cases.
- Unchanged migration replay through local `psql`: passed; immediate post-replay pgTAP passed 38/38.
- Local advisors: exit 0 with 104 unrelated pre-existing warnings and zero target findings. Local lint remains non-green only for pre-existing `public.upsert_routine_lww` SQLSTATE `42703`.
- `npm run test:sync`: 269 passed, 17 skipped.
- `npm run verify`: passed (Biome baseline warnings only, TypeScript, 1,355 tests with 17 skipped, production build, sourcemap assertion, and Supabase-config assertion).
- The Supabase Preview check may retain the initially applied definition because Supabase branches apply only newly named migration files on later commits. The latest clean-apply CI result is therefore the authoritative isolated check for edits to this existing migration; the PR must not merge until the latest checks are reviewed.