### PR TITLE
fix: surface sync error details and guard progress/PR rows against LWW-rejected sessions

### DIFF
--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,6 +1,8 @@
 {
   "version": "4",
   "specifiers": {
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
     "jsr:@supabase/supabase-js@2": "2.107.0",
     "npm:@supabase/auth-js@2.107.0": "2.107.0",
     "npm:@supabase/functions-js@2.107.0": "2.107.0",
@@ -11,6 +13,15 @@
     "npm:zod@4.3.6": "4.3.6"
   },
   "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
     "@supabase/supabase-js@2.107.0": {
       "integrity": "e28d6ef6e79200417b4838a0051066c44170a1de7cccc8b00a671947b72ba0e3",
       "dependencies": [

--- a/supabase/functions/mobile-sync-push/index.test.ts
+++ b/supabase/functions/mobile-sync-push/index.test.ts
@@ -2786,3 +2786,113 @@ Deno.test({
     }
   },
 });
+
+// Issue #99 regression: top-level catch surfaces underlying error in
+// non-production and returns opaque message in production.
+Deno.test("Issue #99: top-level catch surfaces error in non-production", async () => {
+  // Save and clear ENVIRONMENT to simulate non-production
+  const savedEnv = Deno.env.get("ENVIRONMENT");
+  Deno.env.delete("ENVIRONMENT");
+
+  try {
+    const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
+    const harness = makeHarness(async () => VALID_AUTH_RESULT, {
+      // Make the RPC throw to trigger the top-level catch
+      rpcBehavior: async () => {
+        throw new Error(errorMessage);
+      },
+    });
+
+    // Build a body with a session that will trigger the RPC path
+    const body = validPushBody();
+    (body.sessions as Record<string, unknown>[]).push({
+      id: SESSION_ID,
+      startedAt: "2026-01-20T10:00:00.000Z",
+      updatedAt: "2026-01-20T10:30:00.000Z",
+      workoutMode: "OLD_SCHOOL",
+      exercises: [{
+        id: EXERCISE_ID,
+        name: "Bench Press",
+        exerciseId: "bench-press-id",
+        muscleGroup: "Chest",
+        sets: [{
+          id: SET_ID,
+          exerciseId: EXERCISE_ID,
+          setNumber: 1,
+          targetReps: 10,
+          actualReps: 10,
+          weightKg: 80,
+          isPr: true,
+          prType: "1RM",
+          prPhase: "COMBINED",
+        }],
+      }],
+    });
+
+    const response = await harness.handler(requestFromBody(body));
+    const responseBody = await json(response);
+
+    assertEquals(response.status, 500);
+    // In non-production, the actual error message should be surfaced
+    assertEquals(responseBody.error, errorMessage);
+  } finally {
+    // Restore ENVIRONMENT
+    if (savedEnv !== undefined) {
+      Deno.env.set("ENVIRONMENT", savedEnv);
+    }
+  }
+});
+
+Deno.test("Issue #99: top-level catch returns opaque error in production", async () => {
+  // Set ENVIRONMENT to production
+  const savedEnv = Deno.env.get("ENVIRONMENT");
+  Deno.env.set("ENVIRONMENT", "production");
+
+  try {
+    const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
+    const harness = makeHarness(async () => VALID_AUTH_RESULT, {
+      rpcBehavior: async () => {
+        throw new Error(errorMessage);
+      },
+    });
+
+    const body = validPushBody();
+    (body.sessions as Record<string, unknown>[]).push({
+      id: SESSION_ID,
+      startedAt: "2026-01-20T10:00:00.000Z",
+      updatedAt: "2026-01-20T10:30:00.000Z",
+      workoutMode: "OLD_SCHOOL",
+      exercises: [{
+        id: EXERCISE_ID,
+        name: "Bench Press",
+        exerciseId: "bench-press-id",
+        muscleGroup: "Chest",
+        sets: [{
+          id: SET_ID,
+          exerciseId: EXERCISE_ID,
+          setNumber: 1,
+          targetReps: 10,
+          actualReps: 10,
+          weightKg: 80,
+          isPr: true,
+          prType: "1RM",
+          prPhase: "COMBINED",
+        }],
+      }],
+    });
+
+    const response = await harness.handler(requestFromBody(body));
+    const responseBody = await json(response);
+
+    assertEquals(response.status, 500);
+    // In production, the error should be opaque
+    assertEquals(responseBody.error, "Internal server error");
+  } finally {
+    // Restore ENVIRONMENT
+    if (savedEnv !== undefined) {
+      Deno.env.set("ENVIRONMENT", savedEnv);
+    } else {
+      Deno.env.delete("ENVIRONMENT");
+    }
+  }
+});

--- a/supabase/functions/mobile-sync-push/index.test.ts
+++ b/supabase/functions/mobile-sync-push/index.test.ts
@@ -2788,11 +2788,11 @@ Deno.test({
 });
 
 // Issue #99 regression: top-level catch surfaces underlying error in
-// non-production and returns opaque message in production.
-Deno.test("Issue #99: top-level catch surfaces error in non-production", async () => {
-  // Save and clear ENVIRONMENT to simulate non-production
+// known non-production environments and returns opaque message otherwise.
+Deno.test("Issue #99: top-level catch surfaces error in known non-production env", async () => {
+  // Set ENVIRONMENT to a known verbose value
   const savedEnv = Deno.env.get("ENVIRONMENT");
-  Deno.env.delete("ENVIRONMENT");
+  Deno.env.set("ENVIRONMENT", "development");
 
   try {
     const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
@@ -2839,6 +2839,8 @@ Deno.test("Issue #99: top-level catch surfaces error in non-production", async (
     // Restore ENVIRONMENT
     if (savedEnv !== undefined) {
       Deno.env.set("ENVIRONMENT", savedEnv);
+    } else {
+      Deno.env.delete("ENVIRONMENT");
     }
   }
 });
@@ -2886,6 +2888,60 @@ Deno.test("Issue #99: top-level catch returns opaque error in production", async
 
     assertEquals(response.status, 500);
     // In production, the error should be opaque
+    assertEquals(responseBody.error, "Internal server error");
+  } finally {
+    // Restore ENVIRONMENT
+    if (savedEnv !== undefined) {
+      Deno.env.set("ENVIRONMENT", savedEnv);
+    } else {
+      Deno.env.delete("ENVIRONMENT");
+    }
+  }
+});
+
+Deno.test("Issue #99: unknown ENVIRONMENT defaults to opaque error", async () => {
+  // Set ENVIRONMENT to an unknown value (not in the allowlist)
+  const savedEnv = Deno.env.get("ENVIRONMENT");
+  Deno.env.set("ENVIRONMENT", "custom-staging");
+
+  try {
+    const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
+    const harness = makeHarness(async () => VALID_AUTH_RESULT, {
+      rpcBehavior: async () => {
+        throw new Error(errorMessage);
+      },
+    });
+
+    const body = validPushBody();
+    (body.sessions as Record<string, unknown>[]).push({
+      id: SESSION_ID,
+      startedAt: "2026-01-20T10:00:00.000Z",
+      updatedAt: "2026-01-20T10:30:00.000Z",
+      workoutMode: "OLD_SCHOOL",
+      exercises: [{
+        id: EXERCISE_ID,
+        name: "Bench Press",
+        exerciseId: "bench-press-id",
+        muscleGroup: "Chest",
+        sets: [{
+          id: SET_ID,
+          exerciseId: EXERCISE_ID,
+          setNumber: 1,
+          targetReps: 10,
+          actualReps: 10,
+          weightKg: 80,
+          isPr: true,
+          prType: "1RM",
+          prPhase: "COMBINED",
+        }],
+      }],
+    });
+
+    const response = await harness.handler(requestFromBody(body));
+    const responseBody = await json(response);
+
+    assertEquals(response.status, 500);
+    // Unknown ENVIRONMENT should default to opaque
     assertEquals(responseBody.error, "Internal server error");
   } finally {
     // Restore ENVIRONMENT

--- a/supabase/functions/mobile-sync-push/index.test.ts
+++ b/supabase/functions/mobile-sync-push/index.test.ts
@@ -2789,166 +2789,74 @@ Deno.test({
 
 // Issue #99 regression: top-level catch surfaces underlying error in
 // known non-production environments and returns opaque message otherwise.
-Deno.test("Issue #99: top-level catch surfaces error in known non-production env", async () => {
-  // Set ENVIRONMENT to a known verbose value
-  const savedEnv = Deno.env.get("ENVIRONMENT");
-  Deno.env.set("ENVIRONMENT", "development");
-
-  try {
-    const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
-    const harness = makeHarness(async () => VALID_AUTH_RESULT, {
-      // Make the RPC throw to trigger the top-level catch
-      rpcBehavior: async () => {
-        throw new Error(errorMessage);
-      },
-    });
-
-    // Build a body with a session that will trigger the RPC path
-    const body = validPushBody();
-    (body.sessions as Record<string, unknown>[]).push({
-      id: SESSION_ID,
-      startedAt: "2026-01-20T10:00:00.000Z",
-      updatedAt: "2026-01-20T10:30:00.000Z",
-      workoutMode: "OLD_SCHOOL",
-      exercises: [{
-        id: EXERCISE_ID,
-        name: "Bench Press",
-        exerciseId: "bench-press-id",
-        muscleGroup: "Chest",
-        sets: [{
-          id: SET_ID,
-          exerciseId: EXERCISE_ID,
-          setNumber: 1,
-          targetReps: 10,
-          actualReps: 10,
-          weightKg: 80,
-          isPr: true,
-          prType: "1RM",
-          prPhase: "COMBINED",
-        }],
+// Helper: builds the pushed session object shared by every ENVIRONMENT case.
+function makePrSession() {
+  return {
+    id: SESSION_ID,
+    startedAt: "2026-01-20T10:00:00.000Z",
+    updatedAt: "2026-01-20T10:30:00.000Z",
+    workoutMode: "OLD_SCHOOL",
+    exercises: [{
+      id: EXERCISE_ID,
+      name: "Bench Press",
+      exerciseId: "bench-press-id",
+      muscleGroup: "Chest",
+      sets: [{
+        id: SET_ID,
+        exerciseId: EXERCISE_ID,
+        setNumber: 1,
+        targetReps: 10,
+        actualReps: 10,
+        weightKg: 80,
+        isPr: true,
+        prType: "1RM",
+        prPhase: "COMBINED",
       }],
-    });
+    }],
+  };
+}
 
-    const response = await harness.handler(requestFromBody(body));
-    const responseBody = await json(response);
-
-    assertEquals(response.status, 500);
-    // In non-production, the actual error message should be surfaced
-    assertEquals(responseBody.error, errorMessage);
-  } finally {
-    // Restore ENVIRONMENT
-    if (savedEnv !== undefined) {
-      Deno.env.set("ENVIRONMENT", savedEnv);
-    } else {
-      Deno.env.delete("ENVIRONMENT");
-    }
-  }
-});
-
-Deno.test("Issue #99: top-level catch returns opaque error in production", async () => {
-  // Set ENVIRONMENT to production
+// Helper: temporarily set ENVIRONMENT, restore it on scope exit.
+function withEnvironment<T>(value: string, body: () => Promise<T>): Promise<T> {
   const savedEnv = Deno.env.get("ENVIRONMENT");
-  Deno.env.set("ENVIRONMENT", "production");
-
-  try {
-    const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
-    const harness = makeHarness(async () => VALID_AUTH_RESULT, {
-      rpcBehavior: async () => {
-        throw new Error(errorMessage);
-      },
-    });
-
-    const body = validPushBody();
-    (body.sessions as Record<string, unknown>[]).push({
-      id: SESSION_ID,
-      startedAt: "2026-01-20T10:00:00.000Z",
-      updatedAt: "2026-01-20T10:30:00.000Z",
-      workoutMode: "OLD_SCHOOL",
-      exercises: [{
-        id: EXERCISE_ID,
-        name: "Bench Press",
-        exerciseId: "bench-press-id",
-        muscleGroup: "Chest",
-        sets: [{
-          id: SET_ID,
-          exerciseId: EXERCISE_ID,
-          setNumber: 1,
-          targetReps: 10,
-          actualReps: 10,
-          weightKg: 80,
-          isPr: true,
-          prType: "1RM",
-          prPhase: "COMBINED",
-        }],
-      }],
-    });
-
-    const response = await harness.handler(requestFromBody(body));
-    const responseBody = await json(response);
-
-    assertEquals(response.status, 500);
-    // In production, the error should be opaque
-    assertEquals(responseBody.error, "Internal server error");
-  } finally {
-    // Restore ENVIRONMENT
-    if (savedEnv !== undefined) {
-      Deno.env.set("ENVIRONMENT", savedEnv);
-    } else {
-      Deno.env.delete("ENVIRONMENT");
+  Deno.env.set("ENVIRONMENT", value);
+  return (async () => {
+    try {
+      return await body();
+    } finally {
+      if (savedEnv !== undefined) {
+        Deno.env.set("ENVIRONMENT", savedEnv);
+      } else {
+        Deno.env.delete("ENVIRONMENT");
+      }
     }
-  }
-});
+  })();
+}
 
-Deno.test("Issue #99: unknown ENVIRONMENT defaults to opaque error", async () => {
-  // Set ENVIRONMENT to an unknown value (not in the allowlist)
-  const savedEnv = Deno.env.get("ENVIRONMENT");
-  Deno.env.set("ENVIRONMENT", "custom-staging");
+const ENV_CASES = [
+  { name: "known verbose (development)", env: "development", expectedError: "Batch 2/3 failed: FK violation on personal_records" },
+  { name: "production", env: "production", expectedError: "Internal server error" },
+  { name: "unknown value (custom-staging)", env: "custom-staging", expectedError: "Internal server error" },
+];
 
-  try {
+for (const tc of ENV_CASES) {
+  Deno.test(`Issue #99: top-level catch [${tc.name}] returns ${tc.expectedError}`, async () => {
     const errorMessage = "Batch 2/3 failed: FK violation on personal_records";
-    const harness = makeHarness(async () => VALID_AUTH_RESULT, {
-      rpcBehavior: async () => {
-        throw new Error(errorMessage);
-      },
+    await withEnvironment(tc.env, async () => {
+      const harness = makeHarness(async () => VALID_AUTH_RESULT, {
+        rpcBehavior: async () => {
+          throw new Error(errorMessage);
+        },
+      });
+
+      const body = validPushBody();
+      (body.sessions as Record<string, unknown>[]).push(makePrSession());
+
+      const response = await harness.handler(requestFromBody(body));
+      const responseBody = await json(response);
+
+      assertEquals(response.status, 500);
+      assertEquals(responseBody.error, tc.expectedError);
     });
-
-    const body = validPushBody();
-    (body.sessions as Record<string, unknown>[]).push({
-      id: SESSION_ID,
-      startedAt: "2026-01-20T10:00:00.000Z",
-      updatedAt: "2026-01-20T10:30:00.000Z",
-      workoutMode: "OLD_SCHOOL",
-      exercises: [{
-        id: EXERCISE_ID,
-        name: "Bench Press",
-        exerciseId: "bench-press-id",
-        muscleGroup: "Chest",
-        sets: [{
-          id: SET_ID,
-          exerciseId: EXERCISE_ID,
-          setNumber: 1,
-          targetReps: 10,
-          actualReps: 10,
-          weightKg: 80,
-          isPr: true,
-          prType: "1RM",
-          prPhase: "COMBINED",
-        }],
-      }],
-    });
-
-    const response = await harness.handler(requestFromBody(body));
-    const responseBody = await json(response);
-
-    assertEquals(response.status, 500);
-    // Unknown ENVIRONMENT should default to opaque
-    assertEquals(responseBody.error, "Internal server error");
-  } finally {
-    // Restore ENVIRONMENT
-    if (savedEnv !== undefined) {
-      Deno.env.set("ENVIRONMENT", savedEnv);
-    } else {
-      Deno.env.delete("ENVIRONMENT");
-    }
-  }
-});
+  });
+}

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -1754,15 +1754,21 @@ async function mobileSyncPushHandler(
 
       // =====================================================================
       // 5. Compute exercise_progress (mobile-provided 1RM, hybrid fallback)
+      // Defense-in-depth: filter sessions through childAllowed like every
+      // other child path (exercises/sets/rep_summaries/rep_telemetry) so
+      // progress rows for LWW-rejected sessions are never inserted.
+      // (Issue #99 RCA layer 3)
       // =====================================================================
+      const acceptedSessions = payload.sessions
+        .filter((s) => childAllowed(acceptedSessionIds, s.id));
       const progressRows = buildExerciseProgressRows(
-        payload.sessions,
+        acceptedSessions,
         userId,
         localProfileId,
       );
 
       if (progressRows.length > 0) {
-        const sessionIds = [...new Set(payload.sessions.map((session) => session.id))];
+        const sessionIds = [...new Set(acceptedSessions.map((session) => session.id))];
         const { data: existingProgress, error: existingProgressErr } = await supabase
           .from('exercise_progress')
           .select('session_id, exercise_id, exercise_name')
@@ -1988,7 +1994,14 @@ async function mobileSyncPushHandler(
 
         const { error: prErr } = await writePersonalRecords(prRowsToWrite);
         if (prErr && isPostgresForeignKeyViolation(prErr)) {
-          const profilePartition = shouldValidatePersonalRecordProfileIds
+          // Issue #99 RCA layer 2: always partition by local_profile_id
+          // validity when the valid set is populated, even for derived PR
+          // rows (sessions[].sets[].isPr). The dedicated-records path
+          // already covers this via buildDedicatedPersonalRecordRows, but
+          // the derived path uses the handler-level localProfileId which
+          // can reference a profile not in validLocalProfileIdsForPush
+          // when allProfiles is empty in non-final batches.
+          const profilePartition = (shouldValidatePersonalRecordProfileIds || validLocalProfileIdsForPush.size > 0)
             ? partitionPersonalRecordRowsByLocalProfileValidity(
                 prRowsToWrite,
                 validLocalProfileIdsForPush,
@@ -2776,8 +2789,17 @@ async function mobileSyncPushHandler(
     dependencies.logOperationalFailure({
       name: safeErrorName(err, 'MobileSyncPushFailure'),
     });
+    // Surface the underlying error in non-production so future occurrences
+    // of this class are actionable (Issue #99 RCA layer 1).
+    const isProduction = Deno.env.get('ENVIRONMENT') === 'production';
+    const errorBody: Record<string, unknown> = {
+      error: isProduction ? 'Internal server error' : (err instanceof Error ? err.message : String(err)),
+    };
+    if (!isProduction && err && typeof err === 'object' && 'code' in err) {
+      errorBody.code = (err as { code: unknown }).code;
+    }
     return new Response(
-      JSON.stringify({ error: 'Internal server error' }),
+      JSON.stringify(errorBody),
       { status: 500, headers: { ...cors, 'Content-Type': 'application/json' } }
     );
   }

--- a/supabase/functions/mobile-sync-push/index.ts
+++ b/supabase/functions/mobile-sync-push/index.ts
@@ -2789,13 +2789,15 @@ async function mobileSyncPushHandler(
     dependencies.logOperationalFailure({
       name: safeErrorName(err, 'MobileSyncPushFailure'),
     });
-    // Surface the underlying error in non-production so future occurrences
-    // of this class are actionable (Issue #99 RCA layer 1).
-    const isProduction = Deno.env.get('ENVIRONMENT') === 'production';
+    // Surface the underlying error only in known non-production environments
+    // so future occurrences of this class are actionable (Issue #99 RCA layer 1).
+    // Kilo review: opt-in to verbose errors via allowlist; unknown values default to opaque.
+    const VERBOSE_ENVIRONMENTS = ['development', 'staging', 'preview', 'local'];
+    const isVerbose = VERBOSE_ENVIRONMENTS.includes(Deno.env.get('ENVIRONMENT') ?? '');
     const errorBody: Record<string, unknown> = {
-      error: isProduction ? 'Internal server error' : (err instanceof Error ? err.message : String(err)),
+      error: isVerbose ? (err instanceof Error ? err.message : String(err)) : 'Internal server error',
     };
-    if (!isProduction && err && typeof err === 'object' && 'code' in err) {
+    if (isVerbose && err && typeof err === 'object' && 'code' in err) {
       errorBody.code = (err as { code: unknown }).code;
     }
     return new Response(


### PR DESCRIPTION
## Summary

Three-layer fix for portal initial sync batch 2/3 failure (Issue #99).

## Changes

### Layer 1: Surface underlying error in non-production 500s
The top-level catch at `mobile-sync-push/index.ts` now returns the actual error message when `ENVIRONMENT !== 'production'`, making future occurrences of this class actionable instead of opaque "Internal server error".

### Layer 2: Extend personal_records FK retry for derived PR rows
When an FK violation occurs and `validLocalProfileIdsForPush` is populated, always partition by `local_profile_id` validity — even for derived PR rows (`sessions[].sets[].isPr`) that previously skipped this check when `shouldValidatePersonalRecordProfileIds` was false.

### Layer 3: Filter progressRows through childAllowed
`buildExerciseProgressRows` now receives only sessions accepted by the LWW gate, matching the contract every other child path (exercises/sets/rep_summaries/rep_telemetry) follows. Prevents `exercise_progress` FK violations on `session_id` when a parent session is rejected.

## RCA Context
- Root cause: top-level catch at line 2775 swallows underlying error; progressRows at line 1758 is the only child path not filtered by childAllowed; personal_records FK retry at line 1989 may exhaust on derived PR rows when allProfiles is empty
- RCA driver: GPT-5.6 Terra xhigh
- Architecture review: Approved

## Regression Tests
Added two tests verifying error surfacing behavior in non-production vs production environments.

Fixes #99