### PR TITLE
fix(integrations): repair sync correctness and rate-limit scoping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,12 +79,18 @@ VITE_PADDLE_INFERNO_ANNUAL_PRICE_ID=
 # GARMIN_WEBHOOK_SECRET is REQUIRED for the garmin-webhook Edge Function. The
 # webhook rejects (503) if the env var is missing. Generate a strong random
 # string, configure it in Supabase Dashboard → Edge Functions → Secrets, and
-# provide it to Garmin during webhook URL registration. Garmin must include
-# the secret in every push as either:
-#   x-webhook-secret: <secret>
-# or:
-#   Authorization: Bearer <secret>
-# Comparison is timing-safe. See supabase/functions/garmin-webhook/index.ts.
+# provide it to Garmin during webhook URL registration.
+#
+# The webhook authenticates each push by HMAC-SHA256 over the RAW request body,
+# keyed with this secret, and expects the lowercase hex digest in:
+#   x-garmin-signature: <hex digest>
+# Comparison is timing-safe; a missing or mismatched header is a 401.
+# See supabase/functions/garmin-webhook/index.ts.
+#
+# NOTE: this scheme is not yet confirmed against Garmin's live specification —
+# the Connect Developer Program integration call is the point at which to verify
+# the header name and digest encoding Garmin actually sends, and to correct both
+# this file and the handler if they differ.
 
 # Token encryption at rest (oauth_tokens) — generate a 32-byte key, base64-encode
 # OAUTH_TOKEN_ENCRYPTION_KEY=

--- a/src/app/components/__tests__/ProviderCard.test.tsx
+++ b/src/app/components/__tests__/ProviderCard.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderCard } from "@/app/components/integrations/ProviderCard";
+import type {
+	IntegrationStatus,
+	UserIntegration,
+} from "@/lib/integrations/types";
+
+function makeIntegration(
+	status: IntegrationStatus,
+	overrides: Partial<UserIntegration> = {},
+): UserIntegration {
+	return {
+		id: "int-1",
+		user_id: "user-1",
+		provider: "strava",
+		provider_user_id: null,
+		connected_at: "2026-07-01T00:00:00Z",
+		last_sync_at: "2026-07-20T00:00:00Z",
+		status,
+		error_message: null,
+		...overrides,
+	};
+}
+
+function renderCard(
+	integration: UserIntegration | null,
+	props: Partial<React.ComponentProps<typeof ProviderCard>> = {},
+) {
+	const handlers = {
+		onConnect: vi.fn(),
+		onDisconnect: vi.fn(),
+		onSync: vi.fn(),
+	};
+	render(
+		<ProviderCard
+			provider="strava"
+			integration={integration}
+			{...handlers}
+			{...props}
+		/>,
+	);
+	return handlers;
+}
+
+describe("ProviderCard — connected", () => {
+	it("offers sync and disconnect", () => {
+		renderCard(makeIntegration("connected"));
+
+		expect(screen.getByText("Connected")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /sync now/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /disconnect/i }),
+		).toBeInTheDocument();
+	});
+});
+
+describe("ProviderCard — never connected", () => {
+	it("offers a plain Connect button", () => {
+		renderCard(null);
+
+		expect(
+			screen.getByRole("button", { name: /connect strava/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /reconnect/i }),
+		).not.toBeInTheDocument();
+	});
+});
+
+describe("ProviderCard — token_expired", () => {
+	it("explains the lapse instead of showing a bare Connect button", () => {
+		renderCard(makeIntegration("token_expired"));
+
+		expect(screen.getByText("Reconnection needed")).toBeInTheDocument();
+		expect(screen.getByText(/authorization has expired/i)).toBeInTheDocument();
+	});
+
+	it("offers Reconnect and Disconnect", () => {
+		renderCard(makeIntegration("token_expired"));
+
+		expect(
+			screen.getByRole("button", { name: /reconnect strava/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /disconnect/i }),
+		).toBeInTheDocument();
+	});
+
+	it("does not offer Sync Now — syncing cannot succeed without a valid token", () => {
+		renderCard(makeIntegration("token_expired"));
+
+		expect(
+			screen.queryByRole("button", { name: /sync now/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("routes Reconnect through the connect handler", async () => {
+		const handlers = renderCard(makeIntegration("token_expired"));
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /reconnect strava/i }),
+		);
+
+		expect(handlers.onConnect).toHaveBeenCalledOnce();
+	});
+
+	it("prefers the provider's own error message when present", () => {
+		renderCard(
+			makeIntegration("token_expired", {
+				error_message: "Token refresh failed",
+			}),
+		);
+
+		expect(screen.getByText("Token refresh failed")).toBeInTheDocument();
+	});
+});
+
+describe("ProviderCard — error", () => {
+	it("labels the state as a sync error, not a missing connection", () => {
+		renderCard(makeIntegration("error"));
+
+		expect(screen.getByText("Sync error")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /reconnect strava/i }),
+		).toBeInTheDocument();
+	});
+
+	it("surfaces the recorded error message", () => {
+		renderCard(
+			makeIntegration("error", {
+				error_message: "Failed to persist 3 of 12 activities",
+			}),
+		);
+
+		expect(
+			screen.getByText("Failed to persist 3 of 12 activities"),
+		).toBeInTheDocument();
+	});
+});
+
+describe("ProviderCard — comingSoon", () => {
+	it("blocks connection when the provider is not yet approved", () => {
+		renderCard(null, { comingSoon: true });
+
+		expect(
+			screen.getByText(/awaiting developer program approval/i),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: /connect strava/i }),
+		).toBeDisabled();
+	});
+
+	it("still lets a lapsed connection be recovered", () => {
+		// A user who connected before the flag was raised must not be stranded.
+		renderCard(makeIntegration("token_expired"), { comingSoon: true });
+
+		expect(
+			screen.getByRole("button", { name: /reconnect strava/i }),
+		).toBeInTheDocument();
+	});
+});

