### PR TITLE
fix: restrict parity sync RPC execution

### DIFF
--- a/supabase/migrations/20260706120000_fix_parity_sync_profile_bleed.sql
+++ b/supabase/migrations/20260706120000_fix_parity_sync_profile_bleed.sql
@@ -318,6 +318,32 @@ $$;
 COMMENT ON FUNCTION get_cycles_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT, TIMESTAMPTZ) IS
 'Fetches training cycles not in the provided ID list OR updated since last sync. Uses POST body via RPC to bypass URL length limits.';
 
+-- Restore service-role-only execution after DROP/CREATE. Newly-created
+-- PostgreSQL functions grant EXECUTE to PUBLIC by default, but these parity
+-- sync RPCs trust caller-supplied user IDs and are Edge Function internals.
+DO $$
+DECLARE
+  fn regprocedure;
+BEGIN
+  FOR fn IN
+    SELECT p.oid::regprocedure
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = ANY (ARRAY[
+        'get_sessions_excluding_ids',
+        'get_routines_excluding_ids',
+        'get_cycles_excluding_ids'
+      ])
+  LOOP
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC', fn);
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM anon', fn);
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM authenticated', fn);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', fn);
+  END LOOP;
+END;
+$$;
+
 -- ============================================================================
 -- get_personal_records_excluding_ids
 -- Source: 20260428234500_fix_parity_sync_uuid_badges_prs.sql


### PR DESCRIPTION
### Motivation
- A migration recreated `SECURITY DEFINER` parity-sync RPCs (`get_sessions_excluding_ids`, `get_routines_excluding_ids`, `get_cycles_excluding_ids`) but did not restore the prior function ACLs, which left the RPCs executable by `PUBLIC`/anon/authenticated and permitted anon callers to read other users' data by supplying arbitrary `p_user_id`, bypassing RLS and Edge Function protections.

### Description
- Added an ACL remediation block to `supabase/migrations/20260706120000_fix_parity_sync_profile_bleed.sql` that runs after the recreated RPCs and enforces service-role-only execution.
- The remediation scans `public` functions named `get_sessions_excluding_ids`, `get_routines_excluding_ids`, and `get_cycles_excluding_ids`, then executes `REVOKE ALL` from `PUBLIC`, `anon`, and `authenticated` and `GRANT EXECUTE` only to `service_role` for each function.
- No change was made to the RPC SQL logic or result shapes; this only restores the intended ACLs so the RPCs remain Edge Function internals.

### Testing
- Ran `npm run test:sync` and the sync unit tests completed successfully (all sync tests passed). 
- Ran a static ACL assertion script (`python` check) to confirm the new `REVOKE`/`GRANT` block is present, and it passed. 
- Ran `npm run verify:full`; unit tests and build steps completed successfully, but Playwright E2E failed in this environment because the Chromium browser binaries are not installed, so full E2E could not run here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c613ab9a083229665a6bf18881939)