### PR TITLE
feat(sync): persist personal record tombstones

### DIFF
--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -255,6 +255,29 @@ describe("buildDedicatedPersonalRecordRows", () => {
 		]);
 	});
 
+	it("preserves a deletion tombstone for the LWW database gate", () => {
+		const deletedAt = "2026-07-16T21:00:00.000Z";
+		const [row] = buildDedicatedPersonalRecordRows(
+			[
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					exerciseName: "Bench Press",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					workoutPhase: "COMBINED",
+					achievedAt: "2026-07-16T20:00:00.000Z",
+					updatedAt: deletedAt,
+					deletedAt,
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+		);
+
+		expect(row?.deleted_at).toBe(deletedAt);
+		expect(row?.updated_at).toBe(deletedAt);
+	});
+
 	it("uses volume as the value for MAX_VOLUME records when value is absent", () => {
 		const out = buildDedicatedPersonalRecordRows(
 			[

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -809,6 +809,7 @@ export type Database = {
 			personal_records: {
 				Row: {
 					achieved_at: string;
+					deleted_at: string | null;
 					exercise_id: string | null;
 					exercise_name: string;
 					id: string;
@@ -827,6 +828,7 @@ export type Database = {
 				};
 				Insert: {
 					achieved_at?: string;
+					deleted_at?: string | null;
 					exercise_id?: string | null;
 					exercise_name: string;
 					id?: string;
@@ -845,6 +847,7 @@ export type Database = {
 				};
 				Update: {
 					achieved_at?: string;
+					deleted_at?: string | null;
 					exercise_id?: string | null;
 					exercise_name?: string;
 					id?: string;

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -55,6 +55,7 @@ export interface PersonalRecordRow {
 	session_id?: string | null;
 	achieved_at: string;
 	updated_at?: string;
+	deleted_at?: string | null;
 	workout_phase: string;
 }
 
@@ -73,6 +74,7 @@ export interface DedicatedPersonalRecordInput {
 	sessionId?: string | null;
 	achievedAt?: string | null;
 	updatedAt?: string | null;
+	deletedAt?: string | null;
 	localProfileId?: string | null;
 	workoutMode?: string | null;
 }
@@ -572,6 +574,7 @@ export function buildDedicatedPersonalRecordRows(
 
 		if (record.id) row.id = record.id;
 		if (record.updatedAt) row.updated_at = record.updatedAt;
+		if (record.deletedAt !== undefined) row.deleted_at = record.deletedAt;
 		return row;
 	});
 }

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -447,6 +447,7 @@ const personalRecordSchema = z.object({
 	sessionId: nullableField(uuid),
 	achievedAt: datetimeWithDefault(() => new Date().toISOString()),
 	updatedAt: nullableDatetime(),
+	deletedAt: nullableDatetime(),
 	localProfileId: localProfileIdSchema.nullable().optional(),
 	// Accepted for wire compatibility; personal_records has no workout_mode
 	// column, so the push handler can only preserve this through session_id.

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -1364,6 +1364,7 @@ async function mobileSyncPullHandler(
         sessionId: pr.session_id,
         achievedAt: pr.achieved_at,
         updatedAt: pr.updated_at,
+        deletedAt: pr.deleted_at ?? null,
       }));
 
       remainingPageSize -= personalRecordDtos.length;

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1948,6 +1948,27 @@ async function mobileSyncPushHandler(
       });
 
       if (dedupedPrRows.length > 0) {
+        // Dedicated rows have stable UUIDs, so route them through the portal LWW
+        // gate. The database function makes a same-timestamp tombstone win and
+        // returns acceptance status without allowing stale clients to resurrect it.
+        if (
+          dedicatedPrsPresent &&
+          SYNC_LWW_ENABLED &&
+          dedupedPrRows.every((row) => typeof row.id === 'string' && row.id.length > 0)
+        ) {
+          const lwwRows = dedupedPrRows.map((row) => ({
+            ...row,
+            updated_at: row.updated_at ?? new Date().toISOString(),
+          }));
+          const { data: lwwData, error: lwwError } = await supabase.rpc(
+            'upsert_personal_records_lww',
+            { p_rows: lwwRows },
+          );
+          if (lwwError) throw new Error(`personal_records LWW RPC failed: ${lwwError.message}`);
+          personalRecordsInserted = ((lwwData ?? []) as LwwUpsertRow[])
+            .filter((row) => row.accepted)
+            .length;
+        } else {
         const writePersonalRecords = (rows: typeof dedupedPrRows) => dedicatedPrsPresent
           ? supabase
               .from('personal_records')
@@ -2021,6 +2042,7 @@ async function mobileSyncPushHandler(
           throw new Error(`personal_records ${dedicatedPrsPresent ? 'upsert' : 'insert'} failed: ${prErr.message}`);
         } else {
           personalRecordsInserted = dedupedPrRows.length;
+        }
         }
       }
     }

--- a/supabase/migrations/20260716210000_personal_record_tombstones.sql
+++ b/supabase/migrations/20260716210000_personal_record_tombstones.sql
@@ -73,9 +73,10 @@ END;
 $$;
 
 -- The legacy RPC is parity-mode's source of truth. Its original signature used BIGINT
--- IDs while dedicated PRs now use UUIDs, so remove that overload before recreating it.
--- Both parity and timestamp pull responses include deleted_at.
+-- IDs, while later parity migrations use UUIDs. Remove both overloads before recreating
+-- the UUID variant with the tombstone field in its return shape.
 DROP FUNCTION IF EXISTS public.get_personal_records_excluding_ids(UUID, BIGINT[], TEXT);
+DROP FUNCTION IF EXISTS public.get_personal_records_excluding_ids(UUID, UUID[], TEXT);
 CREATE FUNCTION public.get_personal_records_excluding_ids(
   p_user_id UUID,
   p_known_ids UUID[] DEFAULT '{}',

--- a/supabase/migrations/20260716210000_personal_record_tombstones.sql
+++ b/supabase/migrations/20260716210000_personal_record_tombstones.sql
@@ -1,0 +1,107 @@
+-- Issue #655: propagate personal-record deletion through normal sync without hard-deleting history.
+-- A tombstone is a row with deleted_at set; active product reads filter it locally while pull
+-- responses retain it so every device converges.
+
+ALTER TABLE public.personal_records
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_personal_records_sync_cursor
+  ON public.personal_records (user_id, local_profile_id, updated_at, id);
+
+-- The edge function passes already-owned rows. Apply LWW by stable row UUID and make a
+-- tombstone win equal timestamps so a stale active client cannot resurrect a deletion.
+CREATE OR REPLACE FUNCTION public.upsert_personal_records_lww(p_rows JSONB)
+RETURNS TABLE(id UUID, accepted BOOLEAN, server_updated_at TIMESTAMPTZ)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  row JSONB;
+  incoming_updated_at TIMESTAMPTZ;
+  incoming_deleted_at TIMESTAMPTZ;
+  current_row public.personal_records%ROWTYPE;
+BEGIN
+  FOR row IN SELECT value FROM jsonb_array_elements(COALESCE(p_rows, '[]'::jsonb)) LOOP
+    incoming_updated_at := COALESCE((row->>'updated_at')::TIMESTAMPTZ, now());
+    incoming_deleted_at := NULLIF(row->>'deleted_at', '')::TIMESTAMPTZ;
+
+    SELECT * INTO current_row FROM public.personal_records WHERE personal_records.id = (row->>'id')::UUID;
+    IF FOUND AND (
+      current_row.updated_at > incoming_updated_at
+      OR (
+        current_row.updated_at = incoming_updated_at
+        AND current_row.deleted_at IS NOT NULL
+        AND incoming_deleted_at IS NULL
+      )
+    ) THEN
+      RETURN QUERY SELECT current_row.id, FALSE, current_row.updated_at;
+      CONTINUE;
+    END IF;
+
+    INSERT INTO public.personal_records (
+      id, user_id, local_profile_id, exercise_name, exercise_id, muscle_group,
+      record_type, value, weight_kg, reps, unit, session_id, achieved_at,
+      updated_at, deleted_at, workout_phase
+    ) VALUES (
+      (row->>'id')::UUID, (row->>'user_id')::UUID, NULLIF(row->>'local_profile_id', ''),
+      row->>'exercise_name', NULLIF(row->>'exercise_id', ''), COALESCE(row->>'muscle_group', 'General'),
+      COALESCE(row->>'record_type', '1RM'), (row->>'value')::NUMERIC,
+      NULLIF(row->>'weight_kg', '')::NUMERIC, NULLIF(row->>'reps', '')::INT,
+      COALESCE(row->>'unit', 'kg'), NULLIF(row->>'session_id', '')::UUID,
+      COALESCE((row->>'achieved_at')::TIMESTAMPTZ, now()), incoming_updated_at,
+      incoming_deleted_at, COALESCE(row->>'workout_phase', 'COMBINED')
+    ) ON CONFLICT (id) DO UPDATE SET
+      local_profile_id = EXCLUDED.local_profile_id,
+      exercise_name = EXCLUDED.exercise_name,
+      exercise_id = EXCLUDED.exercise_id,
+      muscle_group = EXCLUDED.muscle_group,
+      record_type = EXCLUDED.record_type,
+      value = EXCLUDED.value,
+      weight_kg = EXCLUDED.weight_kg,
+      reps = EXCLUDED.reps,
+      unit = EXCLUDED.unit,
+      session_id = EXCLUDED.session_id,
+      achieved_at = EXCLUDED.achieved_at,
+      updated_at = EXCLUDED.updated_at,
+      deleted_at = EXCLUDED.deleted_at,
+      workout_phase = EXCLUDED.workout_phase;
+
+    RETURN QUERY SELECT (row->>'id')::UUID, TRUE, incoming_updated_at;
+  END LOOP;
+END;
+$$;
+
+-- The legacy RPC is parity-mode's source of truth. Its original signature used BIGINT
+-- IDs while dedicated PRs now use UUIDs, so remove that overload before recreating it.
+-- Both parity and timestamp pull responses include deleted_at.
+DROP FUNCTION IF EXISTS public.get_personal_records_excluding_ids(UUID, BIGINT[], TEXT);
+CREATE FUNCTION public.get_personal_records_excluding_ids(
+  p_user_id UUID,
+  p_known_ids UUID[] DEFAULT '{}',
+  p_profile_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  id UUID, user_id UUID, exercise_name TEXT, exercise_id TEXT, muscle_group TEXT,
+  record_type TEXT, value NUMERIC, weight_kg NUMERIC, reps INT, workout_phase TEXT,
+  session_id UUID, achieved_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, deleted_at TIMESTAMPTZ,
+  local_profile_id TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT pr.id, pr.user_id, pr.exercise_name, pr.exercise_id, pr.muscle_group,
+         pr.record_type, pr.value, pr.weight_kg, pr.reps, pr.workout_phase,
+         pr.session_id, pr.achieved_at, pr.updated_at, pr.deleted_at, pr.local_profile_id
+  FROM public.personal_records pr
+  WHERE pr.user_id = p_user_id
+    AND (array_length(p_known_ids, 1) IS NULL OR pr.id != ALL(p_known_ids))
+    AND (
+      p_profile_id IS NULL
+      OR (p_profile_id = 'default' AND pr.local_profile_id IS NULL)
+      OR pr.local_profile_id = p_profile_id
+      OR pr.local_profile_id IS NULL
+    )
+  ORDER BY pr.updated_at ASC, pr.id ASC;
+$$;


### PR DESCRIPTION
## Summary
- add `deleted_at` tombstones plus an atomic personal-record LWW upsert RPC
- validate and preserve `deletedAt` through mobile sync push/pull
- cover tombstone row serialization in sync tests

## Validation
- `npm test -- src/lib/__tests__/sync-personal-records.test.ts` (63 tests)
- `npm run typecheck`
- `npx biome check src/lib/__tests__/sync-personal-records.test.ts src/lib/database.types.ts`

Part of 9thLevelSoftware/Project-Phoenix-MP#655. Deploy this migration and mobile PR #662 together; this PR intentionally does not close the tracking issue alone.