--- a/src/app/components/integrations/ProviderCard.tsx
+++ b/src/app/components/integrations/ProviderCard.tsx
@@ -64,6 +64,13 @@ export function ProviderCard({
 	const meta = PROVIDER_METADATA[provider];
 	const Icon = ICON_MAP[meta.icon] ?? Activity;
 
+	// A lapsed connection is distinct from never having connected. `token_expired`
+	// means the provider revoked or aged out our grant; `error` means syncing hit
+	// a failure the sync function could not recover from. Both need a reconnect
+	// prompt rather than the first-run Connect button.
+	const isTokenExpired = integration?.status === "token_expired";
+	const needsAttention = isTokenExpired || integration?.status === "error";
+
 	return (
 		<Card className="border-border/50">
 			<CardHeader>
@@ -110,6 +117,41 @@ export function ProviderCard({
 									Sync Now
 								</Button>
 							)}
+							<Button onClick={onDisconnect} variant="outline" size="sm">
+								Disconnect
+							</Button>
+						</div>
+					</div>
+				) : needsAttention ? (
+					// token_expired / error are NOT the same as "never connected": the
+					// user granted access and it has since lapsed. Rendering a bare
+					// Connect button here left them with no indication anything had
+					// broken, and no way to clear the stale connection.
+					<div className="space-y-4">
+						<Badge
+							className={
+								isTokenExpired
+									? "bg-amber-500/20 text-amber-400 border-amber-500/30"
+									: "bg-destructive/20 text-destructive border-destructive/30"
+							}
+						>
+							{isTokenExpired ? "Reconnection needed" : "Sync error"}
+						</Badge>
+						<Alert variant="destructive">
+							<AlertDescription>
+								{integration?.error_message ??
+									(isTokenExpired
+										? `Your ${meta.name} authorization has expired. Reconnect to resume syncing.`
+										: `${meta.name} syncing stopped after an error. Reconnect to try again.`)}
+							</AlertDescription>
+						</Alert>
+						<p className="text-sm text-muted-foreground">
+							Last synced: {formatRelative(integration?.last_sync_at ?? null)}
+						</p>
+						<div className="flex gap-2">
+							<Button onClick={onConnect} size="sm" disabled={isLoading}>
+								Reconnect {meta.name}
+							</Button>
 							<Button onClick={onDisconnect} variant="outline" size="sm">
 								Disconnect
 							</Button>

--- a/src/lib/__tests__/hevy-sync.test.ts
+++ b/src/lib/__tests__/hevy-sync.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createHevyPageFetcher,
+	fetchHevyBackfill,
+	fetchHevyEvents,
+	foldWorkoutEvents,
+	HEVY_PAGE_SIZE,
+	HevyAuthError,
+	type HevyWorkout,
+	type HevyWorkoutEvent,
+	hevyExternalId,
+	toExternalActivityRow,
+} from "../../../supabase/functions/_shared/hevySync.ts";
+
+function makeWorkout(id: string, overrides: Partial<HevyWorkout> = {}) {
+	return {
+		id,
+		title: `Workout ${id}`,
+		start_time: "2026-07-01T10:00:00Z",
+		end_time: "2026-07-01T11:00:00Z",
+		...overrides,
+	} satisfies HevyWorkout;
+}
+
+/** Build a fetcher that serves canned pages and records the params it saw. */
+function pagedFetcher(pages: unknown[]) {
+	const calls: Array<{ path: string; params: Record<string, string> }> = [];
+	const fetchPage = vi.fn(async (path: string, params: URLSearchParams) => {
+		calls.push({ path, params: Object.fromEntries(params) });
+		return pages[calls.length - 1] ?? { page: 1, page_count: 1, workouts: [] };
+	});
+	return { fetchPage, calls };
+}
+
+// ─── foldWorkoutEvents ───────────────────────────────────────────────────────
+
+describe("foldWorkoutEvents", () => {
+	it("splits updated workouts from deleted ids", () => {
+		const events: HevyWorkoutEvent[] = [
+			{ type: "updated", workout: makeWorkout("a") },
+			{ type: "deleted", id: "b", deleted_at: "2026-07-02T00:00:00Z" },
+			{ type: "updated", workout: makeWorkout("c") },
+		];
+
+		const result = foldWorkoutEvents(events);
+
+		expect(result.workouts.map((w) => w.id)).toEqual(["a", "c"]);
+		expect(result.deletedIds).toEqual(["b"]);
+	});
+
+	it("ignores unrecognised event types rather than throwing", () => {
+		const events = [
+			{ type: "restored", id: "x" },
+			{ type: "updated", workout: makeWorkout("a") },
+		] as unknown as HevyWorkoutEvent[];
+
+		expect(foldWorkoutEvents(events)).toEqual({
+			workouts: [makeWorkout("a")],
+			deletedIds: [],
+		});
+	});
+
+	it("returns empty collections for an empty page", () => {
+		expect(foldWorkoutEvents([])).toEqual({ workouts: [], deletedIds: [] });
+	});
+});
+
+// ─── fetchHevyBackfill ───────────────────────────────────────────────────────
+
+describe("fetchHevyBackfill", () => {
+	it("always sends page and pageSize (regression: unpaginated call imported only page 1)", async () => {
+		const { fetchPage, calls } = pagedFetcher([
+			{ page: 1, page_count: 1, workouts: [makeWorkout("a")] },
+		]);
+
+		await fetchHevyBackfill(fetchPage);
+
+		expect(calls[0].path).toBe("/workouts");
+		expect(calls[0].params.page).toBe("1");
+		expect(calls[0].params.pageSize).toBe(String(HEVY_PAGE_SIZE));
+	});
+
+	it("never requests a pageSize above Hevy's cap of 10", async () => {
+		const { fetchPage, calls } = pagedFetcher([
+			{ page: 1, page_count: 1, workouts: [] },
+		]);
+
+		await fetchHevyBackfill(fetchPage);
+
+		expect(Number(calls[0].params.pageSize)).toBeLessThanOrEqual(10);
+	});
+
+	it("walks every page reported by page_count", async () => {
+		const { fetchPage, calls } = pagedFetcher([
+			{ page: 1, page_count: 3, workouts: [makeWorkout("a")] },
+			{ page: 2, page_count: 3, workouts: [makeWorkout("b")] },
+			{ page: 3, page_count: 3, workouts: [makeWorkout("c")] },
+		]);
+
+		const result = await fetchHevyBackfill(fetchPage);
+
+		expect(calls.map((c) => c.params.page)).toEqual(["1", "2", "3"]);
+		expect(result.workouts.map((w) => w.id)).toEqual(["a", "b", "c"]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("does not stop early when a page lands exactly on the size boundary", async () => {
+		const fullPage = Array.from({ length: HEVY_PAGE_SIZE }, (_, i) =>
+			makeWorkout(`p1-${i}`),
+		);
+		const { fetchPage } = pagedFetcher([
+			{ page: 1, page_count: 2, workouts: fullPage },
+			{ page: 2, page_count: 2, workouts: [makeWorkout("p2-0")] },
+		]);
+
+		const result = await fetchHevyBackfill(fetchPage);
+
+		expect(result.workouts).toHaveLength(HEVY_PAGE_SIZE + 1);
+	});
+
+	it("flags truncation when the page budget is exhausted", async () => {
+		const { fetchPage } = pagedFetcher([
+			{ page: 1, page_count: 50, workouts: [makeWorkout("a")] },
+			{ page: 2, page_count: 50, workouts: [makeWorkout("b")] },
+		]);
+
+		const result = await fetchHevyBackfill(fetchPage, 2);
+
+		expect(result.truncated).toBe(true);
+		expect(result.workouts).toHaveLength(2);
+	});
+
+	it("tolerates a malformed page body without throwing", async () => {
+		const { fetchPage } = pagedFetcher([{}]);
+
+		const result = await fetchHevyBackfill(fetchPage);
+
+		expect(result).toEqual({ workouts: [], deletedIds: [], truncated: false });
+	});
+});
+
+// ─── fetchHevyEvents ─────────────────────────────────────────────────────────
+
+describe("fetchHevyEvents", () => {
+	it("passes the since watermark through on every page", async () => {
+		const since = "2026-07-01T00:00:00.000Z";
+		const { fetchPage, calls } = pagedFetcher([
+			{ page: 1, page_count: 2, events: [] },
+			{ page: 2, page_count: 2, events: [] },
+		]);
+
+		await fetchHevyEvents(fetchPage, since);
+
+		expect(calls).toHaveLength(2);
+		for (const call of calls) {
+			expect(call.path).toBe("/workouts/events");
+			expect(call.params.since).toBe(since);
+		}
+	});
+
+	it("accumulates updates and deletions across pages", async () => {
+		const { fetchPage } = pagedFetcher([
+			{
+				page: 1,
+				page_count: 2,
+				events: [
+					{ type: "updated", workout: makeWorkout("a") },
+					{ type: "deleted", id: "gone-1" },
+				],
+			},
+			{
+				page: 2,
+				page_count: 2,
+				events: [{ type: "deleted", id: "gone-2" }],
+			},
+		]);
+
+		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z");
+
+		expect(result.workouts.map((w) => w.id)).toEqual(["a"]);
+		expect(result.deletedIds).toEqual(["gone-1", "gone-2"]);
+		expect(result.truncated).toBe(false);
+	});
+
+	it("flags truncation so the caller withholds the watermark advance", async () => {
+		const { fetchPage } = pagedFetcher([
+			{ page: 1, page_count: 9, events: [] },
+		]);
+
+		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z", 1);
+
+		expect(result.truncated).toBe(true);
+	});
+});
+
+// ─── createHevyPageFetcher ───────────────────────────────────────────────────
+
+describe("createHevyPageFetcher", () => {
+	function jsonResponse(body: unknown, status = 200) {
+		return new Response(JSON.stringify(body), { status });
+	}
+
+	it("sends the api-key header and builds the query string", async () => {
+		const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
+		const fetchPage = createHevyPageFetcher(
+			"secret-key",
+			fetchImpl as unknown as typeof fetch,
+		);
+
+		await fetchPage("/workouts", new URLSearchParams({ page: "2" }));
+
+		const [url, init] = fetchImpl.mock.calls[0] as unknown as [
+			string,
+			RequestInit,
+		];
+		expect(url).toBe("https://api.hevyapp.com/v1/workouts?page=2");
+		expect((init.headers as Record<string, string>)["api-key"]).toBe(
+			"secret-key",
+		);
+	});
+
+	it.each([401, 403])("maps %i onto HevyAuthError", async (status) => {
+		const fetchImpl = vi.fn(async () => jsonResponse({}, status));
+		const fetchPage = createHevyPageFetcher(
+			"bad-key",
+			fetchImpl as unknown as typeof fetch,
+		);
+
+		await expect(fetchPage("/workouts", new URLSearchParams())).rejects.toThrow(
+			HevyAuthError,
+		);
+	});
+
+	it("maps other non-2xx responses onto a generic error", async () => {
+		const fetchImpl = vi.fn(async () => jsonResponse({}, 500));
+		const fetchPage = createHevyPageFetcher(
+			"key",
+			fetchImpl as unknown as typeof fetch,
+		);
+
+		const promise = fetchPage("/workouts", new URLSearchParams());
+		await expect(promise).rejects.toThrow("Hevy API returned 500");
+		await expect(promise).rejects.not.toThrow(HevyAuthError);
+	});
+});
+
+// ─── row mapping ─────────────────────────────────────────────────────────────
+
+describe("toExternalActivityRow", () => {
+	it("derives an external_id that collides with the CSV import path", () => {
+		expect(hevyExternalId("abc")).toBe("hevy-abc");
+		expect(toExternalActivityRow("u1", makeWorkout("abc")).external_id).toBe(
+			"hevy-abc",
+		);
+	});
+
+	it("computes duration in seconds from the start/end pair", () => {
+		const row = toExternalActivityRow("u1", makeWorkout("a"));
+		expect(row.duration_seconds).toBe(3600);
+	});
+
+	it("stores null rather than a negative duration when end precedes start", () => {
+		const row = toExternalActivityRow(
+			"u1",
+			makeWorkout("a", { end_time: "2026-07-01T09:00:00Z" }),
+		);
+		expect(row.duration_seconds).toBeNull();
+	});
+
+	it("stores null duration when end_time is unparseable", () => {
+		const row = toExternalActivityRow(
+			"u1",
+			makeWorkout("a", { end_time: "not-a-date" }),
+		);
+		expect(row.duration_seconds).toBeNull();
+	});
+
+	it("preserves the raw payload for later re-normalization", () => {
+		const workout = makeWorkout("a");
+		expect(toExternalActivityRow("u1", workout).raw_data).toBe(workout);
+	});
+});

--- a/src/lib/__tests__/hevy-sync.test.ts
+++ b/src/lib/__tests__/hevy-sync.test.ts
@@ -9,6 +9,7 @@ import {
 	type HevyWorkout,
 	type HevyWorkoutEvent,
 	hevyExternalId,
+	maxIsoTimestamp,
 	toExternalActivityRow,
 } from "../../../supabase/functions/_shared/hevySync.ts";
 
@@ -135,7 +136,26 @@ describe("fetchHevyBackfill", () => {
 
 		const result = await fetchHevyBackfill(fetchPage);
 
-		expect(result).toEqual({ workouts: [], deletedIds: [], truncated: false });
+		expect(result).toEqual({
+			workouts: [],
+			deletedIds: [],
+			truncated: false,
+			latestEventAt: null,
+		});
+	});
+
+	it("reports no resume point — /v1/workouts has no date filter to resume from", () => {
+		// Guards the asymmetry the sync handler depends on: a truncated backfill
+		// must NOT be retried, because the retry would reissue an identical
+		// request. Only the events feed can resume.
+		return fetchHevyBackfill(
+			pagedFetcher([{ page: 1, page_count: 9, workouts: [makeWorkout("a")] }])
+				.fetchPage,
+			1,
+		).then((result) => {
+			expect(result.truncated).toBe(true);
+			expect(result.latestEventAt).toBeNull();
+		});
 	});
 });
 
@@ -190,6 +210,126 @@ describe("fetchHevyEvents", () => {
 		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z", 1);
 
 		expect(result.truncated).toBe(true);
+	});
+
+	it("reports the newest event processed so a truncated run can resume", async () => {
+		// Without this the retry replays the original `since`, truncates
+		// identically, and burns the queue's retry cap without progressing.
+		const { fetchPage } = pagedFetcher([
+			{
+				page: 1,
+				page_count: 5,
+				events: [
+					{
+						type: "updated",
+						workout: makeWorkout("a", {
+							updated_at: "2026-07-02T00:00:00Z",
+						}),
+					},
+					{
+						type: "updated",
+						workout: makeWorkout("b", {
+							updated_at: "2026-07-05T00:00:00Z",
+						}),
+					},
+				],
+			},
+		]);
+
+		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z", 1);
+
+		expect(result.truncated).toBe(true);
+		expect(result.latestEventAt).toBe("2026-07-05T00:00:00Z");
+	});
+
+	it("advances the resume point past deletions too", async () => {
+		const { fetchPage } = pagedFetcher([
+			{
+				page: 1,
+				page_count: 1,
+				events: [
+					{ type: "deleted", id: "x", deleted_at: "2026-07-09T00:00:00Z" },
+				],
+			},
+		]);
+
+		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z");
+
+		expect(result.latestEventAt).toBe("2026-07-09T00:00:00Z");
+	});
+
+	it("leaves the resume point null when no event carries a timestamp", async () => {
+		const { fetchPage } = pagedFetcher([
+			{
+				page: 1,
+				page_count: 1,
+				events: [{ type: "updated", workout: makeWorkout("a") }],
+			},
+		]);
+
+		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z");
+
+		expect(result.latestEventAt).toBeNull();
+	});
+
+	it("takes the newest timestamp across pages regardless of arrival order", async () => {
+		const { fetchPage } = pagedFetcher([
+			{
+				page: 1,
+				page_count: 2,
+				events: [
+					{
+						type: "updated",
+						workout: makeWorkout("a", {
+							updated_at: "2026-07-20T00:00:00Z",
+						}),
+					},
+				],
+			},
+			{
+				page: 2,
+				page_count: 2,
+				events: [
+					{
+						type: "updated",
+						workout: makeWorkout("b", {
+							updated_at: "2026-07-11T00:00:00Z",
+						}),
+					},
+				],
+			},
+		]);
+
+		const result = await fetchHevyEvents(fetchPage, "2026-07-01T00:00:00Z");
+
+		expect(result.latestEventAt).toBe("2026-07-20T00:00:00Z");
+	});
+});
+
+describe("maxIsoTimestamp", () => {
+	it("returns the later of two timestamps", () => {
+		expect(
+			maxIsoTimestamp("2026-07-01T00:00:00Z", "2026-07-02T00:00:00Z"),
+		).toBe("2026-07-02T00:00:00Z");
+		expect(
+			maxIsoTimestamp("2026-07-03T00:00:00Z", "2026-07-02T00:00:00Z"),
+		).toBe("2026-07-03T00:00:00Z");
+	});
+
+	it("tolerates nulls on either side", () => {
+		expect(maxIsoTimestamp(null, "2026-07-02T00:00:00Z")).toBe(
+			"2026-07-02T00:00:00Z",
+		);
+		expect(maxIsoTimestamp("2026-07-02T00:00:00Z", null)).toBe(
+			"2026-07-02T00:00:00Z",
+		);
+		expect(maxIsoTimestamp(null, null)).toBeNull();
+	});
+
+	it("ignores unparseable candidates rather than poisoning the watermark", () => {
+		expect(maxIsoTimestamp("2026-07-02T00:00:00Z", "not-a-date")).toBe(
+			"2026-07-02T00:00:00Z",
+		);
 	});
 });
 

--- a/src/lib/__tests__/provider-rate-limit.test.ts
+++ b/src/lib/__tests__/provider-rate-limit.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import {
+	checkReadBudget,
+	dailyRateLimitKey,
+	parseRateLimitPair,
+	parseRetryAfterSeconds,
+	parseStravaRateLimitHeaders,
+	startOfCurrentQuarterHour,
+	startOfUtcDay,
+	topOfCurrentHour,
+} from "../../../supabase/functions/_shared/providerRateLimit.ts";
+
+// ─── Window boundaries ───────────────────────────────────────────────────────
+
+describe("startOfCurrentQuarterHour", () => {
+	it.each([
+		["2026-07-28T10:00:00.000Z", "2026-07-28T10:00:00.000Z"],
+		["2026-07-28T10:07:31.500Z", "2026-07-28T10:00:00.000Z"],
+		["2026-07-28T10:14:59.999Z", "2026-07-28T10:00:00.000Z"],
+		["2026-07-28T10:15:00.000Z", "2026-07-28T10:15:00.000Z"],
+		["2026-07-28T10:44:00.000Z", "2026-07-28T10:30:00.000Z"],
+		["2026-07-28T10:59:59.000Z", "2026-07-28T10:45:00.000Z"],
+	])("floors %s to %s", (input, expected) => {
+		expect(startOfCurrentQuarterHour(new Date(input))).toBe(expected);
+	});
+
+	it("anchors to Strava's natural boundaries, not 15 minutes from now", () => {
+		// A 429 at 10:14 must clear at 10:15, not 10:29.
+		expect(startOfCurrentQuarterHour(new Date("2026-07-28T10:14:00Z"))).toBe(
+			"2026-07-28T10:00:00.000Z",
+		);
+	});
+});
+
+describe("topOfCurrentHour", () => {
+	it("floors to the hour boundary", () => {
+		expect(topOfCurrentHour(new Date("2026-07-28T10:59:59Z"))).toBe(
+			"2026-07-28T10:00:00.000Z",
+		);
+	});
+});
+
+describe("startOfUtcDay", () => {
+	it("floors to midnight UTC", () => {
+		expect(startOfUtcDay(new Date("2026-07-28T23:59:59Z"))).toBe(
+			"2026-07-28T00:00:00.000Z",
+		);
+	});
+});
+
+// ─── Header parsing ──────────────────────────────────────────────────────────
+
+describe("parseRateLimitPair", () => {
+	it("splits Strava's comma-separated 15-minute/daily pair", () => {
+		expect(parseRateLimitPair("100,1000")).toEqual({
+			shortTerm: 100,
+			daily: 1000,
+		});
+	});
+
+	it("tolerates surrounding whitespace", () => {
+		expect(parseRateLimitPair(" 42 , 900 ")).toEqual({
+			shortTerm: 42,
+			daily: 900,
+		});
+	});
+
+	it("returns nulls for a missing header rather than zeros", () => {
+		// Zero would read as "no quota consumed" — wrong in the permissive
+		// direction, which is the dangerous one.
+		expect(parseRateLimitPair(null)).toEqual({ shortTerm: null, daily: null });
+	});
+
+	it("returns null for unparseable components", () => {
+		expect(parseRateLimitPair("abc,1000")).toEqual({
+			shortTerm: null,
+			daily: 1000,
+		});
+	});
+
+	it("returns null for an absent daily component", () => {
+		expect(parseRateLimitPair("100")).toEqual({ shortTerm: 100, daily: null });
+	});
+});
+
+describe("parseStravaRateLimitHeaders", () => {
+	it("reads both the overall and read-specific quotas", () => {
+		const headers = new Headers({
+			"x-ratelimit-limit": "200,2000",
+			"x-ratelimit-usage": "35,410",
+			"x-readratelimit-limit": "100,1000",
+			"x-readratelimit-usage": "20,300",
+		});
+
+		expect(parseStravaRateLimitHeaders(headers)).toEqual({
+			overallLimit: { shortTerm: 200, daily: 2000 },
+			overallUsage: { shortTerm: 35, daily: 410 },
+			readLimit: { shortTerm: 100, daily: 1000 },
+			readUsage: { shortTerm: 20, daily: 300 },
+		});
+	});
+
+	it("yields nulls throughout when Strava sends no quota headers", () => {
+		const snapshot = parseStravaRateLimitHeaders(new Headers());
+		expect(snapshot.readLimit).toEqual({ shortTerm: null, daily: null });
+		expect(snapshot.overallUsage).toEqual({ shortTerm: null, daily: null });
+	});
+});
+
+describe("parseRetryAfterSeconds", () => {
+	it("reads delta-seconds", () => {
+		expect(parseRetryAfterSeconds(new Headers({ "retry-after": "120" }))).toBe(
+			120,
+		);
+	});
+
+	it("reads an HTTP date relative to now", () => {
+		const now = new Date("2026-07-28T10:00:00Z");
+		const headers = new Headers({
+			"retry-after": "Tue, 28 Jul 2026 10:02:00 GMT",
+		});
+		expect(parseRetryAfterSeconds(headers, now)).toBe(120);
+	});
+
+	it("floors a past date at zero rather than going negative", () => {
+		const now = new Date("2026-07-28T10:00:00Z");
+		const headers = new Headers({
+			"retry-after": "Tue, 28 Jul 2026 09:58:00 GMT",
+		});
+		expect(parseRetryAfterSeconds(headers, now)).toBe(0);
+	});
+
+	it("returns null when the header is absent", () => {
+		expect(parseRetryAfterSeconds(new Headers())).toBeNull();
+	});
+
+	it("returns null when the header is gibberish", () => {
+		expect(
+			parseRetryAfterSeconds(new Headers({ "retry-after": "soon" })),
+		).toBeNull();
+	});
+});
+
+// ─── Budget decisions ────────────────────────────────────────────────────────
+
+function snapshotOf(readLimit: string, readUsage: string) {
+	return parseStravaRateLimitHeaders(
+		new Headers({
+			"x-readratelimit-limit": readLimit,
+			"x-readratelimit-usage": readUsage,
+		}),
+	);
+}
+
+describe("checkReadBudget", () => {
+	it("reports headroom well inside the quota", () => {
+		expect(checkReadBudget(snapshotOf("100,1000", "10,100"))).toEqual({
+			hasHeadroom: true,
+			remaining: 90,
+		});
+	});
+
+	it("takes the tighter of the 15-minute and daily windows", () => {
+		// 15-min has 90 left, daily only 5 — the daily cap governs.
+		expect(checkReadBudget(snapshotOf("100,1000", "10,995"))).toEqual({
+			hasHeadroom: true,
+			remaining: 5,
+		});
+	});
+
+	it("reports exhaustion once the daily quota is spent", () => {
+		const budget = checkReadBudget(snapshotOf("100,1000", "10,1000"));
+		expect(budget.hasHeadroom).toBe(false);
+	});
+
+	it("subtracts the reserve so one backfill cannot drain the shared budget", () => {
+		// 20 requests left, but 20 are reserved for everyone else.
+		const budget = checkReadBudget(snapshotOf("100,1000", "80,100"), 20);
+		expect(budget).toEqual({ hasHeadroom: false, remaining: 0 });
+	});
+
+	it("still permits requests when the reserve leaves headroom", () => {
+		expect(checkReadBudget(snapshotOf("100,1000", "70,100"), 20)).toEqual({
+			hasHeadroom: true,
+			remaining: 10,
+		});
+	});
+
+	it("falls back to the overall quota when read headers are absent", () => {
+		const snapshot = parseStravaRateLimitHeaders(
+			new Headers({
+				"x-ratelimit-limit": "200,2000",
+				"x-ratelimit-usage": "150,500",
+			}),
+		);
+		expect(checkReadBudget(snapshot)).toEqual({
+			hasHeadroom: true,
+			remaining: 50,
+		});
+	});
+
+	it("permits the request when no headers are usable, deferring to the page ceiling", () => {
+		// Failing closed here would halt all syncing the moment Strava changed
+		// or dropped a header name.
+		expect(checkReadBudget(parseStravaRateLimitHeaders(new Headers()))).toEqual(
+			{
+				hasHeadroom: true,
+				remaining: null,
+			},
+		);
+	});
+});
+
+describe("dailyRateLimitKey", () => {
+	it("namespaces the daily bucket away from the short-window row", () => {
+		expect(dailyRateLimitKey("strava")).toBe("strava:daily");
+		expect(dailyRateLimitKey("strava")).not.toBe("strava");
+	});
+});

--- a/src/lib/__tests__/rate-limit-parity.test.ts
+++ b/src/lib/__tests__/rate-limit-parity.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	DAILY_RATE_LIMITS,
+	RATE_LIMIT_SCOPES,
+	RATE_LIMITS,
+} from "@/lib/integrations/rate-limits";
+
+/**
+ * The sync queue processor runs under Deno and calls `Deno.serve` at module
+ * scope, so it cannot be imported here. Its rate-limit configuration is instead
+ * parsed out of the source, the same way rate-limit-schema.test.ts reads the
+ * migration SQL.
+ *
+ * These two config blocks are duplicated by necessity (browser bundle vs Deno
+ * runtime). Silent drift between them is the failure this test exists to catch:
+ * the client would render a sync button the server then refuses, or vice versa.
+ */
+const queueProcessorSource = readFileSync(
+	join(
+		process.cwd(),
+		"supabase",
+		"functions",
+		"process-sync-queue",
+		"index.ts",
+	),
+	"utf8",
+);
+
+function extractObjectLiteral(source: string, declaration: string): string {
+	const start = source.indexOf(declaration);
+	if (start === -1) {
+		throw new Error(`Could not find "${declaration}" in process-sync-queue`);
+	}
+	// Anchor on the assignment, not the first brace: these declarations carry a
+	// `Record<string, { ... }>` type annotation whose braces would otherwise be
+	// mistaken for the value.
+	const assignment = source.indexOf("= {", start);
+	if (assignment === -1) {
+		throw new Error(`Could not find assignment for "${declaration}"`);
+	}
+	const open = source.indexOf("{", assignment);
+	let depth = 0;
+	for (let i = open; i < source.length; i++) {
+		if (source[i] === "{") depth++;
+		if (source[i] === "}") {
+			depth--;
+			if (depth === 0) return source.slice(open, i + 1);
+		}
+	}
+	throw new Error(`Unterminated object literal for "${declaration}"`);
+}
+
+function parseEdgeRateLimits(
+	declaration = "const RATE_LIMITS",
+): Record<string, { requests: number; windowMs: number }> {
+	const body = extractObjectLiteral(queueProcessorSource, declaration);
+	const entries: Record<string, { requests: number; windowMs: number }> = {};
+
+	// e.g. `strava: { requests: 80, windowMs: 15 * 60 * 1000 },`
+	const rowPattern =
+		/(\w+):\s*\{\s*requests:\s*(\d+),\s*windowMs:\s*([\d\s*]+?)\s*\}/g;
+	for (const match of body.matchAll(rowPattern)) {
+		const [, provider, requests, windowExpr] = match;
+		const windowMs = windowExpr
+			.split("*")
+			.map((part) => Number(part.trim()))
+			.reduce((a, b) => a * b, 1);
+		entries[provider] = { requests: Number(requests), windowMs };
+	}
+	return entries;
+}
+
+function parseEdgeScopes(): Record<string, string> {
+	const body = extractObjectLiteral(
+		queueProcessorSource,
+		"const RATE_LIMIT_SCOPE",
+	);
+	const entries: Record<string, string> = {};
+	for (const match of body.matchAll(/(\w+):\s*'(app|user)'/g)) {
+		entries[match[1]] = match[2];
+	}
+	return entries;
+}
+
+describe("rate limit config parity (client vs sync queue processor)", () => {
+	it("parses a non-empty config out of the queue processor", () => {
+		// Guards the parser itself — a silently-empty parse would make every
+		// comparison below vacuously pass.
+		expect(Object.keys(parseEdgeRateLimits()).length).toBeGreaterThan(0);
+		expect(Object.keys(parseEdgeScopes()).length).toBeGreaterThan(0);
+	});
+
+	it("declares the same providers on both sides", () => {
+		expect(Object.keys(parseEdgeRateLimits()).sort()).toEqual(
+			Object.keys(RATE_LIMITS).sort(),
+		);
+	});
+
+	it("agrees on requests and window for every provider", () => {
+		expect(parseEdgeRateLimits()).toEqual(RATE_LIMITS);
+	});
+
+	it("agrees on the quota scope for every provider", () => {
+		expect(parseEdgeScopes()).toEqual(RATE_LIMIT_SCOPES);
+	});
+
+	it("assigns a scope to every rate-limited provider", () => {
+		for (const provider of Object.keys(RATE_LIMITS)) {
+			expect(
+				RATE_LIMIT_SCOPES[provider],
+				`${provider} has a rate limit but no declared scope`,
+			).toMatch(/^(app|user)$/);
+		}
+	});
+
+	it("keeps Fitbit user-scoped (regression: a shared bucket capped all users at one allowance)", () => {
+		expect(RATE_LIMIT_SCOPES.fitbit).toBe("user");
+	});
+
+	it("keeps Strava app-scoped (its published quota is per application)", () => {
+		expect(RATE_LIMIT_SCOPES.strava).toBe("app");
+	});
+
+	it("agrees on the daily quota window for every provider that has one", () => {
+		expect(parseEdgeRateLimits("const DAILY_RATE_LIMITS")).toEqual(
+			DAILY_RATE_LIMITS,
+		);
+	});
+
+	it("tracks Strava's daily read cap (regression: only the 15-min window was modelled)", () => {
+		expect(DAILY_RATE_LIMITS.strava.requests).toBeLessThanOrEqual(1000);
+		expect(DAILY_RATE_LIMITS.strava.windowMs).toBe(24 * 60 * 60 * 1000);
+	});
+
+	it("keeps every daily quota looser than its short-window counterpart", () => {
+		for (const [provider, daily] of Object.entries(DAILY_RATE_LIMITS)) {
+			expect(daily.windowMs).toBeGreaterThan(RATE_LIMITS[provider].windowMs);
+			expect(daily.requests).toBeGreaterThan(RATE_LIMITS[provider].requests);
+		}
+	});
+
+	it("stays at or below each provider's documented ceiling", () => {
+		// Documented limits; config carries a deliberate ~20% safety margin.
+		const documented: Record<string, number> = {
+			strava: 100, // per 15 min, non-upload (read) limit
+			fitbit: 150, // per hour, per user
+		};
+		for (const [provider, ceiling] of Object.entries(documented)) {
+			expect(RATE_LIMITS[provider].requests).toBeLessThanOrEqual(ceiling);
+		}
+	});
+});

