### PR TITLE
fix(db): restore per-user local profile keys

### DIFF
--- a/docs/profile-preferences-advisor-dispositions.md
+++ b/docs/profile-preferences-advisor-dispositions.md
@@ -292,10 +292,43 @@ resolved.
 
 ## PR disposition
 
-The feature adds no local, preview, or production advisor error or warning on
-the target table or functions. The migration is deployed and verified in both
-fresh preview and production, including production no-drift evidence. The
-unrelated non-clean baselines above remain visible for follow-up in their own
-scope. The Edge implementation, preview smoke, fail-closed live workflow, and
-cleanup audit are complete. PR #88 is ready for the final Task 11 production
-release gate.
+The profile-preference feature added no local, preview, or production advisor
+finding on its target table or functions. PR #88 merged after its Edge
+implementation, preview smoke, fail-closed live workflow, and cleanup audit
+completed. The final mobile backend-ready decision is now governed by the
+Task 11 reconciliation evidence below.
+
+## Task 11 production preflight reconciliation
+
+The main-only production migration-drift workflow
+[`29507101015`](https://github.com/9thLevelSoftware/phoenix-portal/actions/runs/29507101015)
+passed immediately before Edge Function PR #88 merged. Read-only production
+catalog checks confirmed migration `20260715234034`, the preference table,
+both invoker-security functions with empty search paths, and the intended table
+ACL boundary. PR #88 then squash-merged as `49a36eab`; protected production
+deployment run
+[`29507381498`](https://github.com/9thLevelSoftware/phoenix-portal/actions/runs/29507381498)
+passed from `main`. `mobile-sync-push` version 133 and
+`mobile-sync-pull` version 127 became active with handler-owned authentication.
+
+The designated production smoke did not use a real user account. Its first
+disposable public signup failed with HTTP 500 and left no Auth row. Read-only
+catalog diagnosis found a legacy `PRIMARY KEY (id)` on
+`public.local_profiles`, even though migration `20260321120000` declares
+`PRIMARY KEY (user_id, id)`. The existing `handle_new_user()` trigger inserts
+the mobile sentinel `id = 'default'` for every account, so the global key makes
+that trigger fail after one default row. Aggregate-only evidence at discovery
+time was 144 Auth users, 2 local-profile rows, 1 default row, and 143 users
+missing their default parent. No real-user identity or preference payload was
+read.
+
+Migration `20260716151000_fix_local_profiles_composite_primary_key.sql`
+repairs only the recognized legacy key shape. It fails closed on unexpected
+primary-key or foreign-key catalogs, rebinds all six composite foreign keys to
+the intended composite primary key, backfills missing default profiles, and
+reasserts the signup trigger. Fresh replay and 39 pgTAP assertions pass. A
+disposable local legacy-shape simulation proved the transition from one global
+default to per-user defaults and verified a subsequent signup creates its own
+default row. Production smoke and the mobile backend-ready gate remain paused
+until this reconciliation migration passes preview review and deploys through
+the normal migration pipeline.

--- a/docs/profile-preferences-advisor-dispositions.md
+++ b/docs/profile-preferences-advisor-dispositions.md
@@ -329,6 +329,12 @@ the intended composite primary key, backfills missing default profiles, and
 reasserts the signup trigger. Fresh replay and 39 pgTAP assertions pass. A
 disposable local legacy-shape simulation proved the transition from one global
 default to per-user defaults and verified a subsequent signup creates its own
-default row. Production smoke and the mobile backend-ready gate remain paused
-until this reconciliation migration passes preview review and deploys through
-the normal migration pipeline.
+default row.
+
+Draft PR #89 created isolated preview `bfgpylzbilgouskczcen`. The preview
+recorded migration `20260716151000`, reported the exact composite primary key
+and all six referencing foreign keys, and allowed two disposable Auth users to
+receive separate `id = 'default'` rows through the real trigger. Cleanup
+audited zero remaining fixture users and local profiles. Production smoke and
+the mobile backend-ready gate remain paused until PR #89 passes final review,
+merges, and deploys through the normal migration pipeline.

--- a/supabase/migrations/20260716151000_fix_local_profiles_composite_primary_key.sql
+++ b/supabase/migrations/20260716151000_fix_local_profiles_composite_primary_key.sql
@@ -1,0 +1,189 @@
+-- =============================================================================
+-- Reconcile legacy local_profiles(id) primary keys with the intended
+-- per-user key. The original local-profile migration declares
+-- PRIMARY KEY (user_id, id), but older production state retained a global
+-- PRIMARY KEY (id) and only added UNIQUE (user_id, id). That makes the
+-- mobile "default" sentinel globally unique and causes handle_new_user() to
+-- fail after the first account.
+-- =============================================================================
+
+DO $migration$
+DECLARE
+    primary_key_columns text[];
+    unexpected_foreign_keys text[];
+BEGIN
+    SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+      INTO primary_key_columns
+      FROM pg_constraint constraint_row
+      CROSS JOIN LATERAL unnest(constraint_row.conkey)
+          WITH ORDINALITY AS key_column(attnum, ordinality)
+      JOIN pg_attribute attribute
+        ON attribute.attrelid = constraint_row.conrelid
+       AND attribute.attnum = key_column.attnum
+     WHERE constraint_row.conrelid = 'public.local_profiles'::regclass
+       AND constraint_row.contype = 'p';
+
+    -- Fresh databases already have the intended composite primary key.
+    IF primary_key_columns = ARRAY['user_id', 'id']::text[] THEN
+        RETURN;
+    END IF;
+
+    IF primary_key_columns IS DISTINCT FROM ARRAY['id']::text[] THEN
+        RAISE EXCEPTION
+            'local_profiles reconciliation: unexpected primary key columns %',
+            primary_key_columns;
+    END IF;
+
+    SELECT array_agg(format('%s.%s', child_namespace.nspname, constraint_row.conname)
+                     ORDER BY child_namespace.nspname, constraint_row.conname)
+      INTO unexpected_foreign_keys
+      FROM pg_constraint constraint_row
+      JOIN pg_class child_table
+        ON child_table.oid = constraint_row.conrelid
+      JOIN pg_namespace child_namespace
+        ON child_namespace.oid = child_table.relnamespace
+     WHERE constraint_row.confrelid = 'public.local_profiles'::regclass
+       AND constraint_row.contype = 'f'
+       AND constraint_row.conname NOT IN (
+            'fk_exercise_progress_profile',
+            'local_profile_preferences_parent_fkey',
+            'fk_personal_records_profile',
+            'fk_routines_profile',
+            'fk_training_cycles_profile',
+            'fk_workout_sessions_profile'
+       );
+
+    IF unexpected_foreign_keys IS NOT NULL THEN
+        RAISE EXCEPTION
+            'local_profiles reconciliation: unexpected referencing constraints %',
+            unexpected_foreign_keys;
+    END IF;
+
+    -- These constraints depend on the legacy composite UNIQUE constraint.
+    -- Drop and recreate them around the primary-key repair so PostgreSQL can
+    -- bind every foreign key to the new composite primary key.
+    ALTER TABLE public.exercise_progress
+        DROP CONSTRAINT IF EXISTS fk_exercise_progress_profile;
+    ALTER TABLE public.local_profile_preferences
+        DROP CONSTRAINT IF EXISTS local_profile_preferences_parent_fkey;
+    ALTER TABLE public.personal_records
+        DROP CONSTRAINT IF EXISTS fk_personal_records_profile;
+    ALTER TABLE public.routines
+        DROP CONSTRAINT IF EXISTS fk_routines_profile;
+    ALTER TABLE public.training_cycles
+        DROP CONSTRAINT IF EXISTS fk_training_cycles_profile;
+    ALTER TABLE public.workout_sessions
+        DROP CONSTRAINT IF EXISTS fk_workout_sessions_profile;
+
+    ALTER TABLE public.local_profiles
+        DROP CONSTRAINT IF EXISTS local_profiles_user_id_id_key;
+    ALTER TABLE public.local_profiles
+        DROP CONSTRAINT local_profiles_pkey;
+    ALTER TABLE public.local_profiles
+        ADD CONSTRAINT local_profiles_pkey PRIMARY KEY (user_id, id);
+
+    -- Restore every intended default parent before the validated preference
+    -- foreign key is recreated. The statement is repeated after this block so
+    -- already-correct databases receive the same idempotent backfill.
+    INSERT INTO public.local_profiles (user_id, id, name, device_id)
+    SELECT auth_user.id, 'default', 'Default', 'server'
+    FROM auth.users AS auth_user
+    ON CONFLICT (user_id, id) DO NOTHING;
+
+    ALTER TABLE public.exercise_progress
+        ADD CONSTRAINT fk_exercise_progress_profile
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE SET NULL (local_profile_id)
+        NOT VALID;
+
+    ALTER TABLE public.local_profile_preferences
+        ADD CONSTRAINT local_profile_preferences_parent_fkey
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE CASCADE;
+
+    ALTER TABLE public.personal_records
+        ADD CONSTRAINT fk_personal_records_profile
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE SET NULL (local_profile_id)
+        NOT VALID;
+
+    ALTER TABLE public.routines
+        ADD CONSTRAINT fk_routines_profile
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE SET NULL (local_profile_id)
+        NOT VALID;
+
+    ALTER TABLE public.training_cycles
+        ADD CONSTRAINT fk_training_cycles_profile
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE SET NULL (local_profile_id)
+        NOT VALID;
+
+    ALTER TABLE public.workout_sessions
+        ADD CONSTRAINT fk_workout_sessions_profile
+        FOREIGN KEY (user_id, local_profile_id)
+        REFERENCES public.local_profiles(user_id, id)
+        ON DELETE SET NULL (local_profile_id)
+        NOT VALID;
+END
+$migration$;
+
+-- Backfill every account after the key repair. This is intentionally
+-- idempotent and also covers accounts created between the original migration
+-- and this reconciliation.
+INSERT INTO public.local_profiles (user_id, id, name, device_id)
+SELECT auth_user.id, 'default', 'Default', 'server'
+FROM auth.users AS auth_user
+ON CONFLICT (user_id, id) DO NOTHING;
+
+-- Reassert the signup trigger contract in case the legacy environment also
+-- retained an older function body.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+BEGIN
+    INSERT INTO public.profiles (id, display_name)
+    VALUES (
+        NEW.id,
+        COALESCE(NULLIF(split_part(NEW.email, '@', 1), ''), 'User')
+    )
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO public.local_profiles (user_id, id, name, device_id)
+    VALUES (NEW.id, 'default', 'Default', 'server')
+    ON CONFLICT (user_id, id) DO NOTHING;
+
+    RETURN NEW;
+END
+$function$;
+
+DO $postcondition$
+DECLARE
+    primary_key_columns text[];
+BEGIN
+    SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+      INTO primary_key_columns
+      FROM pg_constraint constraint_row
+      CROSS JOIN LATERAL unnest(constraint_row.conkey)
+          WITH ORDINALITY AS key_column(attnum, ordinality)
+      JOIN pg_attribute attribute
+        ON attribute.attrelid = constraint_row.conrelid
+       AND attribute.attnum = key_column.attnum
+     WHERE constraint_row.conrelid = 'public.local_profiles'::regclass
+       AND constraint_row.contype = 'p';
+
+    IF primary_key_columns IS DISTINCT FROM ARRAY['user_id', 'id']::text[] THEN
+        RAISE EXCEPTION
+            'local_profiles reconciliation: expected composite primary key, got %',
+            primary_key_columns;
+    END IF;
+END
+$postcondition$;

--- a/supabase/tests/database/profile_preferences.test.sql
+++ b/supabase/tests/database/profile_preferences.test.sql
@@ -13,6 +13,24 @@ SELECT has_table(
     'profile preferences table exists'
 );
 
+SELECT diag('database:local-profiles-composite-primary-key');
+
+SELECT is(
+    (
+        SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)
+        FROM pg_constraint constraint_row
+        CROSS JOIN LATERAL unnest(constraint_row.conkey)
+            WITH ORDINALITY AS key_column(attnum, ordinality)
+        JOIN pg_attribute attribute
+          ON attribute.attrelid = constraint_row.conrelid
+         AND attribute.attnum = key_column.attnum
+        WHERE constraint_row.conrelid = 'public.local_profiles'::regclass
+          AND constraint_row.contype = 'p'
+    ),
+    ARRAY['user_id', 'id']::text[],
+    'local_profiles primary key is exactly (user_id, id)'
+);
+
 SELECT is(
     (
         SELECT array_agg(attribute.attname::text ORDER BY key_column.ordinality)


### PR DESCRIPTION
Task 11 production smoke exposed a legacy schema mismatch: public.local_profiles retained PRIMARY KEY (id), while the intended schema and mobile wire model require PRIMARY KEY (user_id, id). The existing signup trigger inserts id='default' for every user, so later signups fail.

This migration:
- fails closed unless the legacy key and expected six foreign keys are present;
- restores the composite primary key and rebinds all six foreign keys;
- backfills missing per-user default profiles;
- reasserts the signup trigger;
- adds executable pgTAP catalog coverage.

Evidence:
- production diagnosis used aggregate/catalog reads only; no real-user payload was read;
- clean local replay passed;
- pgTAP passed 39/39;
- simulated legacy repair changed PK(id) + one default into PK(user_id,id) + per-user defaults and a subsequent signup succeeded;
- profile-preference orphan count is zero before the validated FK rebuild.

Follow-up to #88 and database PR #86. Mobile release PR remains gated: https://github.com/9thLevelSoftware/Project-Phoenix-MP/pull/651

Rollback posture: do not restore the global id key. If a later Edge issue occurs, roll back Edge Functions while leaving the additive preference schema and repaired parent key in place.