### PR TITLE
fix: add cursor/limit pagination to get_personal_records_excluding_ids (#97)

### DIFF
--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -2421,7 +2421,10 @@ export type Database = {
 			};
 			get_personal_records_excluding_ids: {
 				Args: {
+					p_cursor_id?: string;
+					p_cursor_updated_at?: string;
 					p_known_ids?: string[];
+					p_limit?: number;
 					p_profile_id?: string;
 					p_user_id: string;
 				};

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -1289,25 +1289,16 @@ async function mobileSyncPullHandler(
       let personalRecordsData: Record<string, unknown>[] = [];
 
       if (useRpcPR) {
-        // RPC path: excludes IDs the client already has; chain order + limit
-        // client-side because get_personal_records_excluding_ids has no p_limit
-        // or cursor params (unlike get_cycles_excluding_ids / get_badges_excluding_ids).
-        let prQuery = supabase.rpc('get_personal_records_excluding_ids', {
+        // RPC path: excludes IDs the client already has.
+        // Cursor/limit params are now server-side (fix #97).
+        const { data, error } = await supabase.rpc('get_personal_records_excluding_ids', {
           p_user_id: userId,
           p_known_ids: knownPRIds,
           p_profile_id: profileId,
-        })
-          .order('updated_at', { ascending: true })
-          .order('id', { ascending: true })
-          .limit(remainingPageSize + 1);
-
-        if (cursorUpdatedAt && cursorId) {
-          prQuery = prQuery.or(
-            `updated_at.gt.${cursorUpdatedAt},and(updated_at.eq.${cursorUpdatedAt},id.gt.${cursorId})`
-          );
-        }
-
-        const { data, error } = await prQuery;
+          p_cursor_updated_at: cursorUpdatedAt,
+          p_cursor_id: cursorId,
+          p_limit: remainingPageSize + 1,
+        });
         if (error) return readFailure('personal records', error, cors);
         const unseenRows = (data as Record<string, unknown>[]) ?? [];
 

--- a/supabase/migrations/20260816120000_fix_pr_rpc_cursor_pagination.sql
+++ b/supabase/migrations/20260816120000_fix_pr_rpc_cursor_pagination.sql
@@ -1,0 +1,57 @@
+-- ============================================================================
+-- Fix: add cursor/limit pagination to get_personal_records_excluding_ids
+-- Issue: #97 — cloud sync pull fails with repeated cursor loop detection
+-- Root cause: this is the only parity RPC missing p_cursor_updated_at /
+--             p_cursor_id / p_limit. The edge function chained .or() on the
+--             RPC builder as a workaround, but PostgREST silently ignores
+--             .or() on RPC function responses, so the same cursor was returned
+--             every call and the client loop guard aborted after 4 pages.
+-- Fix: add the three pagination params + composite cursor predicate + LIMIT,
+--      matching get_cycles_excluding_ids / get_badges_excluding_ids / the
+--      tombstone sibling. Profile filter matches the H-18-safe form (no
+--      OR pr.local_profile_id IS NULL).
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.get_personal_records_excluding_ids(UUID, UUID[], TEXT);
+
+CREATE FUNCTION public.get_personal_records_excluding_ids(
+  p_user_id UUID,
+  p_known_ids UUID[] DEFAULT '{}',
+  p_profile_id TEXT DEFAULT NULL,
+  p_cursor_updated_at TIMESTAMPTZ DEFAULT NULL,
+  p_cursor_id UUID DEFAULT NULL,
+  p_limit INT DEFAULT 76
+)
+RETURNS SETOF public.personal_records
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT pr.*
+  FROM public.personal_records pr
+  WHERE pr.user_id = p_user_id
+    AND pr.deleted_at IS NULL
+    AND (array_length(p_known_ids, 1) IS NULL OR pr.id != ALL(p_known_ids))
+    AND (
+      p_profile_id IS NULL
+      OR (p_profile_id = 'default' AND pr.local_profile_id IS NULL)
+      OR pr.local_profile_id = p_profile_id
+    )
+    AND (
+      p_cursor_updated_at IS NULL
+      OR pr.updated_at > p_cursor_updated_at
+      OR (pr.updated_at = p_cursor_updated_at AND pr.id > p_cursor_id)
+    )
+  ORDER BY pr.updated_at ASC, pr.id ASC
+  LIMIT p_limit;
+$$;
+
+COMMENT ON FUNCTION public.get_personal_records_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT) IS
+'Fetches personal records not in the provided UUID list with cursor pagination. Uses POST body via RPC to bypass URL length limits.';
+
+-- Restore service-role-only grant (parity helper, not a public API).
+REVOKE ALL ON FUNCTION public.get_personal_records_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_personal_records_excluding_ids(UUID, UUID[], TEXT, TIMESTAMPTZ, UUID, INT)
+  TO service_role;


### PR DESCRIPTION
## Summary

Adds server-side cursor/limit pagination to `get_personal_records_excluding_ids`, the only parity RPC missing these params. Fixes the cloud sync pull cursor loop that aborts after 4 pages / ~407 entities.

## Root Cause

`get_personal_records_excluding_ids` was the only parity RPC without `p_cursor_updated_at` / `p_cursor_id` / `p_limit` parameters. The edge function chained `.or()` on the PostgREST RPC builder as a workaround for cursor filtering, but PostgREST silently ignores `.or()` on RPC function responses. Result: the same cursor was returned every call, and the mobile client's loop-detection guard (issue #679) aborted the sync.

## Changes

- **New migration** (`20260816120000_fix_pr_rpc_cursor_pagination.sql`): Adds the three pagination params + composite cursor predicate + `LIMIT p_limit` to `get_personal_records_excluding_ids`, matching the pattern in `get_cycles_excluding_ids` / `get_badges_excluding_ids` / the tombstone sibling. Uses H-18-safe profile filter (no `OR pr.local_profile_id IS NULL`).
- **Edge function** (`mobile-sync-pull/index.ts`): Passes cursor params as RPC args instead of chaining `.or()` on the builder.
- **Type definitions** (`database.types.ts`): Updates `Args` shape with new optional params.

## Architecture Review

Arch review (phoenixarchitect) confirmed root cause at source (commit 25ffe47). Fix direction approved with one change request: the initial proposed SQL included `OR pr.local_profile_id IS NULL` which re-introduces the H-18 cross-profile bleed bug. This PR uses the H-18-safe profile filter matching the current live function and tombstone sibling.

## Testing

- Edge function tests: 67/67 passed (Deno)
- Vitest tests require `npm install` (not available in shallow clone CI context)

Fixes #97