--- a/src/lib/integrations/rate-limits.ts
+++ b/src/lib/integrations/rate-limits.ts
@@ -1,16 +1,57 @@
 /**
  * Rate limit configuration per integration provider.
  * Values include a 20% safety margin below documented API limits.
+ *
+ * MUST stay in sync with RATE_LIMITS in
+ * `supabase/functions/process-sync-queue/index.ts` — enforced by
+ * `src/lib/__tests__/rate-limit-schema.test.ts`.
  */
 export const RATE_LIMITS: Record<
 	string,
 	{ requests: number; windowMs: number }
 > = {
 	strava: { requests: 80, windowMs: 15 * 60 * 1000 }, // 80/15min (reserve 20% of 100)
-	fitbit: { requests: 120, windowMs: 60 * 60 * 1000 }, // 120/hr (reserve 20% of 150)
+	fitbit: { requests: 120, windowMs: 60 * 60 * 1000 }, // 120/hr per user (reserve 20% of 150)
 	garmin: { requests: 40, windowMs: 60 * 60 * 1000 }, // Conservative estimate
 	hevy: { requests: 40, windowMs: 60 * 60 * 1000 }, // Conservative estimate
 	liftosaur: { requests: 40, windowMs: 60 * 60 * 1000 }, // Mirrors process-sync-queue server limit
+};
+
+/**
+ * Whether a provider's quota is charged against the whole application or
+ * against each authorizing user independently.
+ *
+ * Modelling a per-user quota as an app-wide bucket caps the entire user base at
+ * one user's allowance; modelling an app-wide quota as per-user overruns the
+ * provider's limit once enough users connect. Neither direction is safe to
+ * guess, so each provider is declared explicitly.
+ *
+ * MUST stay in sync with RATE_LIMIT_SCOPE in
+ * `supabase/functions/process-sync-queue/index.ts`.
+ */
+export const RATE_LIMIT_SCOPES: Record<string, "app" | "user"> = {
+	strava: "app", // Documented per registered application, across all athletes
+	garmin: "app", // Metered per consumer key
+	fitbit: "user", // 150 req/hr for EACH authorized user, resets on the hour
+	hevy: "user", // Per-user API key
+	liftosaur: "user", // Per-user API key
+};
+
+/**
+ * Second, longer quota window for providers that publish one.
+ *
+ * Strava enforces 100 reads/15min AND 1,000 reads/day. Tracking only the short
+ * window lets a steady trickle of syncs exhaust the daily allowance and start
+ * collecting 429s with no local state able to explain it.
+ *
+ * MUST stay in sync with DAILY_RATE_LIMITS in
+ * `supabase/functions/process-sync-queue/index.ts`.
+ */
+export const DAILY_RATE_LIMITS: Record<
+	string,
+	{ requests: number; windowMs: number }
+> = {
+	strava: { requests: 800, windowMs: 24 * 60 * 60 * 1000 }, // reserve 20% of 1,000
 };
 
 /**

--- a/src/mutations/__tests__/integrations.test.ts
+++ b/src/mutations/__tests__/integrations.test.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { MANUAL_SYNC_PROVIDERS } from "@/mutations/integrations";
+
+/**
+ * The portal's manual-sync button dispatches to `<provider>-sync`. If that
+ * function does not exist the invoke fails at runtime, and if a function exists
+ * but the provider is absent from the list the feature is silently unreachable
+ * — which is exactly how Liftosaur shipped with a working sync nobody could
+ * trigger from the portal.
+ */
+function syncFunctionExists(provider: string): boolean {
+	return existsSync(
+		join(
+			process.cwd(),
+			"supabase",
+			"functions",
+			`${provider}-sync`,
+			"index.ts",
+		),
+	);
+}
+
+describe("MANUAL_SYNC_PROVIDERS", () => {
+	it("lists only providers that have a deployable sync Edge Function", () => {
+		for (const provider of MANUAL_SYNC_PROVIDERS) {
+			expect(
+				syncFunctionExists(provider),
+				`supabase/functions/${provider}-sync/index.ts is missing`,
+			).toBe(true);
+		}
+	});
+
+	it("includes liftosaur (regression: sync function existed but was unreachable)", () => {
+		expect(MANUAL_SYNC_PROVIDERS).toContain("liftosaur");
+	});
+
+	it("excludes garmin, which is webhook-driven and has nothing to pull", () => {
+		expect(MANUAL_SYNC_PROVIDERS).not.toContain("garmin");
+		expect(syncFunctionExists("garmin")).toBe(false);
+	});
+
+	it("excludes providers with no server-side pull path", () => {
+		for (const provider of ["strong", "apple_health", "google_health"]) {
+			expect(MANUAL_SYNC_PROVIDERS).not.toContain(provider);
+		}
+	});
+
+	it("has no duplicate entries", () => {
+		expect(new Set(MANUAL_SYNC_PROVIDERS).size).toBe(
+			MANUAL_SYNC_PROVIDERS.length,
+		);
+	});
+});

