### PR TITLE
feat(sync): retain portal personal record tombstones

### DIFF
--- a/src/lib/__tests__/personal-record-tombstone-contract.test.ts
+++ b/src/lib/__tests__/personal-record-tombstone-contract.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MIGRATION = "20260716211500_personal_record_tombstones.sql";
+
+function readWorkspaceFile(...segments: string[]): string {
+	return readFileSync(join(process.cwd(), ...segments), "utf8");
+}
+
+function personalRecordQuery(source: string): string {
+	const start = source.search(/\.from\(["']personal_records["']\)/);
+	expect(start).toBeGreaterThanOrEqual(0);
+	const end = source.indexOf(";", start);
+	expect(end).toBeGreaterThan(start);
+	return source.slice(start, end);
+}
+
+describe("personal record tombstone migration", () => {
+	const migration = readWorkspaceFile("supabase", "migrations", MIGRATION);
+
+	it("keeps unseen parity rows active and returns the complete table shape", () => {
+		const match = migration.match(
+			/CREATE\s+FUNCTION\s+public\.get_personal_records_excluding_ids[\s\S]*?\$\$;/i,
+		);
+		expect(match).not.toBeNull();
+		expect(match?.[0]).toMatch(/RETURNS\s+SETOF\s+public\.personal_records/i);
+		expect(match?.[0]).toMatch(/pr\.deleted_at\s+IS\s+NULL/i);
+		expect(match?.[0]).toMatch(/SECURITY\s+INVOKER/i);
+	});
+
+	it("defines a bounded known-ID tombstone RPC", () => {
+		const match = migration.match(
+			/CREATE\s+FUNCTION\s+public\.get_personal_record_tombstones[\s\S]*?\$\$;/i,
+		);
+		expect(match).not.toBeNull();
+		expect(match?.[0]).toMatch(/RETURNS\s+SETOF\s+public\.personal_records/i);
+		expect(match?.[0]).toMatch(/pr\.id\s*=\s*ANY\s*\(p_known_ids\)/i);
+		expect(match?.[0]).toMatch(/pr\.deleted_at\s+IS\s+NOT\s+NULL/i);
+		expect(match?.[0]).toMatch(/pr\.updated_at\s*>\s*p_last_sync_at/i);
+		expect(match?.[0]).toMatch(/LIMIT\s+p_limit/i);
+		expect(match?.[0]).toMatch(/SECURITY\s+INVOKER/i);
+	});
+
+	it("limits both internal RPCs to the service role", () => {
+		for (const functionName of [
+			"get_personal_records_excluding_ids",
+			"get_personal_record_tombstones",
+		]) {
+			expect(migration).toMatch(
+				new RegExp(
+					`REVOKE\\s+ALL\\s+ON\\s+FUNCTION\\s+public\\.${functionName}`,
+					"i",
+				),
+			);
+			expect(migration).toMatch(
+				new RegExp(
+					`GRANT\\s+EXECUTE\\s+ON\\s+FUNCTION\\s+public\\.${functionName}`,
+					"i",
+				),
+			);
+		}
+	});
+});
+
+describe("personal record tombstone database types", () => {
+	const databaseTypes = readWorkspaceFile("src", "lib", "database.types.ts");
+
+	it("uses UUID parity IDs and exposes the tombstone RPC", () => {
+		const activeRpc = databaseTypes.match(
+			/get_personal_records_excluding_ids:[\s\S]*?get_pr_count_rankings:/,
+		)?.[0];
+		expect(activeRpc).toMatch(/p_known_ids\?: string\[\]/);
+		expect(activeRpc).toMatch(/deleted_at: string \| null/);
+		expect(databaseTypes).toMatch(/get_personal_record_tombstones:/);
+	});
+});
+
+describe("server-side active personal record reads", () => {
+	for (const path of [
+		["supabase", "functions", "compute-rankings", "index.ts"],
+		["supabase", "functions", "generate-insights", "index.ts"],
+		["src", "lib", "export", "data-export.ts"],
+	]) {
+		it(`${path.join("/")} excludes tombstones`, () => {
+			const query = personalRecordQuery(readWorkspaceFile(...path));
+			expect(query).toMatch(/\.is\(["']deleted_at["'],\s*null\)/);
+		});
+	}
+});

--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -257,6 +257,23 @@ describe("buildDedicatedPersonalRecordRows", () => {
 		]);
 	});
 
+	it("uses deletedAt as the LWW timestamp when updatedAt is absent", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					exerciseName: "Bench Press",
+					achievedAt: "2026-04-20T12:00:00.000Z",
+					deletedAt: "2026-04-21T12:30:00.000Z",
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+		);
+
+		expect(out[0]?.updated_at).toBe("2026-04-21T12:30:00.000Z");
+	});
+
 	it("uses volume as the value for MAX_VOLUME records when value is absent", () => {
 		const out = buildDedicatedPersonalRecordRows(
 			[

--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -228,6 +228,7 @@ describe("buildDedicatedPersonalRecordRows", () => {
 					sessionId: "22222222-2222-4222-8222-222222222222",
 					achievedAt: "2026-04-21T12:00:00.000Z",
 					updatedAt: "2026-04-21T12:30:00.000Z",
+					deletedAt: "2026-04-21T12:31:00.000Z",
 				},
 			],
 			USER_ID,
@@ -250,6 +251,7 @@ describe("buildDedicatedPersonalRecordRows", () => {
 				session_id: "22222222-2222-4222-8222-222222222222",
 				achieved_at: "2026-04-21T12:00:00.000Z",
 				updated_at: "2026-04-21T12:30:00.000Z",
+				deleted_at: "2026-04-21T12:31:00.000Z",
 				workout_phase: "CONCENTRIC",
 			},
 		]);

--- a/src/lib/__tests__/sync-push-schema.test.ts
+++ b/src/lib/__tests__/sync-push-schema.test.ts
@@ -106,6 +106,40 @@ describe("pushPayloadSchema", () => {
 		expect(parsed.personalRecords).toEqual([]);
 	});
 
+	it("accepts an optional personal-record tombstone timestamp", () => {
+		const parsed = pushPayloadSchema.parse({
+			deviceId: "d1",
+			platform: "android",
+			personalRecords: [
+				{
+					id: UUID,
+					exerciseName: "Bench Press",
+					achievedAt: "2026-04-20T12:00:00.000Z",
+					deletedAt: "2026-04-21T12:30:00.000Z",
+				},
+			],
+		});
+		expect(parsed.personalRecords[0]?.deletedAt).toBe(
+			"2026-04-21T12:30:00.000Z",
+		);
+	});
+
+	it("rejects malformed personal-record tombstone timestamps", () => {
+		expect(() =>
+			pushPayloadSchema.parse({
+				deviceId: "d1",
+				platform: "android",
+				personalRecords: [
+					{
+						exerciseName: "Bench Press",
+						achievedAt: "2026-04-20T12:00:00.000Z",
+						deletedAt: "not-a-date",
+					},
+				],
+			}),
+		).toThrow();
+	});
+
 	it("rejects non-array values in array positions", () => {
 		// arrayOf() intentionally rejects non-array, non-null values to prevent
 		// the client from silently losing sync data (see pushPayloadSchema.ts comment)

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -809,6 +809,7 @@ export type Database = {
 			personal_records: {
 				Row: {
 					achieved_at: string;
+					deleted_at: string | null;
 					exercise_id: string | null;
 					exercise_name: string;
 					id: string;
@@ -827,6 +828,7 @@ export type Database = {
 				};
 				Insert: {
 					achieved_at?: string;
+					deleted_at?: string | null;
 					exercise_id?: string | null;
 					exercise_name: string;
 					id?: string;
@@ -845,6 +847,7 @@ export type Database = {
 				};
 				Update: {
 					achieved_at?: string;
+					deleted_at?: string | null;
 					exercise_id?: string | null;
 					exercise_name?: string;
 					id?: string;

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -2389,26 +2389,60 @@ export type Database = {
 					user_value: number;
 				}[];
 			};
-			get_personal_records_excluding_ids: {
+			get_personal_record_tombstones: {
 				Args: {
-					p_known_ids?: number[];
+					p_cursor_id?: string;
+					p_cursor_updated_at?: string;
+					p_known_ids?: string[];
+					p_last_sync_at?: string;
+					p_limit?: number;
 					p_profile_id?: string;
 					p_user_id: string;
 				};
 				Returns: {
 					achieved_at: string;
+					deleted_at: string | null;
+					exercise_id: string | null;
 					exercise_name: string;
-					id: number;
-					local_profile_id: string;
+					id: string;
+					local_profile_id: string | null;
 					muscle_group: string;
+					previous_value: number | null;
 					record_type: string;
-					reps: number;
-					session_id: string;
+					reps: number | null;
+					session_id: string | null;
+					unit: string;
 					updated_at: string;
 					user_id: string;
 					value: number;
-					weight_kg: number;
-					workout_phase: string;
+					weight_kg: number | null;
+					workout_phase: string | null;
+				}[];
+			};
+			get_personal_records_excluding_ids: {
+				Args: {
+					p_known_ids?: string[];
+					p_profile_id?: string;
+					p_user_id: string;
+				};
+				Returns: {
+					achieved_at: string;
+					deleted_at: string | null;
+					exercise_id: string | null;
+					exercise_name: string;
+					id: string;
+					local_profile_id: string | null;
+					muscle_group: string;
+					previous_value: number | null;
+					record_type: string;
+					reps: number | null;
+					session_id: string | null;
+					unit: string;
+					updated_at: string;
+					user_id: string;
+					value: number;
+					weight_kg: number | null;
+					workout_phase: string | null;
 				}[];
 			};
 			get_pr_count_rankings: {

--- a/src/lib/export/data-export.ts
+++ b/src/lib/export/data-export.ts
@@ -103,7 +103,11 @@ export async function exportAllUserData(
 		await addTable(
 			"personal_records",
 			"records",
-			supabase.from("personal_records").select("*").eq("user_id", userId),
+			supabase
+				.from("personal_records")
+				.select("*")
+				.eq("user_id", userId)
+				.is("deleted_at", null),
 		);
 
 		await addTable(

--- a/src/queries/__tests__/analytics.test.ts
+++ b/src/queries/__tests__/analytics.test.ts
@@ -5,7 +5,7 @@ import { queryKeys } from "@/queries/keys";
 
 function buildChain(terminal: { data: unknown; error: unknown }) {
 	const self: Record<string, ReturnType<typeof vi.fn>> = {};
-	const methods = ["select", "eq", "order", "gte", "lt", "in", "limit"];
+	const methods = ["select", "eq", "is", "order", "gte", "lt", "in", "limit"];
 	for (const m of methods) {
 		self[m] = vi.fn();
 	}
@@ -201,6 +201,7 @@ describe("strengthProgressOptions", () => {
 		const { strengthProgressOptions } = await import("../analytics");
 		const opts = strengthProgressOptions("user-1");
 		const result = await opts.queryFn?.({} as never);
+		expect(chain.is).toHaveBeenCalledWith("deleted_at", null);
 		expect(result).toHaveLength(1);
 		expect(result[0].exercise_name).toBe("Bench Press");
 	});

--- a/src/queries/__tests__/challenges.test.ts
+++ b/src/queries/__tests__/challenges.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 function buildChain(terminal: { data: unknown; error: unknown }) {
 	const self: Record<string, ReturnType<typeof vi.fn>> = {};
-	const methods = ["select", "eq", "gte", "lte", "order"];
+	const methods = ["select", "eq", "is", "gte", "lte", "order"];
 	for (const method of methods) {
 		self[method] = vi.fn();
 	}
@@ -47,6 +47,7 @@ describe("challengeProgressOptions", () => {
 		const result = await opts.queryFn?.({} as never);
 
 		expect(fromFn).toHaveBeenCalledWith("personal_records");
+		expect(chain.is).toHaveBeenCalledWith("deleted_at", null);
 		expect(result).toEqual({ current: 3, target: 3, percentage: 100 });
 	});
 });

--- a/src/queries/__tests__/profile.test.ts
+++ b/src/queries/__tests__/profile.test.ts
@@ -5,7 +5,7 @@ import { queryKeys } from "@/queries/keys";
 
 function buildChain(terminal: Record<string, unknown>) {
 	const self: Record<string, ReturnType<typeof vi.fn>> = {};
-	const methods = ["select", "eq", "order", "in", "maybeSingle"];
+	const methods = ["select", "eq", "is", "order", "in", "maybeSingle"];
 	for (const m of methods) {
 		self[m] = vi.fn();
 	}
@@ -145,12 +145,18 @@ describe("profileStatsOptions", () => {
 			{ started_at: "2026-03-17T08:00:00Z", total_volume: 400 },
 		];
 
+		const sessionsChain = buildChain({ data: sessions, error: null });
+		const personalRecordsChain = buildChain({
+			data: null,
+			error: null,
+			count: 5,
+		});
 		let callCount = 0;
 		fromFn.mockImplementation(() => {
 			callCount++;
-			if (callCount === 1) return buildChain({ data: sessions, error: null });
+			if (callCount === 1) return sessionsChain;
 			// PR count query uses { count: "exact", head: true }
-			return buildChain({ data: null, error: null, count: 5 });
+			return personalRecordsChain;
 		});
 
 		const { profileStatsOptions } = await import("../profile");
@@ -163,6 +169,7 @@ describe("profileStatsOptions", () => {
 		// 3 consecutive days = streak of 3
 		expect(result.bestStreak).toBe(3);
 		expect(result.prCount).toBe(5);
+		expect(personalRecordsChain.is).toHaveBeenCalledWith("deleted_at", null);
 	});
 
 	it("returns zeros when user has no sessions", async () => {

--- a/src/queries/__tests__/progress.test.ts
+++ b/src/queries/__tests__/progress.test.ts
@@ -3,7 +3,7 @@ import { queryKeys } from "@/queries/keys";
 
 function buildChain(terminal: { data: unknown; error: unknown }) {
 	const self: Record<string, ReturnType<typeof vi.fn>> = {};
-	for (const method of ["select", "eq", "order"]) {
+	for (const method of ["select", "eq", "is", "order"]) {
 		self[method] = vi.fn();
 	}
 	for (const method of Object.keys(self)) {
@@ -64,6 +64,7 @@ describe("progressionWorkbenchOptions", () => {
 			"local_profile_id",
 			"profile-1",
 		);
+		expect(recordsChain.is).toHaveBeenCalledWith("deleted_at", null);
 		expect(result.progressRows).toHaveLength(1);
 		expect(result.records).toEqual([]);
 	});

--- a/src/queries/__tests__/records.test.ts
+++ b/src/queries/__tests__/records.test.ts
@@ -5,7 +5,7 @@ import { queryKeys } from "@/queries/keys";
 
 function buildChain(terminal: { data: unknown; error: unknown }) {
 	const self: Record<string, ReturnType<typeof vi.fn>> = {};
-	const methods = ["select", "eq", "in", "order"];
+	const methods = ["select", "eq", "in", "is", "order"];
 	for (const m of methods) {
 		self[m] = vi.fn();
 	}
@@ -164,11 +164,12 @@ describe("personalRecordsOptions", () => {
 		expect(result).toEqual([]);
 	});
 
-	it("queries the personal_records table", async () => {
+	it("queries only active personal records", async () => {
 		chain = buildChain({ data: [], error: null });
 		const { personalRecordsOptions } = await import("../records");
 		const opts = personalRecordsOptions("user-1");
 		await opts.queryFn?.({} as never);
 		expect(fromFn).toHaveBeenCalledWith("personal_records");
+		expect(chain.is).toHaveBeenCalledWith("deleted_at", null);
 	});
 });

--- a/src/queries/__tests__/workouts.test.ts
+++ b/src/queries/__tests__/workouts.test.ts
@@ -11,6 +11,7 @@ function buildChain(terminal: { data: unknown; error: unknown }) {
 	const methods = [
 		"select",
 		"eq",
+		"is",
 		"order",
 		"limit",
 		"gte",
@@ -282,6 +283,7 @@ describe("recentPRsOptions", () => {
 		const { recentPRsOptions } = await import("../workouts");
 		const opts = recentPRsOptions("user-1");
 		const result = await opts.queryFn?.({} as never);
+		expect(chain.is).toHaveBeenCalledWith("deleted_at", null);
 		expect(result[0].value).toBe(200); // doubled
 		expect(result[0].previous_value).toBe(180); // doubled
 		expect(result[0].achieved_at).toBeInstanceOf(Date);

--- a/src/queries/analytics.ts
+++ b/src/queries/analytics.ts
@@ -117,7 +117,8 @@ export function strengthProgressOptions(
 			let query = supabase
 				.from("personal_records")
 				.select(STRENGTH_PROGRESS_WITH_CATALOG_SELECT)
-				.eq("user_id", userId);
+				.eq("user_id", userId)
+				.is("deleted_at", null);
 
 			if (profileId) {
 				query = query.eq("local_profile_id", profileId);

--- a/src/queries/challenges.ts
+++ b/src/queries/challenges.ts
@@ -104,6 +104,7 @@ export function challengeProgressOptions(
 						.from("personal_records")
 						.select("id")
 						.eq("user_id", userId)
+						.is("deleted_at", null)
 						.gte("achieved_at", startDate)
 						.lte("achieved_at", endDate);
 					if (error) throw error;

--- a/src/queries/profile.ts
+++ b/src/queries/profile.ts
@@ -69,7 +69,8 @@ export function profileStatsOptions(userId: string, profileId?: string | null) {
 			let prQuery = supabase
 				.from("personal_records")
 				.select("id", { count: "exact", head: true })
-				.eq("user_id", userId);
+				.eq("user_id", userId)
+				.is("deleted_at", null);
 
 			if (profileId) {
 				prQuery = prQuery.eq("local_profile_id", profileId);

--- a/src/queries/progress.ts
+++ b/src/queries/progress.ts
@@ -74,7 +74,8 @@ export function progressionWorkbenchOptions(
 			let recordsQuery = supabase
 				.from("personal_records")
 				.select(PERSONAL_RECORD_WITH_CATALOG_SELECT)
-				.eq("user_id", userId);
+				.eq("user_id", userId)
+				.is("deleted_at", null);
 
 			if (profileId) {
 				progressQuery = progressQuery.eq("local_profile_id", profileId);

--- a/src/queries/records.ts
+++ b/src/queries/records.ts
@@ -17,7 +17,8 @@ export function personalRecordsOptions(
 			let query = supabase
 				.from("personal_records")
 				.select(PERSONAL_RECORD_WITH_CATALOG_SELECT)
-				.eq("user_id", userId);
+				.eq("user_id", userId)
+				.is("deleted_at", null);
 
 			if (profileId) {
 				query = query.eq("local_profile_id", profileId);

--- a/src/queries/workouts.ts
+++ b/src/queries/workouts.ts
@@ -131,7 +131,8 @@ export function recentPRsOptions(userId: string, profileId?: string | null) {
 			let query = supabase
 				.from("personal_records")
 				.select(PERSONAL_RECORD_WITH_CATALOG_SELECT)
-				.eq("user_id", userId);
+				.eq("user_id", userId)
+				.is("deleted_at", null);
 
 			if (profileId) {
 				query = query.eq("local_profile_id", profileId);

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -574,7 +574,9 @@ export function buildDedicatedPersonalRecordRows(
 		};
 
 		if (record.id) row.id = record.id;
-		if (record.updatedAt) row.updated_at = record.updatedAt;
+		if (record.updatedAt ?? record.deletedAt) {
+			row.updated_at = record.updatedAt ?? record.deletedAt ?? undefined;
+		}
 		return row;
 	});
 }

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -55,6 +55,7 @@ export interface PersonalRecordRow {
 	session_id?: string | null;
 	achieved_at: string;
 	updated_at?: string;
+	deleted_at?: string | null;
 	workout_phase: string;
 }
 
@@ -73,6 +74,7 @@ export interface DedicatedPersonalRecordInput {
 	sessionId?: string | null;
 	achievedAt?: string | null;
 	updatedAt?: string | null;
+	deletedAt?: string | null;
 	localProfileId?: string | null;
 	workoutMode?: string | null;
 }
@@ -567,6 +569,7 @@ export function buildDedicatedPersonalRecordRows(
 			unit: unitForRecordType(recordType),
 			session_id: record.sessionId ?? null,
 			achieved_at: record.achievedAt ?? new Date().toISOString(),
+			deleted_at: record.deletedAt ?? null,
 			workout_phase: record.workoutPhase ?? "COMBINED",
 		};
 

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -447,6 +447,7 @@ const personalRecordSchema = z.object({
 	sessionId: nullableField(uuid),
 	achievedAt: datetimeWithDefault(() => new Date().toISOString()),
 	updatedAt: nullableDatetime(),
+	deletedAt: nullableDatetime(),
 	localProfileId: localProfileIdSchema.nullable().optional(),
 	// Accepted for wire compatibility; personal_records has no workout_mode
 	// column, so the push handler can only preserve this through session_id.

--- a/supabase/functions/compute-rankings/index.ts
+++ b/supabase/functions/compute-rankings/index.ts
@@ -553,6 +553,7 @@ async function computeWeeklyRankings(
       .from('personal_records')
       .select('user_id')
       .in('user_id', eligibleUserIds)
+      .is('deleted_at', null)
       .gte('achieved_at', `${start}T00:00:00Z`)
       .lte('achieved_at', `${end}T23:59:59Z`);
 

--- a/supabase/functions/generate-insights/index.ts
+++ b/supabase/functions/generate-insights/index.ts
@@ -509,6 +509,7 @@ Deno.serve(async (req) => {
       .from('personal_records')
       .select('exercise_name, record_type, workout_phase, value, previous_value')
       .eq('user_id', userId)
+      .is('deleted_at', null)
       .gte('achieved_at', currentStart.toISOString())
       .order('achieved_at', { ascending: false });
 

--- a/supabase/functions/mobile-sync-pull/index.test.ts
+++ b/supabase/functions/mobile-sync-pull/index.test.ts
@@ -60,6 +60,7 @@ interface AdminCall {
 interface AdminOptions {
   preferenceResult?: { data: unknown; error: unknown };
   preferenceThrow?: unknown;
+  rpcResults?: Record<string, { data: unknown; error: unknown }>;
 }
 
 function createAdminDouble(
@@ -79,6 +80,7 @@ function createAdminDouble(
       });
     }
     if (name === "get_personal_records_excluding_ids") {
+      const result = options.rpcResults?.[name] ?? { data: [], error: null };
       const builder: Record<string, unknown> = {};
       for (const method of ["order", "limit", "or"]) {
         builder[method] = () => builder;
@@ -87,11 +89,16 @@ function createAdminDouble(
         onFulfilled?: (value: unknown) => unknown,
         onRejected?: (reason: unknown) => unknown,
       ) =>
-        Promise.resolve({ data: [], error: null }).then(
+        Promise.resolve(result).then(
           onFulfilled,
           onRejected,
         );
       return builder;
+    }
+    if (name === "get_personal_record_tombstones") {
+      return Promise.resolve(
+        options.rpcResults?.[name] ?? { data: [], error: null },
+      );
     }
     return Promise.resolve({ data: [], error: null });
   };
@@ -132,6 +139,7 @@ function createAdminDouble(
         "limit",
         "in",
         "is",
+        "not",
       ]
     ) {
       builder[method] = (...args: unknown[]) => {
@@ -598,6 +606,68 @@ Deno.test("strict pull parser rejects every oversize parity list before privileg
     assertEquals(harness.adminConstructionCount.value, 0, field);
     assertEquals(harness.adminCalls, [], field);
   }
+});
+
+Deno.test("known personal record tombstones use the bounded RPC and remain tombstones", async () => {
+  const personalRecordId = "00000000-0000-4000-8000-000000000010";
+  const deletedAt = "2026-07-02T12:00:00.000Z";
+  const harness = makeHarness(undefined, {
+    rpcResults: {
+      get_personal_records_excluding_ids: { data: [], error: null },
+      get_personal_record_tombstones: {
+        data: [{
+          id: personalRecordId,
+          user_id: VALID_USER_ID,
+          local_profile_id: VALID_PROFILE_ID,
+          exercise_id: null,
+          exercise_name: "Bench Press",
+          muscle_group: "Chest",
+          record_type: "MAX_WEIGHT",
+          value: 100,
+          weight_kg: 100,
+          reps: 1,
+          workout_phase: "COMBINED",
+          session_id: null,
+          achieved_at: "2026-06-01T12:00:00.000Z",
+          updated_at: deletedAt,
+          deleted_at: deletedAt,
+        }],
+        error: null,
+      },
+    },
+  });
+  const response = await harness.handler(requestFromBody({
+    ...validPullBody(),
+    lastSync: Date.parse("2026-07-01T00:00:00.000Z"),
+    knownEntityIds: {
+      ...validPullBody().knownEntityIds as Record<string, unknown>,
+      personalRecordIds: [personalRecordId],
+    },
+  }));
+  const body = await json(response);
+
+  assertEquals(response.status, 200, JSON.stringify(body));
+  const tombstoneCall = harness.adminCalls.find((call) =>
+    call.kind === "rpc" && call.name === "get_personal_record_tombstones"
+  );
+  assert(tombstoneCall);
+  assertEquals(tombstoneCall.args?.p_known_ids, [personalRecordId]);
+  assertEquals(tombstoneCall.args?.p_last_sync_at, "2026-07-01T00:00:00.000Z");
+  assertEquals(tombstoneCall.args?.p_profile_id, VALID_PROFILE_ID);
+  assertEquals(tombstoneCall.args?.p_limit, 76);
+  assertEquals(
+    harness.adminCalls.find((call) =>
+      call.kind === "from" && call.name === "personal_records" &&
+      call.operations?.some((operation) =>
+        operation.name === "in" && operation.args[0] === "id"
+      )
+    ),
+    undefined,
+  );
+  const personalRecords = body.personalRecords as Record<string, unknown>[];
+  assertEquals(personalRecords.length, 1);
+  assertEquals(personalRecords[0].id, personalRecordId);
+  assertEquals(personalRecords[0].deletedAt, deletedAt);
 });
 
 Deno.test("first-page pull queries exact owner and profile and maps all five canonicals", async () => {

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -1309,7 +1309,47 @@ async function mobileSyncPullHandler(
 
         const { data, error } = await prQuery;
         if (error) return readFailure('personal records', error, cors);
-        personalRecordsData = (data as Record<string, unknown>[]) ?? [];
+        const unseenRows = (data as Record<string, unknown>[]) ?? [];
+
+        // The parity RPC intentionally excludes IDs the device already has.
+        // That is correct for active rows, but a later tombstone must be sent
+        // back to that same known ID or the client would retain it forever.
+        let knownTombstones: Record<string, unknown>[] = [];
+        if (knownPRIds.length > 0) {
+          let tombstoneQuery = supabase
+            .from('personal_records')
+            .select('*')
+            .eq('user_id', userId)
+            .in('id', knownPRIds)
+            .not('deleted_at', 'is', null)
+            .gt('updated_at', lastSyncISO)
+            .order('updated_at', { ascending: true })
+            .order('id', { ascending: true })
+            .limit(remainingPageSize + 1);
+          if (profileId) {
+            tombstoneQuery = tombstoneQuery.or(
+              buildLocalProfileOrNullPostgrestFilter(profileId),
+            );
+          }
+          if (cursorUpdatedAt && cursorId) {
+            tombstoneQuery = tombstoneQuery.or(
+              `updated_at.gt.${cursorUpdatedAt},and(updated_at.eq.${cursorUpdatedAt},id.gt.${cursorId})`,
+            );
+          }
+          const { data: tombstoneData, error: tombstoneError } = await tombstoneQuery;
+          if (tombstoneError) return readFailure('personal-record tombstones', tombstoneError, cors);
+          knownTombstones = (tombstoneData as Record<string, unknown>[]) ?? [];
+        }
+        const rowsById = new Map<string, Record<string, unknown>>();
+        for (const row of [...unseenRows, ...knownTombstones]) {
+          const id = typeof row.id === 'string' ? row.id : null;
+          if (id) rowsById.set(id, row);
+        }
+        personalRecordsData = [...rowsById.values()].sort((left, right) => {
+          const leftTime = String(left.updated_at ?? '');
+          const rightTime = String(right.updated_at ?? '');
+          return leftTime.localeCompare(rightTime) || String(left.id).localeCompare(String(right.id));
+        });
       } else {
         // Legacy timestamp-based mode
         let personalRecordsQuery = supabase
@@ -1364,6 +1404,7 @@ async function mobileSyncPullHandler(
         sessionId: pr.session_id,
         achievedAt: pr.achieved_at,
         updatedAt: pr.updated_at,
+        deletedAt: pr.deleted_at ?? null,
       }));
 
       remainingPageSize -= personalRecordDtos.length;

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -1316,27 +1316,16 @@ async function mobileSyncPullHandler(
         // back to that same known ID or the client would retain it forever.
         let knownTombstones: Record<string, unknown>[] = [];
         if (knownPRIds.length > 0) {
-          let tombstoneQuery = supabase
-            .from('personal_records')
-            .select('*')
-            .eq('user_id', userId)
-            .in('id', knownPRIds)
-            .not('deleted_at', 'is', null)
-            .gt('updated_at', lastSyncISO)
-            .order('updated_at', { ascending: true })
-            .order('id', { ascending: true })
-            .limit(remainingPageSize + 1);
-          if (profileId) {
-            tombstoneQuery = tombstoneQuery.or(
-              buildLocalProfileOrNullPostgrestFilter(profileId),
-            );
-          }
-          if (cursorUpdatedAt && cursorId) {
-            tombstoneQuery = tombstoneQuery.or(
-              `updated_at.gt.${cursorUpdatedAt},and(updated_at.eq.${cursorUpdatedAt},id.gt.${cursorId})`,
-            );
-          }
-          const { data: tombstoneData, error: tombstoneError } = await tombstoneQuery;
+          const { data: tombstoneData, error: tombstoneError } = await supabase
+            .rpc('get_personal_record_tombstones', {
+              p_user_id: userId,
+              p_known_ids: knownPRIds,
+              p_last_sync_at: lastSyncISO,
+              p_profile_id: profileId,
+              p_cursor_updated_at: cursorUpdatedAt,
+              p_cursor_id: cursorId,
+              p_limit: remainingPageSize + 1,
+            });
           if (tombstoneError) return readFailure('personal-record tombstones', tombstoneError, cors);
           knownTombstones = (tombstoneData as Record<string, unknown>[]) ?? [];
         }

--- a/supabase/functions/mobile-sync-push/index.test.ts
+++ b/supabase/functions/mobile-sync-push/index.test.ts
@@ -407,9 +407,14 @@ function streamingRawRequest(
 function permissiveQuery(
   table: string,
   onWrite: (method: string) => void,
+  terminalResult: { data: unknown; error: unknown; count?: number } = {
+    data: [],
+    error: null,
+    count: 0,
+  },
 ): Record<string, unknown> {
-  const defaultResult = { data: [], error: null, count: 0 };
   const query: Record<string, unknown> = {};
+  let ownershipProbe = false;
   const chainMethods = [
     "select",
     "eq",
@@ -429,6 +434,7 @@ function permissiveQuery(
   ];
   for (const method of chainMethods) {
     query[method] = (..._args: unknown[]) => {
+      if (method === "neq") ownershipProbe = true;
       if (["insert", "upsert", "update", "delete"].includes(method)) {
         onWrite(method);
       }
@@ -452,7 +458,10 @@ function permissiveQuery(
   query.then = (
     resolve: (value: unknown) => unknown,
     reject?: (reason: unknown) => unknown,
-  ) => Promise.resolve(defaultResult).then(resolve, reject);
+  ) =>
+    Promise.resolve(
+      ownershipProbe ? { data: [], error: null, count: 0 } : terminalResult,
+    ).then(resolve, reject);
   return query;
 }
 
@@ -470,7 +479,11 @@ interface PushHarness {
 
 function makeHarness(
   authBehavior: AuthBehavior = async () => VALID_AUTH_RESULT,
-  options: { channelError?: unknown; rpcBehavior?: RpcBehavior } = {},
+  options: {
+    channelError?: unknown;
+    rpcBehavior?: RpcBehavior;
+    personalRecordsResult?: { data: unknown; error: unknown };
+  } = {},
 ): PushHarness {
   const authClientAuthorizations: string[] = [];
   const getUserJwts: string[] = [];
@@ -488,7 +501,7 @@ function makeHarness(
       return permissiveQuery(table, (method) => {
         adminWriteCalls.push({ table, method });
         operationEvents.push(`write:${table}:${method}`);
-      });
+      }, table === "personal_records" ? options.personalRecordsResult : undefined);
     },
     async rpc(name: string, args: Record<string, unknown> = {}) {
       adminRpcCalls.push({ name, args });
@@ -1926,6 +1939,90 @@ Deno.test("legacy push response keeps ordinary fields and adds empty preference 
       call.name === "mutate_local_profile_preference_section"
     ),
     [],
+  );
+});
+
+Deno.test("a newer active personal record cannot resurrect a stored tombstone", async () => {
+  const personalRecordId = "00000000-0000-4000-8000-000000000040";
+  const harness = makeHarness(undefined, {
+    personalRecordsResult: {
+      data: [{
+        id: personalRecordId,
+        user_id: VALID_USER_ID,
+        local_profile_id: null,
+        exercise_id: null,
+        exercise_name: "Bench Press",
+        achieved_at: "2026-06-01T12:00:00.000Z",
+        record_type: "MAX_WEIGHT",
+        workout_phase: "COMBINED",
+        updated_at: "2026-07-02T12:00:00.000Z",
+        deleted_at: "2026-07-02T12:00:00.000Z",
+      }],
+      error: null,
+    },
+  });
+  const response = await harness.handler(requestFromBody({
+    ...validPushBody(),
+    personalRecords: [{
+      id: personalRecordId,
+      exerciseName: "Bench Press",
+      recordType: "MAX_WEIGHT",
+      value: 105,
+      achievedAt: "2026-06-01T12:00:00.000Z",
+      updatedAt: "2026-07-03T12:00:00.000Z",
+    }],
+  }));
+  const body = await json(response);
+
+  assertEquals(response.status, 200, JSON.stringify(body));
+  assertEquals(body.personalRecordsInserted, 0);
+  assertEquals(
+    harness.adminWriteCalls.filter((call) =>
+      call.table === "personal_records"
+    ),
+    [],
+  );
+});
+
+Deno.test("deletedAt is the LWW timestamp when a tombstone omits updatedAt", async () => {
+  const personalRecordId = "00000000-0000-4000-8000-000000000041";
+  const harness = makeHarness(undefined, {
+    personalRecordsResult: {
+      data: [{
+        id: personalRecordId,
+        user_id: VALID_USER_ID,
+        local_profile_id: null,
+        exercise_id: null,
+        exercise_name: "Squat",
+        achieved_at: "2026-06-01T12:00:00.000Z",
+        record_type: "MAX_WEIGHT",
+        workout_phase: "COMBINED",
+        updated_at: "2026-07-01T12:00:00.000Z",
+        deleted_at: null,
+      }],
+      error: null,
+    },
+  });
+  const response = await harness.handler(requestFromBody({
+    ...validPushBody(),
+    personalRecords: [{
+      id: personalRecordId,
+      exerciseName: "Squat",
+      recordType: "MAX_WEIGHT",
+      value: 150,
+      achievedAt: "2026-06-01T12:00:00.000Z",
+      deletedAt: "2026-07-02T12:00:00.000Z",
+    }],
+  }));
+  const body = await json(response);
+
+  assertEquals(response.status, 200, JSON.stringify(body));
+  assertEquals(body.personalRecordsInserted, 1);
+  assertEquals(
+    harness.adminWriteCalls.filter((call) =>
+      call.table === "personal_records"
+    ),
+    [{ table: "personal_records", method: "upsert" }],
   );
 });
 

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1912,7 +1912,7 @@ async function mobileSyncPushHandler(
       const achievedAtValues = [...new Set(prRows.map((row) => row.achieved_at as string))];
       const { data: existingPrs, error: existingPrErr } = await supabase
         .from('personal_records')
-        .select('id, local_profile_id, exercise_id, exercise_name, achieved_at, record_type, workout_phase')
+        .select('id, local_profile_id, exercise_id, exercise_name, achieved_at, record_type, workout_phase, updated_at, deleted_at')
         .eq('user_id', userId)
         .in('achieved_at', achievedAtValues);
       if (existingPrErr) {
@@ -1947,8 +1947,33 @@ async function mobileSyncPushHandler(
         return true;
       });
 
-      if (dedupedPrRows.length > 0) {
-        const writePersonalRecords = (rows: typeof dedupedPrRows) => dedicatedPrsPresent
+      // Dedicated records have stable UUIDs, so enforce the tombstone-aware
+      // last-write-wins rule before the ordinary Supabase upsert. An equal-time
+      // tombstone wins to make a delete monotonic rather than resurrectable.
+      const existingPrsById = new Map(
+        (existingPrs ?? [])
+          .filter((row) => typeof row.id === 'string')
+          .map((row) => [row.id as string, row]),
+      );
+      const prRowsToWrite = dedupedPrRows.filter((row) => {
+        if (!dedicatedPrsPresent || !row.id) return true;
+        const existing = existingPrsById.get(row.id);
+        if (!existing) return true;
+        const incomingUpdatedAt = Date.parse(row.updated_at ?? row.achieved_at);
+        const storedUpdatedAt = Date.parse(
+          String(existing.updated_at ?? existing.achieved_at),
+        );
+        if (Number.isNaN(incomingUpdatedAt) || Number.isNaN(storedUpdatedAt)) {
+          return false;
+        }
+        if (incomingUpdatedAt !== storedUpdatedAt) {
+          return incomingUpdatedAt > storedUpdatedAt;
+        }
+        return row.deleted_at != null && existing.deleted_at == null;
+      });
+
+      if (prRowsToWrite.length > 0) {
+        const writePersonalRecords = (rows: typeof prRowsToWrite) => dedicatedPrsPresent
           ? supabase
               .from('personal_records')
               .upsert(rows, { onConflict: 'id' })
@@ -1956,16 +1981,16 @@ async function mobileSyncPushHandler(
               .from('personal_records')
               .insert(rows);
 
-        const { error: prErr } = await writePersonalRecords(dedupedPrRows);
+        const { error: prErr } = await writePersonalRecords(prRowsToWrite);
         if (prErr && isPostgresForeignKeyViolation(prErr)) {
           const profilePartition = shouldValidatePersonalRecordProfileIds
             ? partitionPersonalRecordRowsByLocalProfileValidity(
-                dedupedPrRows,
+                prRowsToWrite,
                 validLocalProfileIdsForPush,
               )
             : {
                 invalidProfileRows: [],
-                rowsWithInvalidProfilesNulled: dedupedPrRows,
+                rowsWithInvalidProfilesNulled: prRowsToWrite,
               };
 
           // Issue #532: if the local_profile_id partition is a no-op (no
@@ -2020,7 +2045,7 @@ async function mobileSyncPushHandler(
         } else if (prErr) {
           throw new Error(`personal_records ${dedicatedPrsPresent ? 'upsert' : 'insert'} failed: ${prErr.message}`);
         } else {
-          personalRecordsInserted = dedupedPrRows.length;
+          personalRecordsInserted = prRowsToWrite.length;
         }
       }
     }

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1959,7 +1959,12 @@ async function mobileSyncPushHandler(
         if (!dedicatedPrsPresent || !row.id) return true;
         const existing = existingPrsById.get(row.id);
         if (!existing) return true;
-        const incomingUpdatedAt = Date.parse(row.updated_at ?? row.achieved_at);
+        // Once a UUID has been tombstoned, active writes cannot resurrect it,
+        // even if a stale client assigns the write a later timestamp.
+        if (existing.deleted_at != null && row.deleted_at == null) return false;
+        const incomingUpdatedAt = Date.parse(
+          row.updated_at ?? row.deleted_at ?? row.achieved_at,
+        );
         const storedUpdatedAt = Date.parse(
           String(existing.updated_at ?? existing.achieved_at),
         );

--- a/supabase/migrations/20260716211500_personal_record_tombstones.sql
+++ b/supabase/migrations/20260716211500_personal_record_tombstones.sql
@@ -22,3 +22,81 @@ DROP TRIGGER IF EXISTS personal_records_updated_at ON public.personal_records;
 CREATE TRIGGER personal_records_updated_at
 BEFORE UPDATE ON public.personal_records
 FOR EACH ROW EXECUTE FUNCTION public.update_personal_record_updated_at();
+
+-- A parity pull must only treat non-deleted rows as records that are new to
+-- the device. Recreate the RPC after adding deleted_at so its row type includes
+-- the tombstone column and unseen tombstones cannot be serialized as active.
+DROP FUNCTION IF EXISTS public.get_personal_records_excluding_ids(UUID, UUID[], TEXT);
+CREATE FUNCTION public.get_personal_records_excluding_ids(
+  p_user_id UUID,
+  p_known_ids UUID[] DEFAULT '{}',
+  p_profile_id TEXT DEFAULT NULL
+)
+RETURNS SETOF public.personal_records
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.*
+  FROM public.personal_records pr
+  WHERE pr.user_id = p_user_id
+    AND pr.deleted_at IS NULL
+    AND (array_length(p_known_ids, 1) IS NULL OR pr.id != ALL(p_known_ids))
+    AND (
+      p_profile_id IS NULL
+      OR (p_profile_id = 'default' AND pr.local_profile_id IS NULL)
+      OR pr.local_profile_id = p_profile_id
+    )
+  ORDER BY pr.updated_at ASC, pr.id ASC;
+$$;
+
+-- Known-ID tombstones travel through an RPC POST body. This avoids putting up
+-- to 10,000 UUIDs into a PostgREST query URL while retaining stable pagination.
+CREATE FUNCTION public.get_personal_record_tombstones(
+  p_user_id UUID,
+  p_known_ids UUID[] DEFAULT '{}',
+  p_last_sync_at TIMESTAMPTZ DEFAULT '-infinity',
+  p_profile_id TEXT DEFAULT NULL,
+  p_cursor_updated_at TIMESTAMPTZ DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL,
+  p_limit INT DEFAULT 76
+)
+RETURNS SETOF public.personal_records
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.*
+  FROM public.personal_records pr
+  WHERE pr.user_id = p_user_id
+    AND pr.id = ANY(p_known_ids)
+    AND pr.deleted_at IS NOT NULL
+    AND pr.updated_at > p_last_sync_at
+    AND (
+      p_profile_id IS NULL
+      OR (p_profile_id = 'default' AND pr.local_profile_id IS NULL)
+      OR pr.local_profile_id = p_profile_id
+    )
+    AND (
+      p_cursor_updated_at IS NULL
+      OR pr.updated_at > p_cursor_updated_at
+      OR (pr.updated_at = p_cursor_updated_at AND pr.id > p_cursor_id)
+    )
+  ORDER BY pr.updated_at ASC, pr.id ASC
+  LIMIT p_limit;
+$$;
+
+-- Both parity helpers are Edge Function internals. Dropping/recreating the
+-- existing function resets privileges, so restore the service-role-only grant.
+REVOKE ALL ON FUNCTION public.get_personal_records_excluding_ids(UUID, UUID[], TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_personal_records_excluding_ids(UUID, UUID[], TEXT)
+  TO service_role;
+REVOKE ALL ON FUNCTION public.get_personal_record_tombstones(
+  UUID, UUID[], TIMESTAMPTZ, TEXT, TIMESTAMPTZ, UUID, INT
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_personal_record_tombstones(
+  UUID, UUID[], TIMESTAMPTZ, TEXT, TIMESTAMPTZ, UUID, INT
+) TO service_role;

--- a/supabase/migrations/20260716211500_personal_record_tombstones.sql
+++ b/supabase/migrations/20260716211500_personal_record_tombstones.sql
@@ -1,0 +1,24 @@
+-- Issue #655: retain personal-record tombstones so deletes converge across devices.
+-- Existing rows remain active because deleted_at defaults to NULL.
+ALTER TABLE public.personal_records
+  ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ NULL;
+
+-- Mobile supplies the authoritative mutation timestamp used by the dedicated
+-- UUID LWW protocol. Preserve it when present; direct portal edits that leave
+-- updated_at unchanged still receive the normal server timestamp.
+CREATE OR REPLACE FUNCTION public.update_personal_record_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.updated_at IS NULL OR NEW.updated_at = OLD.updated_at THEN
+    NEW.updated_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS personal_records_updated_at ON public.personal_records;
+CREATE TRIGGER personal_records_updated_at
+BEFORE UPDATE ON public.personal_records
+FOR EACH ROW EXECUTE FUNCTION public.update_personal_record_updated_at();


### PR DESCRIPTION
## Summary
- add `deleted_at` migration and preserve mobile-provided LWW timestamps
- accept, persist, return, and reconcile dedicated personal-record tombstones
- preserve tombstones even when parity reconciliation knows the record UUID

## Verification
- `npm test -- --run src/lib/__tests__/sync-personal-records.test.ts src/lib/__tests__/sync-push-schema.test.ts` (98 tests)
- `npm run typecheck`

Refs 9thLevelSoftware/Project-Phoenix-MP#655