### PR TITLE
feat(sync): add personal record tombstones

### DIFF
--- a/src/lib/__tests__/sync-personal-records.test.ts
+++ b/src/lib/__tests__/sync-personal-records.test.ts
@@ -280,6 +280,31 @@ describe("buildDedicatedPersonalRecordRows", () => {
 		expect(out[0]?.workout_phase).toBe("COMBINED");
 		expect(out[0]?.local_profile_id).toBeNull();
 	});
+
+	it("preserves the stable ID and mutation timestamps for a tombstone", () => {
+		const out = buildDedicatedPersonalRecordRows(
+			[
+				{
+					id: "11111111-1111-4111-8111-111111111111",
+					exerciseName: "Bench Press",
+					recordType: "MAX_WEIGHT",
+					value: 125,
+					achievedAt: "2026-04-21T12:00:00.000Z",
+					updatedAt: "2026-04-22T12:00:00.000Z",
+					deletedAt: "2026-04-22T12:00:00.000Z",
+				},
+			],
+			USER_ID,
+			PROFILE_ID,
+		);
+
+		expect(out).toHaveLength(1);
+		expect(out[0]).toMatchObject({
+			id: "11111111-1111-4111-8111-111111111111",
+			updated_at: "2026-04-22T12:00:00.000Z",
+			deleted_at: "2026-04-22T12:00:00.000Z",
+		});
+	});
 });
 
 describe("buildPersonalRecordRowsForPush", () => {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -809,6 +809,7 @@ export type Database = {
 			personal_records: {
 				Row: {
 					achieved_at: string;
+					deleted_at: string | null;
 					exercise_id: string | null;
 					exercise_name: string;
 					id: string;
@@ -827,6 +828,7 @@ export type Database = {
 				};
 				Insert: {
 					achieved_at?: string;
+					deleted_at?: string | null;
 					exercise_id?: string | null;
 					exercise_name: string;
 					id?: string;
@@ -845,6 +847,7 @@ export type Database = {
 				};
 				Update: {
 					achieved_at?: string;
+					deleted_at?: string | null;
 					exercise_id?: string | null;
 					exercise_name?: string;
 					id?: string;
@@ -2388,14 +2391,17 @@ export type Database = {
 			};
 			get_personal_records_excluding_ids: {
 				Args: {
-					p_known_ids?: number[];
+					p_known_ids?: string[];
 					p_profile_id?: string;
+					p_since?: string;
 					p_user_id: string;
 				};
 				Returns: {
 					achieved_at: string;
+					deleted_at: string | null;
+					exercise_id: string | null;
 					exercise_name: string;
-					id: number;
+					id: string;
 					local_profile_id: string;
 					muscle_group: string;
 					record_type: string;
@@ -2406,6 +2412,14 @@ export type Database = {
 					value: number;
 					weight_kg: number;
 					workout_phase: string;
+				}[];
+			};
+			upsert_personal_record_lww: {
+				Args: { p_rows: Json };
+				Returns: {
+					accepted: boolean;
+					id: string;
+					server_updated_at: string | null;
 				}[];
 			};
 			get_pr_count_rankings: {

--- a/supabase/functions/_shared/personalRecordRow.ts
+++ b/supabase/functions/_shared/personalRecordRow.ts
@@ -55,6 +55,7 @@ export interface PersonalRecordRow {
 	session_id?: string | null;
 	achieved_at: string;
 	updated_at?: string;
+	deleted_at?: string | null;
 	workout_phase: string;
 }
 
@@ -73,6 +74,7 @@ export interface DedicatedPersonalRecordInput {
 	sessionId?: string | null;
 	achievedAt?: string | null;
 	updatedAt?: string | null;
+	deletedAt?: string | null;
 	localProfileId?: string | null;
 	workoutMode?: string | null;
 }
@@ -572,6 +574,7 @@ export function buildDedicatedPersonalRecordRows(
 
 		if (record.id) row.id = record.id;
 		if (record.updatedAt) row.updated_at = record.updatedAt;
+		if (record.deletedAt !== undefined) row.deleted_at = record.deletedAt;
 		return row;
 	});
 }

--- a/supabase/functions/_shared/pushPayloadSchema.ts
+++ b/supabase/functions/_shared/pushPayloadSchema.ts
@@ -447,6 +447,7 @@ const personalRecordSchema = z.object({
 	sessionId: nullableField(uuid),
 	achievedAt: datetimeWithDefault(() => new Date().toISOString()),
 	updatedAt: nullableDatetime(),
+	deletedAt: nullableDatetime(),
 	localProfileId: localProfileIdSchema.nullable().optional(),
 	// Accepted for wire compatibility; personal_records has no workout_mode
 	// column, so the push handler can only preserve this through session_id.

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -1296,6 +1296,7 @@ async function mobileSyncPullHandler(
           p_user_id: userId,
           p_known_ids: knownPRIds,
           p_profile_id: profileId,
+          p_since: lastSyncISO,
         })
           .order('updated_at', { ascending: true })
           .order('id', { ascending: true })
@@ -1364,6 +1365,7 @@ async function mobileSyncPullHandler(
         sessionId: pr.session_id,
         achievedAt: pr.achieved_at,
         updatedAt: pr.updated_at,
+        deletedAt: pr.deleted_at ?? null,
       }));
 
       remainingPageSize -= personalRecordDtos.length;

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1948,13 +1948,28 @@ async function mobileSyncPushHandler(
       });
 
       if (dedupedPrRows.length > 0) {
-        const writePersonalRecords = (rows: typeof dedupedPrRows) => dedicatedPrsPresent
-          ? supabase
+        const writePersonalRecords = async (rows: typeof dedupedPrRows) => {
+          if (!dedicatedPrsPresent) {
+            return supabase.from('personal_records').insert(rows);
+          }
+
+          // New mobile builds provide stable UUIDs. Route those rows through an
+          // atomic server-side LWW gate so a stale active write cannot resurrect
+          // a newer deletion tombstone. Keep the legacy id-less fallback for
+          // backwards-compatible clients that only send active PR hints.
+          const stableRows = rows.filter((row) => typeof row.id === 'string' && row.id.length > 0);
+          const legacyRows = rows.filter((row) => !(typeof row.id === 'string' && row.id.length > 0));
+          if (stableRows.length > 0) {
+            const { error } = await supabase.rpc('upsert_personal_record_lww', { p_rows: stableRows });
+            if (error) return { error };
+          }
+          if (legacyRows.length > 0) {
+            return supabase
               .from('personal_records')
-              .upsert(rows, { onConflict: 'id' })
-          : supabase
-              .from('personal_records')
-              .insert(rows);
+              .upsert(legacyRows, { onConflict: 'id' });
+          }
+          return { error: null };
+        };
 
         const { error: prErr } = await writePersonalRecords(dedupedPrRows);
         if (prErr && isPostgresForeignKeyViolation(prErr)) {

--- a/supabase/migrations/20260716000000_personal_record_tombstones.sql
+++ b/supabase/migrations/20260716000000_personal_record_tombstones.sql
@@ -1,0 +1,203 @@
+-- Issue #655: synchronizable Personal Record tombstones.
+-- Never hard-delete PR snapshots: mobile and portal reconcile the same stable UUID
+-- using updated_at, with deleted_at winning equal-timestamp conflicts.
+
+ALTER TABLE public.personal_records
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_personal_records_sync_cursor
+    ON public.personal_records (user_id, local_profile_id, updated_at, id);
+
+-- Replace the obsolete BIGINT parity contract with the UUID identity that the
+-- mobile client already sends. Known IDs are normally omitted, except that a
+-- tombstone changed since the client's checkpoint is deliberately returned.
+DROP FUNCTION IF EXISTS public.get_personal_records_excluding_ids(UUID, BIGINT[], TEXT);
+
+CREATE OR REPLACE FUNCTION public.get_personal_records_excluding_ids(
+    p_user_id UUID,
+    p_known_ids UUID[] DEFAULT '{}',
+    p_profile_id TEXT DEFAULT NULL,
+    p_since TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TABLE (
+    id UUID,
+    user_id UUID,
+    exercise_name TEXT,
+    exercise_id TEXT,
+    muscle_group TEXT,
+    record_type TEXT,
+    value NUMERIC,
+    weight_kg NUMERIC,
+    reps INT,
+    workout_phase TEXT,
+    session_id UUID,
+    achieved_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ,
+    deleted_at TIMESTAMPTZ,
+    local_profile_id TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        pr.id,
+        pr.user_id,
+        pr.exercise_name,
+        pr.exercise_id,
+        pr.muscle_group,
+        pr.record_type,
+        pr.value,
+        pr.weight_kg,
+        pr.reps,
+        pr.workout_phase,
+        pr.session_id,
+        pr.achieved_at,
+        pr.updated_at,
+        pr.deleted_at,
+        pr.local_profile_id
+    FROM public.personal_records pr
+    WHERE pr.user_id = p_user_id
+      AND (
+          cardinality(p_known_ids) = 0
+          OR pr.id <> ALL(p_known_ids)
+          OR (pr.deleted_at IS NOT NULL AND (p_since IS NULL OR pr.updated_at > p_since))
+      )
+      AND (
+          p_profile_id IS NULL
+          OR (p_profile_id = 'default' AND pr.local_profile_id IS NULL)
+          OR pr.local_profile_id = p_profile_id
+          OR pr.local_profile_id IS NULL
+      )
+    ORDER BY pr.updated_at ASC, pr.id ASC;
+$$;
+
+COMMENT ON FUNCTION public.get_personal_records_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ) IS
+    'Returns PR rows absent from the client parity list plus tombstones changed since the client checkpoint.';
+
+-- Atomic LWW upsert for stable-id mobile Personal Record rows. Rows without a
+-- stable ID retain the legacy handler path for backward compatibility, but a
+-- tombstone is always written through this function.
+CREATE OR REPLACE FUNCTION public.upsert_personal_record_lww(p_rows JSONB)
+RETURNS TABLE (
+    id UUID,
+    accepted BOOLEAN,
+    server_updated_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    incoming RECORD;
+    current_row public.personal_records%ROWTYPE;
+    incoming_updated_at TIMESTAMPTZ;
+    incoming_deleted_at TIMESTAMPTZ;
+    should_accept BOOLEAN;
+BEGIN
+    FOR incoming IN
+        SELECT * FROM jsonb_to_recordset(p_rows) AS rows(
+            id UUID,
+            user_id UUID,
+            local_profile_id TEXT,
+            exercise_name TEXT,
+            exercise_id TEXT,
+            muscle_group TEXT,
+            record_type TEXT,
+            value NUMERIC,
+            weight_kg NUMERIC,
+            reps INT,
+            unit TEXT,
+            session_id UUID,
+            achieved_at TIMESTAMPTZ,
+            updated_at TIMESTAMPTZ,
+            deleted_at TIMESTAMPTZ,
+            workout_phase TEXT
+        )
+    LOOP
+        SELECT * INTO current_row
+        FROM public.personal_records
+        WHERE personal_records.id = incoming.id
+        FOR UPDATE;
+
+        incoming_deleted_at := incoming.deleted_at;
+        incoming_updated_at := incoming.updated_at;
+
+        IF NOT FOUND THEN
+            incoming_updated_at := COALESCE(incoming_updated_at, now());
+            INSERT INTO public.personal_records (
+                id, user_id, local_profile_id, exercise_name, exercise_id,
+                muscle_group, record_type, value, weight_kg, reps, unit,
+                session_id, achieved_at, updated_at, deleted_at, workout_phase
+            ) VALUES (
+                incoming.id, incoming.user_id, incoming.local_profile_id,
+                incoming.exercise_name, incoming.exercise_id,
+                COALESCE(incoming.muscle_group, 'General'),
+                COALESCE(incoming.record_type, 'MAX_WEIGHT'),
+                COALESCE(incoming.value, 0), incoming.weight_kg, incoming.reps,
+                COALESCE(incoming.unit, 'kg'), incoming.session_id,
+                COALESCE(incoming.achieved_at, incoming_updated_at),
+                incoming_updated_at, incoming_deleted_at,
+                COALESCE(incoming.workout_phase, 'COMBINED')
+            ) ON CONFLICT (id) DO NOTHING;
+
+            id := incoming.id;
+            accepted := FOUND;
+            server_updated_at := incoming_updated_at;
+            RETURN NEXT;
+            CONTINUE;
+        END IF;
+
+        -- Never let an old client which lacks a mutation timestamp resurrect a
+        -- tombstoned stable record. For still-active historical rows, retain
+        -- the legacy server-time fallback.
+        IF incoming_updated_at IS NULL THEN
+            IF current_row.deleted_at IS NOT NULL AND incoming_deleted_at IS NULL THEN
+                id := incoming.id;
+                accepted := FALSE;
+                server_updated_at := current_row.updated_at;
+                RETURN NEXT;
+                CONTINUE;
+            END IF;
+            incoming_updated_at := now();
+        END IF;
+
+        should_accept := incoming.user_id = current_row.user_id
+            AND (
+                incoming_updated_at > current_row.updated_at
+                OR (
+                    incoming_updated_at = current_row.updated_at
+                    AND incoming_deleted_at IS NOT NULL
+                    AND current_row.deleted_at IS NULL
+                )
+            );
+
+        IF should_accept THEN
+            UPDATE public.personal_records
+            SET local_profile_id = incoming.local_profile_id,
+                exercise_name = incoming.exercise_name,
+                exercise_id = incoming.exercise_id,
+                muscle_group = COALESCE(incoming.muscle_group, 'General'),
+                record_type = COALESCE(incoming.record_type, 'MAX_WEIGHT'),
+                value = COALESCE(incoming.value, 0),
+                weight_kg = incoming.weight_kg,
+                reps = incoming.reps,
+                unit = COALESCE(incoming.unit, 'kg'),
+                session_id = incoming.session_id,
+                achieved_at = COALESCE(incoming.achieved_at, incoming_updated_at),
+                updated_at = incoming_updated_at,
+                deleted_at = incoming_deleted_at,
+                workout_phase = COALESCE(incoming.workout_phase, 'COMBINED')
+            WHERE personal_records.id = incoming.id;
+        END IF;
+
+        id := incoming.id;
+        accepted := should_accept;
+        server_updated_at := CASE WHEN should_accept THEN incoming_updated_at ELSE current_row.updated_at END;
+        RETURN NEXT;
+    END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_personal_record_lww(JSONB) IS
+    'Issue #655 stable UUID LWW upsert; equal timestamp tombstones win over active records.';


### PR DESCRIPTION
## Summary
- Add a portal `deleted_at` tombstone column, sync cursor index, and LWW RPC for stable Personal Record IDs.
- Preserve mobile tombstones in push payload validation/row construction and return changed tombstones even when the client already knows the ID.
- Retain id-less legacy active rows; stale active rows cannot overwrite equal/newer tombstones.

## Validation
- `npm run typecheck`
- `npm test -- --run src/lib/__tests__/sync-personal-records.test.ts` (63 tests)
- Targeted Biome check of changed supported files

## Coordination
Companion mobile PR will depend on this portal contract and must not enable the destructive UI in production before this migration/function is deployed.

Refs #655