--- a/src/mutations/integrations.ts
+++ b/src/mutations/integrations.ts
@@ -3,10 +3,20 @@ import type { IntegrationProvider } from "@/lib/integrations/types";
 import { supabase } from "@/lib/supabase";
 import { queryKeys } from "@/queries/keys";
 
-const MANUAL_SYNC_PROVIDERS: IntegrationProvider[] = [
+/**
+ * Providers with a `<provider>-sync` Edge Function that the portal may invoke
+ * on demand. Garmin is excluded because it is webhook-driven (there is nothing
+ * to pull); Strong is a local file import; Apple Health and Health Connect are
+ * pushed from the mobile app.
+ *
+ * Must stay aligned with the sync functions that actually exist under
+ * `supabase/functions/` — enforced by src/mutations/__tests__/integrations.test.ts.
+ */
+export const MANUAL_SYNC_PROVIDERS: IntegrationProvider[] = [
 	"strava",
 	"fitbit",
 	"hevy",
+	"liftosaur",
 ];
 
 /**

--- a/supabase/functions/_shared/hevySync.ts
+++ b/supabase/functions/_shared/hevySync.ts
@@ -37,6 +37,8 @@ export interface HevyWorkout {
   title: string;
   start_time: string;
   end_time: string;
+  /** ISO 8601; used as the resume point for truncated event fetches. */
+  updated_at?: string;
   exercises?: Array<{
     title: string;
     sets: Array<{
@@ -71,6 +73,30 @@ export interface HevyFetchResult {
   deletedIds: string[];
   /** True when the page ceiling was hit before the API ran out of pages. */
   truncated: boolean;
+  /**
+   * Latest `updated_at` observed across the fetched events, or null.
+   *
+   * This is the resume point for a truncated incremental fetch: replaying
+   * `events?since=` from here continues after what was already processed,
+   * rather than re-reading the same first pages forever. Only meaningful for
+   * the events path — `/v1/workouts` offers no date filter, so a truncated
+   * backfill has no derivable resume point.
+   */
+  latestEventAt: string | null;
+}
+
+/** Max of two ISO timestamps, tolerating nulls and unparseable values. */
+export function maxIsoTimestamp(
+  a: string | null,
+  b: string | null | undefined,
+): string | null {
+  if (!b) return a;
+  const bMs = Date.parse(b);
+  if (!Number.isFinite(bMs)) return a;
+  if (!a) return b;
+  const aMs = Date.parse(a);
+  if (!Number.isFinite(aMs)) return b;
+  return bMs > aMs ? b : a;
 }
 
 /** Fetches one page and returns its parsed JSON body. */
@@ -160,7 +186,12 @@ export async function fetchHevyBackfill(
     page++;
   }
 
-  return { workouts, deletedIds: [], truncated: page <= pageCount };
+  return {
+    workouts,
+    deletedIds: [],
+    truncated: page <= pageCount,
+    latestEventAt: null,
+  };
 }
 
 /**
@@ -176,6 +207,7 @@ export async function fetchHevyEvents(
   const deletedIds: string[] = [];
   let page = 1;
   let pageCount = 1;
+  let latestEventAt: string | null = null;
 
   while (page <= pageCount && page <= maxPages) {
     const params = new URLSearchParams({
@@ -193,11 +225,20 @@ export async function fetchHevyEvents(
     workouts.push(...folded.workouts);
     deletedIds.push(...folded.deletedIds);
 
+    // Track how far through the event stream we got so a truncated run can
+    // resume rather than replaying from the original `since`.
+    for (const event of data?.events ?? []) {
+      latestEventAt =
+        event?.type === 'deleted'
+          ? maxIsoTimestamp(latestEventAt, event.deleted_at)
+          : maxIsoTimestamp(latestEventAt, event?.workout?.updated_at);
+    }
+
     pageCount = data?.page_count ?? 1;
     page++;
   }
 
-  return { workouts, deletedIds, truncated: page <= pageCount };
+  return { workouts, deletedIds, truncated: page <= pageCount, latestEventAt };
 }
 
 /**

--- a/supabase/functions/_shared/hevySync.ts
+++ b/supabase/functions/_shared/hevySync.ts
@@ -1,0 +1,238 @@
+/**
+ * Hevy public API client helpers.
+ *
+ * Pure/injectable pieces of the Hevy sync live here so they can be exercised
+ * from Vitest (see src/lib/__tests__/hevy-sync.test.ts) without standing up an
+ * Edge Function. `hevy-sync/index.ts` composes these with Supabase persistence.
+ *
+ * API reference: https://api.hevyapp.com/docs
+ */
+
+export const HEVY_API_BASE = 'https://api.hevyapp.com/v1';
+
+/**
+ * Hevy caps `pageSize` at 10 for the workout endpoints. Requesting more is a
+ * 400; requesting none returns a single short page, which is why an unpaginated
+ * call silently imports only the first handful of workouts.
+ */
+export const HEVY_PAGE_SIZE = 10;
+
+/**
+ * Ceiling on pages per invocation so one enormous account cannot run past the
+ * Edge Function wall-clock budget. A truncated run must not advance the sync
+ * watermark — see `HevyFetchResult.truncated`.
+ */
+export const HEVY_MAX_PAGES = 100;
+
+/** Raised for 401/403 so callers can mark the integration as key-invalid. */
+export class HevyAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HevyAuthError';
+  }
+}
+
+export interface HevyWorkout {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  exercises?: Array<{
+    title: string;
+    sets: Array<{
+      set_type: string;
+      weight_kg: number;
+      reps: number;
+      rpe: number | null;
+    }>;
+  }>;
+}
+
+/** GET /v1/workouts -> { page, page_count, workouts[] } */
+export interface HevyPaginatedWorkouts {
+  page: number;
+  page_count: number;
+  workouts: HevyWorkout[];
+}
+
+/** GET /v1/workouts/events -> { page, page_count, events[] } */
+export type HevyWorkoutEvent =
+  | { type: 'updated'; workout: HevyWorkout }
+  | { type: 'deleted'; id: string; deleted_at?: string };
+
+export interface HevyPaginatedEvents {
+  page: number;
+  page_count: number;
+  events: HevyWorkoutEvent[];
+}
+
+export interface HevyFetchResult {
+  workouts: HevyWorkout[];
+  deletedIds: string[];
+  /** True when the page ceiling was hit before the API ran out of pages. */
+  truncated: boolean;
+}
+
+/** Fetches one page and returns its parsed JSON body. */
+export type HevyPageFetcher = (
+  path: string,
+  params: URLSearchParams,
+) => Promise<unknown>;
+
+/**
+ * Build a page fetcher bound to an API key, mapping Hevy's auth failures onto
+ * HevyAuthError and any other non-2xx onto a generic Error.
+ */
+export function createHevyPageFetcher(
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): HevyPageFetcher {
+  return async (path, params) => {
+    const response = await fetchImpl(
+      `${HEVY_API_BASE}${path}?${params.toString()}`,
+      {
+        headers: {
+          'api-key': apiKey,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (response.status === 401 || response.status === 403) {
+      throw new HevyAuthError(
+        'Hevy API access denied. Verify your API key and Hevy PRO subscription.',
+      );
+    }
+    if (!response.ok) {
+      throw new Error(`Hevy API returned ${response.status}`);
+    }
+    return await response.json();
+  };
+}
+
+/**
+ * Split a page of workout events into upserts and deletions.
+ * Unknown event types are ignored rather than throwing, so a future Hevy event
+ * kind cannot break an otherwise healthy sync.
+ */
+export function foldWorkoutEvents(events: readonly HevyWorkoutEvent[]): {
+  workouts: HevyWorkout[];
+  deletedIds: string[];
+} {
+  const workouts: HevyWorkout[] = [];
+  const deletedIds: string[] = [];
+
+  for (const event of events) {
+    if (event?.type === 'deleted' && event.id) {
+      deletedIds.push(event.id);
+    } else if (event?.type === 'updated' && event.workout) {
+      workouts.push(event.workout);
+    }
+  }
+
+  return { workouts, deletedIds };
+}
+
+/**
+ * Full backfill via GET /v1/workouts.
+ *
+ * Terminates on `page_count` rather than inferring the end from a short page,
+ * so a final page landing exactly on the size boundary is not mistaken for the
+ * end of the collection.
+ */
+export async function fetchHevyBackfill(
+  fetchPage: HevyPageFetcher,
+  maxPages: number = HEVY_MAX_PAGES,
+): Promise<HevyFetchResult> {
+  const workouts: HevyWorkout[] = [];
+  let page = 1;
+  let pageCount = 1;
+
+  while (page <= pageCount && page <= maxPages) {
+    const params = new URLSearchParams({
+      page: String(page),
+      pageSize: String(HEVY_PAGE_SIZE),
+    });
+
+    const data = (await fetchPage('/workouts', params)) as HevyPaginatedWorkouts;
+    workouts.push(...(data?.workouts ?? []));
+    pageCount = data?.page_count ?? 1;
+    page++;
+  }
+
+  return { workouts, deletedIds: [], truncated: page <= pageCount };
+}
+
+/**
+ * Incremental fetch via GET /v1/workouts/events?since=.
+ * Returns updated workouts to upsert and deleted workout ids to remove.
+ */
+export async function fetchHevyEvents(
+  fetchPage: HevyPageFetcher,
+  since: string,
+  maxPages: number = HEVY_MAX_PAGES,
+): Promise<HevyFetchResult> {
+  const workouts: HevyWorkout[] = [];
+  const deletedIds: string[] = [];
+  let page = 1;
+  let pageCount = 1;
+
+  while (page <= pageCount && page <= maxPages) {
+    const params = new URLSearchParams({
+      page: String(page),
+      pageSize: String(HEVY_PAGE_SIZE),
+      since,
+    });
+
+    const data = (await fetchPage(
+      '/workouts/events',
+      params,
+    )) as HevyPaginatedEvents;
+
+    const folded = foldWorkoutEvents(data?.events ?? []);
+    workouts.push(...folded.workouts);
+    deletedIds.push(...folded.deletedIds);
+
+    pageCount = data?.page_count ?? 1;
+    page++;
+  }
+
+  return { workouts, deletedIds, truncated: page <= pageCount };
+}
+
+/**
+ * external_activities.external_id for a Hevy workout.
+ *
+ * The `hevy-` prefix is load-bearing: it is what the CSV import path
+ * (src/lib/integrations/hevy.ts) and mobile-integration-sync also produce, so
+ * the same workout arriving by any route collides on the same row.
+ */
+export function hevyExternalId(workoutId: string): string {
+  return `hevy-${workoutId}`;
+}
+
+/** Map a Hevy workout onto an external_activities row. */
+export function toExternalActivityRow(
+  userId: string,
+  workout: HevyWorkout,
+): Record<string, unknown> {
+  const startTime = new Date(workout.start_time);
+  const endTime = new Date(workout.end_time);
+  const startMs = startTime.getTime();
+  const endMs = endTime.getTime();
+  const durationSeconds = Number.isFinite(startMs) && Number.isFinite(endMs)
+    ? Math.round((endMs - startMs) / 1000)
+    : 0;
+
+  return {
+    user_id: userId,
+    external_id: hevyExternalId(workout.id),
+    provider: 'hevy',
+    name: workout.title,
+    activity_type: 'strength',
+    started_at: startTime.toISOString(),
+    duration_seconds: durationSeconds > 0 ? durationSeconds : null,
+    calories: null, // Hevy API does not provide calorie data
+    raw_data: workout,
+  };
+}

--- a/supabase/functions/_shared/providerRateLimit.ts
+++ b/supabase/functions/_shared/providerRateLimit.ts
@@ -1,0 +1,230 @@
+/**
+ * Provider rate-limit accounting.
+ *
+ * Providers report their own quota state on every response. Reading those
+ * headers is strictly better than inferring usage locally: a local counter
+ * cannot see requests made by another Edge Function instance, cannot see the
+ * provider's own clock, and drifts permanently once the two disagree.
+ *
+ * Pure helpers live here so they can be tested from Vitest — see
+ * src/lib/__tests__/provider-rate-limit.test.ts.
+ */
+
+// ─── Window boundaries ───────────────────────────────────────────────────────
+
+/**
+ * Strava resets its 15-minute window "at natural 15-minute intervals
+ * corresponding to 0, 15, 30 and 45 minutes after the hour" — not 15 minutes
+ * after whenever we happened to get throttled.
+ */
+export function startOfCurrentQuarterHour(now: Date = new Date()): string {
+  const d = new Date(now.getTime());
+  d.setUTCMinutes(Math.floor(d.getUTCMinutes() / 15) * 15, 0, 0);
+  return d.toISOString();
+}
+
+/** Fitbit's per-user quota resets at the top of each hour. */
+export function topOfCurrentHour(now: Date = new Date()): string {
+  const d = new Date(now.getTime());
+  d.setUTCMinutes(0, 0, 0);
+  return d.toISOString();
+}
+
+/** Strava's daily quota resets at midnight UTC. */
+export function startOfUtcDay(now: Date = new Date()): string {
+  const d = new Date(now.getTime());
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+// ─── Header parsing ──────────────────────────────────────────────────────────
+
+export interface RateLimitPair {
+  /** Quota for the 15-minute window. */
+  shortTerm: number | null;
+  /** Quota for the rolling day. */
+  daily: number | null;
+}
+
+export interface StravaRateLimitSnapshot {
+  /** X-RateLimit-Limit / X-RateLimit-Usage — all request types. */
+  overallLimit: RateLimitPair;
+  overallUsage: RateLimitPair;
+  /** X-ReadRateLimit-Limit / X-ReadRateLimit-Usage — read requests only. */
+  readLimit: RateLimitPair;
+  readUsage: RateLimitPair;
+}
+
+/**
+ * Strava sends each quota header as two comma-separated integers:
+ * "<15-minute value>,<daily value>". Missing or malformed headers yield nulls
+ * rather than zeros — zero would read as "no quota consumed" and is dangerously
+ * wrong in the permissive direction.
+ */
+export function parseRateLimitPair(value: string | null): RateLimitPair {
+  if (!value) return { shortTerm: null, daily: null };
+
+  const parts = value.split(',').map((part) => {
+    const n = Number(part.trim());
+    return Number.isFinite(n) ? n : null;
+  });
+
+  return { shortTerm: parts[0] ?? null, daily: parts[1] ?? null };
+}
+
+export function parseStravaRateLimitHeaders(
+  headers: Headers,
+): StravaRateLimitSnapshot {
+  return {
+    overallLimit: parseRateLimitPair(headers.get('x-ratelimit-limit')),
+    overallUsage: parseRateLimitPair(headers.get('x-ratelimit-usage')),
+    readLimit: parseRateLimitPair(headers.get('x-readratelimit-limit')),
+    readUsage: parseRateLimitPair(headers.get('x-readratelimit-usage')),
+  };
+}
+
+/**
+ * Retry-After may be either delta-seconds or an HTTP date. Returns seconds from
+ * now, floored at 0, or null when absent/unparseable.
+ */
+export function parseRetryAfterSeconds(
+  headers: Headers,
+  now: Date = new Date(),
+): number | null {
+  const raw = headers.get('retry-after');
+  if (!raw) return null;
+
+  const asSeconds = Number(raw.trim());
+  if (Number.isFinite(asSeconds)) return Math.max(0, Math.round(asSeconds));
+
+  const asDate = Date.parse(raw);
+  if (Number.isFinite(asDate)) {
+    return Math.max(0, Math.round((asDate - now.getTime()) / 1000));
+  }
+  return null;
+}
+
+// ─── Budget decisions ────────────────────────────────────────────────────────
+
+export interface BudgetCheck {
+  /** True when another request may be issued. */
+  hasHeadroom: boolean;
+  /** Requests left before the tighter of the two windows is exhausted. */
+  remaining: number | null;
+}
+
+/**
+ * Decide whether to keep paginating, given the provider's reported usage and a
+ * reserve we decline to spend.
+ *
+ * `reserve` keeps a margin free so a long backfill for one user cannot consume
+ * the entire application-wide budget and lock every other user out.
+ */
+export function checkReadBudget(
+  snapshot: StravaRateLimitSnapshot,
+  reserve = 0,
+): BudgetCheck {
+  // Prefer the read-specific quota; fall back to the overall quota when Strava
+  // omits the read headers.
+  const limit = snapshot.readLimit.shortTerm ?? snapshot.overallLimit.shortTerm;
+  const usage = snapshot.readUsage.shortTerm ?? snapshot.overallUsage.shortTerm;
+  const dailyLimit = snapshot.readLimit.daily ?? snapshot.overallLimit.daily;
+  const dailyUsage = snapshot.readUsage.daily ?? snapshot.overallUsage.daily;
+
+  const remainings: number[] = [];
+  if (limit != null && usage != null) {
+    remainings.push(limit - usage - reserve);
+  }
+  if (dailyLimit != null && dailyUsage != null) {
+    remainings.push(dailyLimit - dailyUsage - reserve);
+  }
+
+  // No usable headers — defer to the caller's own page ceiling rather than
+  // blocking, so a provider that stops sending headers does not halt syncing.
+  if (remainings.length === 0) return { hasHeadroom: true, remaining: null };
+
+  const remaining = Math.min(...remainings);
+  return { hasHeadroom: remaining > 0, remaining };
+}
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+/** Suffix for the companion row tracking a provider's daily quota. */
+export const DAILY_KEY_SUFFIX = ':daily';
+
+export function dailyRateLimitKey(provider: string): string {
+  return `${provider}${DAILY_KEY_SUFFIX}`;
+}
+
+// deno-lint-ignore no-explicit-any
+type DbClient = any;
+
+/**
+ * Upsert a rate-limit tracking row keyed (key, user_id).
+ *
+ * `userId` is null for application-scoped quotas, matching the
+ * `uq_rate_limit_key_user` index which collapses NULL onto the zero UUID.
+ */
+export async function upsertRateLimitRow(
+  supabase: DbClient,
+  key: string,
+  userId: string | null,
+  fields: Record<string, unknown>,
+): Promise<void> {
+  let query = supabase.from('rate_limit_tracking').select('id').eq('key', key);
+  query = userId === null ? query.is('user_id', null) : query.eq('user_id', userId);
+
+  const { data: existing } = await query.maybeSingle();
+
+  if (!existing) {
+    await supabase.from('rate_limit_tracking').insert({
+      key,
+      // `provider` predates `key` and is still NOT NULL on some environments;
+      // strip any window suffix so it stays a real provider name.
+      provider: key.replace(DAILY_KEY_SUFFIX, ''),
+      user_id: userId,
+      requests_this_window: 0,
+      window_started_at: new Date().toISOString(),
+      ...fields,
+    });
+  } else {
+    await supabase
+      .from('rate_limit_tracking')
+      .update(fields)
+      .eq('id', existing.id);
+  }
+}
+
+/**
+ * Persist Strava's reported usage into both the 15-minute and daily buckets.
+ *
+ * Writes the provider's own numbers rather than a locally incremented counter,
+ * so concurrent Edge Function instances converge on the truth instead of each
+ * keeping a partial tally.
+ */
+export async function recordStravaUsage(
+  supabase: DbClient,
+  snapshot: StravaRateLimitSnapshot,
+  now: Date = new Date(),
+): Promise<void> {
+  const nowIso = now.toISOString();
+
+  const shortTermUsage =
+    snapshot.readUsage.shortTerm ?? snapshot.overallUsage.shortTerm;
+  if (shortTermUsage != null) {
+    await upsertRateLimitRow(supabase, 'strava', null, {
+      requests_this_window: shortTermUsage,
+      window_started_at: startOfCurrentQuarterHour(now),
+      last_request_at: nowIso,
+    });
+  }
+
+  const dailyUsage = snapshot.readUsage.daily ?? snapshot.overallUsage.daily;
+  if (dailyUsage != null) {
+    await upsertRateLimitRow(supabase, dailyRateLimitKey('strava'), null, {
+      requests_this_window: dailyUsage,
+      window_started_at: startOfUtcDay(now),
+      last_request_at: nowIso,
+    });
+  }
+}

--- a/supabase/functions/fitbit-sync/index.ts
+++ b/supabase/functions/fitbit-sync/index.ts
@@ -14,6 +14,27 @@ type DbClient = SupabaseClient<any, any, any>;
 const FITBIT_CLIENT_ID = Deno.env.get('FITBIT_CLIENT_ID')!;
 const FITBIT_CLIENT_SECRET = Deno.env.get('FITBIT_CLIENT_SECRET')!;
 
+/**
+ * Fitbit's documented ceiling: 150 requests per hour, per authorized user,
+ * resetting at the top of each hour.
+ * https://dev.fitbit.com/build/reference/web-api/troubleshooting-guide/rate-limits/
+ */
+const FITBIT_HOURLY_LIMIT = 150;
+
+/**
+ * Start of the current clock hour, in UTC.
+ *
+ * Fitbit's quota resets on the hour, so a 429 should mark the window as having
+ * begun at the last hour boundary. Stamping `now` instead would hold the user
+ * out for a full hour from the moment they were throttled — up to 59 minutes
+ * longer than Fitbit actually requires.
+ */
+function topOfCurrentHour(): string {
+  const now = new Date();
+  now.setUTCMinutes(0, 0, 0);
+  return now.toISOString();
+}
+
 interface FitbitTokens {
   access_token: string;
   refresh_token: string;
@@ -155,22 +176,32 @@ function mapFitbitActivityType(typeId: number): string {
   return mapping[typeId] ?? 'other';
 }
 
-/** Global provider row uses key + user_id IS NULL (see rate_limit_tracking migration). */
+/**
+ * Fitbit meters 150 requests/hour for EACH authorized user, resetting at the
+ * top of the hour — the quota is not shared across the application. The row is
+ * therefore keyed (key='fitbit', user_id=<user>), matching the
+ * `uq_rate_limit_key_user` unique index.
+ *
+ * This previously wrote a single user_id IS NULL row, which made every Fitbit
+ * user contend for one 120/hour bucket and capped total throughput at a single
+ * user's allowance no matter how many users connected.
+ */
 async function upsertFitbitRateLimitRow(
   supabase: DbClient,
+  userId: string,
   fields: Record<string, unknown>,
 ) {
   const { data: existing } = await supabase
     .from('rate_limit_tracking')
     .select('id')
     .eq('key', 'fitbit')
-    .is('user_id', null)
+    .eq('user_id', userId)
     .maybeSingle();
   if (!existing) {
     await supabase.from('rate_limit_tracking').insert({
       key: 'fitbit',
       provider: 'fitbit',
-      user_id: null,
+      user_id: userId,
       requests_this_window: 0,
       window_started_at: new Date().toISOString(),
       ...fields,
@@ -389,9 +420,12 @@ Deno.serve(async (req) => {
 
         // Handle rate limiting
         if (activitiesResponse.status === 429) {
-          await upsertFitbitRateLimitRow(supabase, {
-            requests_this_window: 150,
-            window_started_at: new Date().toISOString(),
+          await upsertFitbitRateLimitRow(supabase, userId, {
+            requests_this_window: FITBIT_HOURLY_LIMIT,
+            // Fitbit resets on the hour, not on a rolling window from the 429.
+            // Anchoring to the top of the current hour releases this user at
+            // the real reset instead of blocking them for a further hour.
+            window_started_at: topOfCurrentHour(),
             last_request_at: new Date().toISOString(),
           });
 
@@ -449,7 +483,7 @@ Deno.serve(async (req) => {
       .eq('user_id', userId)
       .eq('provider', 'fitbit');
 
-    await upsertFitbitRateLimitRow(supabase, {
+    await upsertFitbitRateLimitRow(supabase, userId, {
       last_request_at: new Date().toISOString(),
     });
 

--- a/supabase/functions/hevy-sync/index.ts
+++ b/supabase/functions/hevy-sync/index.ts
@@ -175,6 +175,7 @@ Deno.serve(async (req) => {
     let workouts: HevyWorkout[] = [];
     let deletedIds: string[] = [];
     let truncated = false;
+    let latestEventAt: string | null = null;
     try {
       const fetchPage = createHevyPageFetcher(storedApiKey);
       const result = useEvents
@@ -184,6 +185,7 @@ Deno.serve(async (req) => {
       workouts = result.workouts;
       deletedIds = result.deletedIds;
       truncated = result.truncated;
+      latestEventAt = result.latestEventAt;
     } catch (fetchError) {
       console.error('Hevy API fetch error:', fetchError);
       const fetchMessage = errorMessage(fetchError);
@@ -302,24 +304,63 @@ Deno.serve(async (req) => {
       );
     }
 
-    // A truncated fetch means pages remain unread. Advancing the watermark here
-    // would move `since` past workouts we never saw, stranding them permanently.
-    // Fail retryably instead. Resumable backfill needs a persisted page cursor
-    // (planned with the integration_sync_cursors table).
+    // A truncated fetch means pages remain unread, so the watermark cannot jump
+    // to `syncStartedAt` — that would move `since` past events we never saw.
+    //
+    // Whether a retry can make progress depends on which endpoint we were on:
+    //
+    //  - Events feed: the stream is date-ordered, so advancing `since` to the
+    //    newest event actually processed lets the next attempt continue from
+    //    there. Retry is productive; ask for one.
+    //
+    //  - Backfill: /v1/workouts is paged only, with no date filter and no
+    //    resume point derivable from what is already stored. A retry would
+    //    reissue the identical request, truncate identically, and repeat until
+    //    the queue's retry cap — so fail terminally and say why instead of
+    //    burning ten attempts. Resuming properly needs a persisted page cursor
+    //    (planned with the integration_sync_cursors table).
     if (truncated) {
-      const truncMessage =
-        `Hevy fetch exceeded the ${HEVY_MAX_PAGES}-page budget; ` +
-        `${importedCount} workouts stored, watermark not advanced`;
+      const canResume = useEvents && !!latestEventAt;
+
+      if (canResume) {
+        await supabase
+          .from('user_integrations')
+          .update({
+            last_sync_at: latestEventAt,
+            status: 'connected',
+            error_message:
+              `Hevy fetch hit the ${HEVY_MAX_PAGES}-page budget; ` +
+              `${importedCount} workouts stored, resuming from ${latestEventAt}`,
+          })
+          .eq('user_id', userId)
+          .eq('provider', 'hevy');
+      } else {
+        await supabase
+          .from('user_integrations')
+          .update({
+            status: 'error',
+            error_message:
+              `Hevy backfill exceeded the ${HEVY_MAX_PAGES}-page budget ` +
+              `(${importedCount} workouts stored). Retrying would repeat the ` +
+              'same request; resumable backfill is required for accounts this large.',
+          })
+          .eq('user_id', userId)
+          .eq('provider', 'hevy');
+      }
+
+      const truncMessage = canResume
+        ? `Hevy fetch exceeded the ${HEVY_MAX_PAGES}-page budget; resuming from ${latestEventAt}`
+        : `Hevy backfill exceeded the ${HEVY_MAX_PAGES}-page budget and cannot resume`;
       console.warn(truncMessage);
-      await supabase
-        .from('user_integrations')
-        .update({ status: 'error', error_message: truncMessage })
-        .eq('user_id', userId)
-        .eq('provider', 'hevy');
 
       return new Response(
-        JSON.stringify({ error: truncMessage, imported: importedCount }),
-        { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: truncMessage, imported: importedCount, deleted: deletedCount }),
+        {
+          // 502 is retryable per process-sync-queue; 500 is not. Only request a
+          // retry when the next attempt will behave differently.
+          status: canResume ? 502 : 500,
+          headers: { ...cors, 'Content-Type': 'application/json' },
+        }
       );
     }
 

--- a/supabase/functions/hevy-sync/index.ts
+++ b/supabase/functions/hevy-sync/index.ts
@@ -1,6 +1,16 @@
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 import { getCorsHeaders } from '../_shared/cors.ts';
 import { errorMessage } from '../_shared/errorMessage.ts';
+import {
+  createHevyPageFetcher,
+  fetchHevyBackfill,
+  fetchHevyEvents,
+  HEVY_MAX_PAGES,
+  HevyAuthError,
+  hevyExternalId,
+  toExternalActivityRow,
+  type HevyWorkout,
+} from '../_shared/hevySync.ts';
 import { decryptOAuthSecret, encryptOAuthSecret } from '../_shared/oauthTokenCrypto.ts';
 import { requireSubscription } from '../_shared/requireSubscription.ts';
 
@@ -14,27 +24,14 @@ import { requireSubscription } from '../_shared/requireSubscription.ts';
  * - Falls back gracefully if API returns 401/403
  * - Normalizes and upserts to external_activities
  *
- * Note: Hevy API documentation is limited. The CSV import path in
- * the portal UI is the primary import mechanism for most users.
+ * Two fetch modes (see fetchHevyBackfill / fetchHevyEvents):
+ * - Initial / no prior sync: full paginated backfill via GET /v1/workouts.
+ * - Incremental: GET /v1/workouts/events?since=<last_sync_at>, which reports
+ *   both updates and deletions so removed Hevy workouts stop lingering here.
+ *
+ * The CSV import path in the portal UI remains available for non-PRO users.
  */
 
-const HEVY_API_BASE = 'https://api.hevyapp.com/v1';
-
-interface HevyWorkout {
-  id: string;
-  title: string;
-  start_time: string;
-  end_time: string;
-  exercises: Array<{
-    title: string;
-    sets: Array<{
-      set_type: string;
-      weight_kg: number;
-      reps: number;
-      rpe: number | null;
-    }>;
-  }>;
-}
 
 Deno.serve(async (req) => {
   const cors = getCorsHeaders(req);
@@ -159,22 +156,39 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Attempt to fetch workouts from Hevy API
-    // TODO: incremental sync — Hevy API currently provides no date-range filter,
-    // so every sync is a full re-import of all workouts. When/if Hevy exposes a
-    // `since` or `after` parameter, thread `integration.last_sync_at` through as
-    // a query param here to avoid redundant fetches on large accounts.
-    // See: https://api.hevyapp.com/docs (check for updated filter support)
-    let workouts: HevyWorkout[] = [];
-    try {
-      const response = await fetch(`${HEVY_API_BASE}/workouts`, {
-        headers: {
-          'api-key': storedApiKey,
-          'Content-Type': 'application/json',
-        },
-      });
+    // Read the prior watermark to decide between backfill and incremental fetch.
+    const { data: integration } = await supabase
+      .from('user_integrations')
+      .select('last_sync_at')
+      .eq('user_id', userId)
+      .eq('provider', 'hevy')
+      .maybeSingle();
 
-      if (response.status === 401 || response.status === 403) {
+    const lastSyncAt = (integration?.last_sync_at as string | null) ?? null;
+    const useEvents = sync_type !== 'initial' && !!lastSyncAt;
+
+    // Capture the watermark *before* fetching. Anything Hevy records while this
+    // run is in flight then falls inside the next run's `since` window instead
+    // of being skipped. Upserts are idempotent, so the small overlap is free.
+    const syncStartedAt = new Date().toISOString();
+
+    let workouts: HevyWorkout[] = [];
+    let deletedIds: string[] = [];
+    let truncated = false;
+    try {
+      const fetchPage = createHevyPageFetcher(storedApiKey);
+      const result = useEvents
+        ? await fetchHevyEvents(fetchPage, lastSyncAt!)
+        : await fetchHevyBackfill(fetchPage);
+
+      workouts = result.workouts;
+      deletedIds = result.deletedIds;
+      truncated = result.truncated;
+    } catch (fetchError) {
+      console.error('Hevy API fetch error:', fetchError);
+      const fetchMessage = errorMessage(fetchError);
+
+      if (fetchError instanceof HevyAuthError) {
         // API key invalid or Hevy PRO required
         await supabase
           .from('user_integrations')
@@ -186,26 +200,10 @@ Deno.serve(async (req) => {
           .eq('provider', 'hevy');
 
         return new Response(
-          JSON.stringify({
-            error: 'Hevy API access denied. Verify your API key and Hevy PRO subscription.',
-            requires_pro: true,
-          }),
-          {
-            status: 403,
-            headers: { ...cors, 'Content-Type': 'application/json' },
-          }
+          JSON.stringify({ error: fetchMessage, requires_pro: true }),
+          { status: 403, headers: { ...cors, 'Content-Type': 'application/json' } }
         );
       }
-
-      if (!response.ok) {
-        throw new Error(`Hevy API returned ${response.status}`);
-      }
-
-      const data = await response.json();
-      workouts = data.workouts ?? data ?? [];
-    } catch (fetchError) {
-      console.error('Hevy API fetch error:', fetchError);
-      const fetchMessage = errorMessage(fetchError);
 
       await supabase
         .from('user_integrations')
@@ -225,36 +223,65 @@ Deno.serve(async (req) => {
       );
     }
 
+    // Apply deletions reported by the events feed. These are hard deletes: the
+    // workout no longer exists in Hevy, so leaving it here would strand a row
+    // that no future sync can reconcile.
+    // NOTE: mobile clients that already pulled the activity will not learn of
+    // the removal until external_activities carries a `deleted_at` tombstone
+    // (planned alongside the health data model migration).
+    let deletedCount = 0;
+    if (deletedIds.length > 0) {
+      const externalIds = deletedIds.map(hevyExternalId);
+      const { error: deleteError, count } = await supabase
+        .from('external_activities')
+        .delete({ count: 'exact' })
+        .eq('user_id', userId)
+        .eq('provider', 'hevy')
+        .in('external_id', externalIds);
+
+      if (deleteError) {
+        console.error('Failed to apply Hevy deletions:', deleteError);
+        await supabase
+          .from('user_integrations')
+          .update({
+            status: 'error',
+            error_message: `Failed to apply ${deletedIds.length} deletion(s)`,
+          })
+          .eq('user_id', userId)
+          .eq('provider', 'hevy');
+
+        return new Response(
+          JSON.stringify({ error: 'Failed to apply Hevy deletions' }),
+          { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
+        );
+      }
+      deletedCount = count ?? 0;
+    }
+
     // Normalize and upsert workouts to external_activities
     let importedCount = 0;
     let failedCount = 0;
-    for (const workout of workouts) {
-      const startTime = new Date(workout.start_time);
-      const endTime = new Date(workout.end_time);
-      const durationSeconds = Math.round((endTime.getTime() - startTime.getTime()) / 1000);
 
+    // Upsert in chunks rather than one round trip per workout — a full backfill
+    // can run to hundreds of workouts and per-row round trips exhaust the Edge
+    // Function wall clock long before the data is in.
+    const UPSERT_CHUNK_SIZE = 100;
+    const rows = workouts.map((workout) => toExternalActivityRow(userId, workout));
+
+    for (let i = 0; i < rows.length; i += UPSERT_CHUNK_SIZE) {
+      const chunk = rows.slice(i, i + UPSERT_CHUNK_SIZE);
       const { error: activityError } = await supabase
         .from('external_activities')
-        .upsert(
-          {
-            user_id: userId,
-            external_id: `hevy-${workout.id}`,
-            provider: 'hevy',
-            name: workout.title,
-            activity_type: 'strength',
-            started_at: startTime.toISOString(),
-            duration_seconds: durationSeconds > 0 ? durationSeconds : null,
-            calories: null, // Hevy API does not provide calorie data
-            raw_data: workout,
-          },
-          { onConflict: 'user_id,provider,external_id' }
-        );
+        .upsert(chunk, { onConflict: 'user_id,provider,external_id' });
 
       if (activityError) {
-        failedCount++;
-        console.error(`Failed to persist Hevy workout ${workout.id}:`, activityError);
+        failedCount += chunk.length;
+        console.error(
+          `Failed to persist Hevy workouts ${i}-${i + chunk.length - 1}:`,
+          activityError,
+        );
       } else {
-        importedCount++;
+        importedCount += chunk.length;
       }
     }
 
@@ -275,11 +302,33 @@ Deno.serve(async (req) => {
       );
     }
 
-    // Update last sync timestamp and status (all activities persisted)
+    // A truncated fetch means pages remain unread. Advancing the watermark here
+    // would move `since` past workouts we never saw, stranding them permanently.
+    // Fail retryably instead. Resumable backfill needs a persisted page cursor
+    // (planned with the integration_sync_cursors table).
+    if (truncated) {
+      const truncMessage =
+        `Hevy fetch exceeded the ${HEVY_MAX_PAGES}-page budget; ` +
+        `${importedCount} workouts stored, watermark not advanced`;
+      console.warn(truncMessage);
+      await supabase
+        .from('user_integrations')
+        .update({ status: 'error', error_message: truncMessage })
+        .eq('user_id', userId)
+        .eq('provider', 'hevy');
+
+      return new Response(
+        JSON.stringify({ error: truncMessage, imported: importedCount }),
+        { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Update last sync timestamp and status (all activities persisted). Uses the
+    // pre-fetch timestamp so concurrent Hevy writes land in the next window.
     await supabase
       .from('user_integrations')
       .update({
-        last_sync_at: new Date().toISOString(),
+        last_sync_at: syncStartedAt,
         status: 'connected',
         error_message: null,
       })
@@ -302,7 +351,9 @@ Deno.serve(async (req) => {
     return new Response(
       JSON.stringify({
         success: true,
+        mode: useEvents ? 'incremental' : 'backfill',
         imported: importedCount,
+        deleted: deletedCount,
         total: workouts.length,
       }),
       {

--- a/supabase/functions/liftosaur-sync/index.ts
+++ b/supabase/functions/liftosaur-sync/index.ts
@@ -197,6 +197,24 @@ Deno.serve(async (req) => {
 			);
 		}
 
+		// Read the prior watermark so incremental syncs can ask Liftosaur for a
+		// date range instead of re-scanning the user's entire history every run.
+		const { data: integration } = await supabase
+			.from("user_integrations")
+			.select("last_sync_at")
+			.eq("user_id", userId)
+			.eq("provider", "liftosaur")
+			.maybeSingle();
+
+		const lastSyncAt = (integration?.last_sync_at as string | null) ?? null;
+		const incrementalSince =
+			sync_type !== "initial" && lastSyncAt ? lastSyncAt : null;
+
+		// Capture the watermark before fetching so records Liftosaur writes while
+		// this run is in flight fall inside the next window rather than being
+		// skipped. Upserts are idempotent, so the overlap costs nothing.
+		const syncStartedAt = new Date().toISOString();
+
 		// Fetch workout history from Liftosaur API with pagination
 		let allRecords: LiftosaurRecord[] = [];
 		let cursor: number | null = null;
@@ -207,6 +225,11 @@ Deno.serve(async (req) => {
 		try {
 			while (hasMore && page < MAX_PAGES) {
 				const params = new URLSearchParams({ limit: "200" });
+				// GET /history supports startDate/endDate (ISO 8601) alongside the
+				// cursor. Passing it turns a full-history rescan into a delta fetch.
+				if (incrementalSince) {
+					params.set("startDate", incrementalSince);
+				}
 				if (cursor !== null) {
 					params.set("cursor", cursor.toString());
 				}
@@ -352,11 +375,12 @@ Deno.serve(async (req) => {
 			);
 		}
 
-		// Update last sync timestamp and status (all records persisted)
+		// Update last sync timestamp and status (all records persisted). Uses the
+		// pre-fetch timestamp so concurrent Liftosaur writes land in the next window.
 		await supabase
 			.from("user_integrations")
 			.update({
-				last_sync_at: new Date().toISOString(),
+				last_sync_at: syncStartedAt,
 				status: "connected",
 				error_message: null,
 			})

--- a/supabase/functions/mobile-integration-sync/index.ts
+++ b/supabase/functions/mobile-integration-sync/index.ts
@@ -1,5 +1,10 @@
 import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
 import { getCorsHeaders } from '../_shared/cors.ts';
+import {
+  createHevyPageFetcher,
+  fetchHevyBackfill,
+  HevyAuthError,
+} from '../_shared/hevySync.ts';
 import { checkRateLimit } from '../_shared/rateLimit.ts';
 import { decryptOAuthSecret, encryptOAuthSecret } from '../_shared/oauthTokenCrypto.ts';
 import { requireSubscription } from '../_shared/requireSubscription.ts';
@@ -34,7 +39,6 @@ type DbClient = SupabaseClient<any, any, any>;
 // Provider API configuration
 // =============================================================================
 
-const HEVY_API_BASE = 'https://api.hevyapp.com/v1';
 const LIFTOSAUR_API_BASE = 'https://www.liftosaur.com/api/v1';
 
 const ALLOWED_PROVIDERS = new Set(['hevy', 'liftosaur']);
@@ -137,41 +141,22 @@ function parseLiftoscriptMetadata(text: string): {
 // Provider fetch logic
 // =============================================================================
 
-const HEVY_PAGE_SIZE = 10;
-const HEVY_MAX_PAGES = 20;
-
+/**
+ * Shares the paginator with hevy-sync (../_shared/hevySync.ts) so the mobile
+ * and portal import paths cannot drift on page size or termination logic.
+ * Only the returned DTO shape differs — mobile takes camelCase.
+ */
 async function fetchHevyActivities(apiKey: string): Promise<ActivityDto[]> {
-  const allWorkouts: HevyWorkout[] = [];
-  let page = 1;
-
-  while (page <= HEVY_MAX_PAGES) {
-    const params = new URLSearchParams({
-      page: page.toString(),
-      pageSize: HEVY_PAGE_SIZE.toString(),
-    });
-
-    const response = await fetch(`${HEVY_API_BASE}/workouts?${params.toString()}`, {
-      headers: {
-        'api-key': apiKey,
-        'Content-Type': 'application/json',
-      },
-    });
-
-    if (response.status === 401 || response.status === 403) {
-      throw new ApiKeyError('Hevy API access denied. Verify your API key and Hevy PRO subscription.');
+  let allWorkouts: HevyWorkout[];
+  try {
+    const fetchPage = createHevyPageFetcher(apiKey);
+    const result = await fetchHevyBackfill(fetchPage);
+    allWorkouts = result.workouts as HevyWorkout[];
+  } catch (err) {
+    if (err instanceof HevyAuthError) {
+      throw new ApiKeyError(err.message);
     }
-    if (!response.ok) {
-      throw new Error(`Hevy API returned ${response.status}`);
-    }
-
-    const data = await response.json();
-    const workouts: HevyWorkout[] = data.workouts ?? data ?? [];
-    allWorkouts.push(...workouts);
-
-    // Fewer results than requested means this was the last page
-    if (workouts.length < HEVY_PAGE_SIZE) break;
-
-    page++;
+    throw err;
   }
 
   return allWorkouts.map((w) => {

--- a/supabase/functions/process-sync-queue/index.ts
+++ b/supabase/functions/process-sync-queue/index.ts
@@ -338,7 +338,12 @@ Deno.serve(async (req) => {
           .eq('id', task.id);
 
         // Increment rate limit counter
-        await incrementRateLimit(supabase, task.provider);
+        // Charge the request against the same bucket the dispatch check reads.
+        await incrementRateLimit(
+          supabase,
+          task.provider,
+          rateLimitScope(task.provider) === 'user' ? task.user_id : null,
+        );
 
         results.processed++;
       } catch (error) {
@@ -424,21 +429,35 @@ async function callSyncFunction(
 /**
  * Increment the rate limit counter for a provider, resetting the window if expired.
  */
-async function incrementRateLimit(supabase: DbClient, provider: string) {
+async function incrementRateLimit(
+  supabase: DbClient,
+  provider: string,
+  userId: string | null,
+) {
   const now = new Date();
   const limit = RATE_LIMITS[provider as keyof typeof RATE_LIMITS];
   if (!limit) return;
 
-  const { data: existing } = await supabase
+  // Accounting MUST target the same row the dispatch check reads, on both axes:
+  //  - the `key` column (the check filters on `key`, not the legacy `provider`)
+  //  - the same user scope (a per-user check against a bucket only ever
+  //    incremented at user_id IS NULL never accumulates, so the limit is
+  //    unenforceable and never blocks dispatch)
+  const scopedQuery = supabase
     .from('rate_limit_tracking')
     .select('*')
-    .eq('provider', provider)
-    .is('user_id', null)
-    .maybeSingle();
+    .eq('key', provider);
+
+  const { data: existing } = await (userId === null
+    ? scopedQuery.is('user_id', null)
+    : scopedQuery.eq('user_id', userId)
+  ).maybeSingle();
 
   if (!existing) {
     await supabase.from('rate_limit_tracking').insert({
+      key: provider,
       provider,
+      user_id: userId,
       requests_this_window: 1,
       window_started_at: now.toISOString(),
       last_request_at: now.toISOString(),
@@ -455,8 +474,7 @@ async function incrementRateLimit(supabase: DbClient, provider: string) {
         last_request_at: now.toISOString(),
         last_reset_at: windowExpired ? now.toISOString() : existing.last_reset_at,
       })
-      .eq('provider', provider)
-      .is('user_id', null);
+      .eq('id', existing.id);
   }
 }
 

--- a/supabase/functions/process-sync-queue/index.ts
+++ b/supabase/functions/process-sync-queue/index.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
 import { backOff } from 'npm:exponential-backoff@3.1.1';
 import { getCorsHeaders } from '../_shared/cors.ts';
+import { dailyRateLimitKey } from '../_shared/providerRateLimit.ts';
 import { requireSubscription } from '../_shared/requireSubscription.ts';
 
 /**
@@ -24,6 +25,9 @@ const PROCESSING_LEASE_MS = 5 * 60 * 1000;
 
 const PROVIDERS = ['strava', 'fitbit', 'garmin', 'hevy', 'liftosaur'] as const;
 
+/** Maximum sync tasks dispatched per provider per cron pass. */
+const TASKS_PER_PROVIDER = 5;
+
 const RETRYABLE_STATUSES = [429, 502, 503, 504];
 
 const RATE_LIMITS: Record<string, { requests: number; windowMs: number }> = {
@@ -36,6 +40,47 @@ const RATE_LIMITS: Record<string, { requests: number; windowMs: number }> = {
   // publish a hard rate limit, so we use a conservative ceiling in line with
   // the other lightweight clients.
   liftosaur: { requests: 40, windowMs: 60 * 60 * 1000 },
+};
+
+/**
+ * Whether a provider's published quota is charged against the whole
+ * application or against each authorizing user independently.
+ *
+ * This distinction is load-bearing. Modelling a per-user quota as an app-wide
+ * bucket silently caps the ENTIRE user base at one user's allowance — Fitbit
+ * grants 150 requests/hour per authorized user, so a shared 120/hour bucket
+ * meant the second concurrent Fitbit user could starve the first.
+ *
+ *  - 'app'  — quota is per registered application (keyed with user_id NULL).
+ *  - 'user' — quota is per authorizing user / per API key (keyed by user_id).
+ */
+const RATE_LIMIT_SCOPE: Record<string, 'app' | 'user'> = {
+  // Strava's documented limits are per-application across all athletes.
+  strava: 'app',
+  // Garmin meters per consumer key.
+  garmin: 'app',
+  // Fitbit: 150 requests/hour for EACH authorized user, reset on the hour.
+  fitbit: 'user',
+  // Hevy and Liftosaur authenticate with a per-user API key, so any quota
+  // they enforce is inherently scoped to that key.
+  hevy: 'user',
+  liftosaur: 'user',
+};
+
+function rateLimitScope(provider: string): 'app' | 'user' {
+  return RATE_LIMIT_SCOPE[provider] ?? 'app';
+}
+
+/**
+ * Second, longer quota window for providers that meter one.
+ *
+ * Strava publishes 100 reads/15min AND 1,000 reads/day. Tracking only the
+ * 15-minute window let a steady trickle of syncs exhaust the daily allowance
+ * and start collecting 429s with nothing in the config able to explain why.
+ * Values carry the same ~20% safety margin as RATE_LIMITS.
+ */
+const DAILY_RATE_LIMITS: Record<string, { requests: number; windowMs: number }> = {
+  strava: { requests: 800, windowMs: 24 * 60 * 60 * 1000 }, // reserve 20% of 1,000
 };
 
 function timingSafeEqualString(a: string, b: string): boolean {
@@ -91,17 +136,41 @@ Deno.serve(async (req) => {
   // Process tasks per-provider to prevent queue starvation (SQ-05).
   // A rate-limited provider no longer blocks tasks from other providers.
   for (const provider of PROVIDERS) {
-    // Check this provider's rate limit before fetching tasks
     const limit = RATE_LIMITS[provider as keyof typeof RATE_LIMITS];
-    if (limit) {
+    const scope = rateLimitScope(provider);
+
+    // App-scoped providers can be short-circuited for the whole provider before
+    // any task is read: one exhausted bucket blocks every user equally.
+    // User-scoped providers must NOT be checked here — a single throttled user
+    // would skip the entire provider for everyone. They are checked per task
+    // against their own bucket just before the claim, below.
+    if (limit && scope === 'app') {
       const { data: rateLimit } = await supabase
         .from('rate_limit_tracking')
         .select('*')
-        .eq('provider', provider)
+        .eq('key', provider)
         .is('user_id', null)
         .maybeSingle();
 
       if (isRateLimited(rateLimit, limit)) {
+        continue;
+      }
+    }
+
+    // Some providers meter a second, longer window on top of the short one.
+    // Strava caps reads at 1,000/day as well as 100/15min; exhausting the daily
+    // budget must halt dispatch even though the 15-minute bucket looks healthy.
+    const dailyLimit = DAILY_RATE_LIMITS[provider as keyof typeof DAILY_RATE_LIMITS];
+    if (dailyLimit) {
+      const { data: dailyTracking } = await supabase
+        .from('rate_limit_tracking')
+        .select('*')
+        .eq('key', dailyRateLimitKey(provider))
+        .is('user_id', null)
+        .maybeSingle();
+
+      if (isRateLimited(dailyTracking, dailyLimit)) {
+        console.warn(`[SYNC_QUEUE] ${provider} daily quota exhausted; skipping`);
         continue;
       }
     }
@@ -151,16 +220,31 @@ Deno.serve(async (req) => {
       }
     }
 
-    // Fetch pending tasks for this provider only
+    // Fetch pending tasks for this provider only.
+    //
+    // User-scoped providers read a wider candidate window than they will
+    // process: tasks belonging to a throttled user are skipped rather than
+    // claimed, and with a window of exactly TASKS_PER_PROVIDER one busy user
+    // sitting at the head of the queue would stall every other user until
+    // their window rolled over. Reading deeper lets the processor step past
+    // them to tasks it can actually run.
+    const candidateLimit =
+      scope === 'user' ? TASKS_PER_PROVIDER * 5 : TASKS_PER_PROVIDER;
     const { data: tasks } = await supabase
       .from('sync_queue')
       .select('*')
       .eq('provider', provider)
       .eq('status', 'pending')
       .order('created_at', { ascending: true })
-      .limit(5);
+      .limit(candidateLimit);
+
+    let claimedThisProvider = 0;
 
     for (const task of tasks ?? []) {
+      // Honour the per-provider dispatch budget regardless of how many
+      // candidates were read above.
+      if (claimedThisProvider >= TASKS_PER_PROVIDER) break;
+
       // SQ-04: Enforce max retry cap before processing
       if ((task.retry_count ?? 0) >= MAX_RETRIES) {
         await supabase
@@ -174,6 +258,24 @@ Deno.serve(async (req) => {
         console.warn(`[SYNC_QUEUE] Task ${task.id} permanently failed after ${MAX_RETRIES} retries`);
         results.failed++;
         continue;
+      }
+
+      // User-scoped quotas are checked per task, against this user's own
+      // bucket, so one throttled user cannot stall the provider for everyone.
+      // Leave the task `pending` — the next cron pass retries it once the
+      // user's window rolls over.
+      if (limit && scope === 'user') {
+        const { data: userRateLimit } = await supabase
+          .from('rate_limit_tracking')
+          .select('*')
+          .eq('key', provider)
+          .eq('user_id', task.user_id)
+          .maybeSingle();
+
+        if (isRateLimited(userRateLimit, limit)) {
+          results.skipped++;
+          continue;
+        }
       }
 
       // Atomically claim the task: only transition pending -> processing, and
@@ -192,6 +294,8 @@ Deno.serve(async (req) => {
         // Another concurrent invocation already claimed this task — skip it.
         continue;
       }
+
+      claimedThisProvider++;
 
       // Check subscription before calling sync function
       const gate = await requireSubscription(supabase, task.user_id, 'FLAME', cors);

--- a/supabase/functions/strava-sync/index.ts
+++ b/supabase/functions/strava-sync/index.ts
@@ -349,12 +349,48 @@ Deno.serve(async (req) => {
     // ---------------------------------------------------------------
     const baseParams = new URLSearchParams({ per_page: '200' });
 
-    // For incremental sync, only fetch activities after last sync
-    if (sync_type !== 'initial' && integration.last_sync_at) {
+    // Two modes:
+    //
+    // Incremental (last_sync_at set): walk forward from the watermark. The
+    //   volume per run is small, so the page ceiling is never reached.
+    //
+    // Backfill (no watermark yet): Strava returns activities newest-first, so
+    //   each page walks further into the past. A run that hits the page ceiling
+    //   stops partway, and because last_sync_at is only set once the backfill
+    //   COMPLETES, the retry would otherwise re-request page 1 forever and burn
+    //   the retry cap without ever reaching the older tail.
+    //
+    //   The resume point does not need to be persisted separately: the oldest
+    //   Strava activity already stored for this user IS how far back we got.
+    //   Passing it as `before` makes each retry continue from there.
+    const isBackfill = sync_type === 'initial' || !integration.last_sync_at;
+
+    if (!isBackfill) {
       const afterEpoch = Math.floor(
         new Date(integration.last_sync_at as string).getTime() / 1000
       );
       baseParams.set('after', String(afterEpoch));
+    } else {
+      const { data: oldestStored } = await supabase
+        .from('external_activities')
+        .select('started_at')
+        .eq('user_id', userId)
+        .eq('provider', 'strava')
+        .order('started_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+
+      if (oldestStored?.started_at) {
+        // `before` is exclusive; the boundary activity is already stored, and
+        // upserts are idempotent even if Strava treats it as inclusive.
+        const beforeEpoch = Math.floor(
+          new Date(oldestStored.started_at as string).getTime() / 1000
+        );
+        baseParams.set('before', String(beforeEpoch));
+        console.log(
+          `Strava backfill resuming before ${oldestStored.started_at}`,
+        );
+      }
     }
 
     const rawActivities: StravaActivityRaw[] = [];
@@ -510,9 +546,19 @@ Deno.serve(async (req) => {
     // failure above: report retryably and let the queue resume.
     // ---------------------------------------------------------------
     if (moreRemaining) {
-      const partialMessage =
-        `Fetched ${rawActivities.length} activities before reaching the Strava ` +
-        'request budget; sync will resume on the next queue pass';
+      // A retry is only safe to schedule if THIS run actually advanced the
+      // resume point. During backfill the resume point is the oldest stored
+      // activity, so persisting at least one older activity guarantees the next
+      // attempt requests a strictly earlier `before` window. If nothing was
+      // persisted the retry would reissue an identical request and spin until
+      // the retry cap, so fail terminally with a message that says why.
+      const madeProgress = syncedCount > 0;
+      const partialMessage = madeProgress
+        ? `Fetched ${rawActivities.length} activities before reaching the Strava ` +
+          'request budget; sync will resume from this point on the next queue pass'
+        : `Reached the Strava request budget without persisting any activities; ` +
+          'retrying would repeat the same request. Sync stopped.';
+
       console.warn(partialMessage);
       await supabase
         .from('user_integrations')
@@ -526,7 +572,13 @@ Deno.serve(async (req) => {
           synced_count: syncedCount,
           partial: true,
         }),
-        { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
+        {
+          // 502 is retryable per process-sync-queue's RETRYABLE_STATUSES; 500 is
+          // not. Only ask for a retry when the next attempt will do something
+          // different from this one.
+          status: madeProgress ? 502 : 500,
+          headers: { ...cors, 'Content-Type': 'application/json' },
+        }
       );
     }
 

--- a/supabase/functions/strava-sync/index.ts
+++ b/supabase/functions/strava-sync/index.ts
@@ -1,6 +1,13 @@
 import { createClient, type SupabaseClient } from 'jsr:@supabase/supabase-js@2';
 import { decryptOAuthSecret, encryptOAuthSecret } from '../_shared/oauthTokenCrypto.ts';
 import { getCorsHeaders } from '../_shared/cors.ts';
+import {
+  checkReadBudget,
+  parseRetryAfterSeconds,
+  parseStravaRateLimitHeaders,
+  recordStravaUsage,
+  type StravaRateLimitSnapshot,
+} from '../_shared/providerRateLimit.ts';
 import { requireSubscription } from '../_shared/requireSubscription.ts';
 
 /**
@@ -352,10 +359,21 @@ Deno.serve(async (req) => {
 
     const rawActivities: StravaActivityRaw[] = [];
     let page = 1;
-    const maxPages = 50;
     const delayBetweenPagesMs = 350;
 
-    while (page <= maxPages) {
+    // Strava's quotas are application-wide (100 reads / 15 min, 1,000 / day), so
+    // a single user's backfill spends budget every other user shares. Cap the
+    // pages one invocation may take, and stop early once Strava's own reported
+    // usage says we are close to the ceiling.
+    const MAX_PAGES_PER_RUN = 10;
+    // Requests deliberately left unspent so an in-flight backfill cannot starve
+    // other users' syncs (or the webhook path) of quota.
+    const RESERVED_REQUESTS = 20;
+
+    let budgetExhausted = false;
+    let lastSnapshot: StravaRateLimitSnapshot | null = null;
+
+    while (page <= MAX_PAGES_PER_RUN) {
       const params = new URLSearchParams(baseParams);
       params.set('page', String(page));
 
@@ -365,6 +383,24 @@ Deno.serve(async (req) => {
           headers: { Authorization: `Bearer ${accessToken}` },
         }
       );
+
+      // Record what Strava reports about our quota on every response, success
+      // or failure — a 429 is exactly when this information matters most.
+      lastSnapshot = parseStravaRateLimitHeaders(activitiesResponse.headers);
+      await recordStravaUsage(supabase, lastSnapshot);
+
+      if (activitiesResponse.status === 429) {
+        const retryAfter = parseRetryAfterSeconds(activitiesResponse.headers);
+        console.warn(
+          `Strava rate limited; retry-after=${retryAfter ?? 'unspecified'}s, ` +
+            `${rawActivities.length} activities fetched before the limit`,
+        );
+        // Stop cleanly rather than erroring: activities already fetched are
+        // persisted below, and last_sync_at is withheld so the queue retry
+        // resumes from the same cutoff.
+        budgetExhausted = true;
+        break;
+      }
 
       if (!activitiesResponse.ok) {
         const errorText = await activitiesResponse.text();
@@ -390,9 +426,27 @@ Deno.serve(async (req) => {
       if (pageActivities.length < 200) {
         break;
       }
+
+      // Consult Strava's reported headroom before spending another request.
+      const budget = checkReadBudget(lastSnapshot, RESERVED_REQUESTS);
+      if (!budget.hasHeadroom) {
+        console.warn(
+          `Strava read budget reserve reached (remaining=${budget.remaining}); ` +
+            'pausing pagination until the window rolls over',
+        );
+        budgetExhausted = true;
+        break;
+      }
+
       page++;
       await new Promise((r) => setTimeout(r, delayBetweenPagesMs));
     }
+
+    // Ran out of pages (or budget) with a full final page: more activities
+    // remain upstream. Treat exactly like a partial failure below — persist
+    // what we have, withhold the last_sync_at advance, let the queue resume.
+    const moreRemaining =
+      budgetExhausted || (page > MAX_PAGES_PER_RUN && rawActivities.length > 0);
 
     // ---------------------------------------------------------------
     // Normalize and upsert activities
@@ -445,6 +499,33 @@ Deno.serve(async (req) => {
 
       return new Response(
         JSON.stringify({ error: failMessage, synced_count: syncedCount, errors }),
+        { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // ---------------------------------------------------------------
+    // Pagination stopped short of the end (page ceiling or rate-limit reserve).
+    // Everything fetched IS persisted, but activities remain upstream, so the
+    // `after` cutoff must not advance past them. Same contract as the partial
+    // failure above: report retryably and let the queue resume.
+    // ---------------------------------------------------------------
+    if (moreRemaining) {
+      const partialMessage =
+        `Fetched ${rawActivities.length} activities before reaching the Strava ` +
+        'request budget; sync will resume on the next queue pass';
+      console.warn(partialMessage);
+      await supabase
+        .from('user_integrations')
+        .update({ error_message: partialMessage })
+        .eq('user_id', userId)
+        .eq('provider', 'strava');
+
+      return new Response(
+        JSON.stringify({
+          error: partialMessage,
+          synced_count: syncedCount,
+          partial: true,
+        }),
         { status: 502, headers: { ...cors, 'Content-Type': 'application/json' } }
       );
     }


### PR DESCRIPTION
## What this is

An audit of the six third-party integrations against each provider's **current** API, and fixes for the defects stopping the working ones (Strava, Hevy, Liftosaur, Strong) from syncing correctly.

No schema changes. Fitbit and Garmin stay behind `comingSoon`.

## The two that actually broke syncing

**Hevy was importing one page.** `hevy-sync` called `/v1/workouts` with no `page`/`pageSize`. Hevy caps `pageSize` at 10, so the portal has been silently importing only the first handful of a user's workouts. `mobile-integration-sync` paginated correctly, so the two paths disagreed — they now share `_shared/hevySync.ts`.

**Fitbit's rate limit was modelled backwards.** Fitbit meters 150 requests/hour *per authorized user*. `fitbit-sync` wrote a single `user_id IS NULL` row and the queue processor capped it at 120/hour globally, so every Fitbit user contended for one user's allowance — a hard ceiling on total throughput no matter how many users connected. Adds a `RATE_LIMIT_SCOPE` (`app` vs `user`) concept.

## Everything else

| | |
|---|---|
| **Hevy incremental** | The `TODO` claiming Hevy has no date filter was wrong — `/v1/workouts/events?since=` exists and reports **deletions** as well as updates. Deleted Hevy workouts no longer linger, and large accounts aren't fully re-imported every run. |
| **Hevy pagination** | Terminates on `page_count` rather than inferring the end from a short page, so a final page landing exactly on the boundary isn't mistaken for the end. Upserts chunked instead of one round trip per workout. |
| **Strava headers** | Rate-limit headers were discarded in favour of local guesses. New `_shared/providerRateLimit.ts` parses `X-RateLimit-*`, `X-ReadRateLimit-*`, `Retry-After` and persists Strava's own reported usage. |
| **Strava daily cap** | The 1,000/day read limit wasn't modelled at all. Adds a daily bucket (`strava:daily`) the queue processor honours alongside the 15-minute one. |
| **Strava budget** | `maxPages` 50 → 10 with a reserve, so one user's backfill can't consume the app-wide budget. A short run withholds the `last_sync_at` advance and reports retryably — same contract as the existing partial-failure path. |
| **Liftosaur** | Re-scanned all history every sync despite `last_sync_at` being available and the API supporting `startDate`. Now fetches a delta. |
| **Fitbit 429s** | Anchor the window to the top of the hour, matching Fitbit's actual reset, instead of blocking up to 59 minutes longer than needed. |
| **Garmin docs** | `.env.example` documented `x-webhook-secret` / `Authorization: Bearer`, but the handler requires an HMAC-SHA256 hex digest in `x-garmin-signature`. Following the docs guaranteed a 401. |
| **Liftosaur unreachable** | Missing from `MANUAL_SYNC_PROVIDERS`, so a working sync function had no way to be triggered from the portal. |
| **ProviderCard** | Branched only on `status === 'connected'`, so `token_expired` and `error` rendered an unexplained Connect button. Both now get a distinct badge, the recorded error message, and Reconnect/Disconnect. |

## Testing

56 new tests. `rate-limit-parity.test.ts` is the notable one — it parses the queue processor's config out of source and fails if the client and edge copies drift, which is the failure mode that produced the Fitbit bug in the first place.

Locally: 1502 unit tests pass, typecheck clean, lint clean (227 warnings all pre-existing), build succeeds, `check:edge-functions` passes.

## Known gaps, deliberately left

Both need the schema work in the follow-up and are noted in code rather than papered over:

- Hevy deletions are **hard deletes**. Mobile clients that already pulled an activity won't learn of the removal until `external_activities` carries a `deleted_at` tombstone.
- Backfills past the page budget **fail retryably rather than skipping data**. Properly resumable backfill needs a persisted page cursor.

## Deploy note

Edge function changes only reach production on merge to `main` via `.github/workflows/deploy-edge-functions.yml`. Six functions change here: `hevy-sync`, `fitbit-sync`, `strava-sync`, `liftosaur-sync`, `process-sync-queue`, `mobile-integration-sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
