### PR TITLE
fix(sync): preserve microsecond precision in pull cursors

### DIFF
--- a/supabase/functions/mobile-sync-pull/index.test.ts
+++ b/supabase/functions/mobile-sync-pull/index.test.ts
@@ -61,6 +61,10 @@ interface AdminOptions {
   preferenceResult?: { data: unknown; error: unknown };
   preferenceThrow?: unknown;
   rpcResults?: Record<string, { data: unknown; error: unknown }>;
+  rpcImpl?: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => { data: unknown; error: unknown } | undefined;
 }
 
 function createAdminDouble(
@@ -69,6 +73,10 @@ function createAdminDouble(
 ): Record<string, unknown> {
   const rpc = (name: string, args: Record<string, unknown>) => {
     calls.push({ kind: "rpc", name, args });
+    const implResult = options.rpcImpl?.(name, args);
+    if (implResult) {
+      return Promise.resolve(implResult);
+    }
     if (name === "check_rate_limit") {
       return Promise.resolve({
         data: {
@@ -668,6 +676,104 @@ Deno.test("known personal record tombstones use the bounded RPC and remain tombs
   assertEquals(personalRecords.length, 1);
   assertEquals(personalRecords[0].id, personalRecordId);
   assertEquals(personalRecords[0].deletedAt, deletedAt);
+});
+
+// Issue #97 follow-up: 200 PRs sharing one microsecond timestamp must still
+// produce distinct page cursors. JS Date truncates µs → ms, which makes
+// `updated_at > cursor` match the entire cluster and replay page 1.
+function timestampSortKey(value: string): string {
+  const millis = Date.parse(value);
+  const frac = (value.match(/\.(\d+)/)?.[1] ?? "").padEnd(6, "0").slice(0, 6);
+  return `${Number.isFinite(millis) ? millis : 0}:${frac}`;
+}
+
+function applyPersonalRecordCursor(
+  rows: Array<Record<string, unknown>>,
+  args: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  const cursorAt = typeof args.p_cursor_updated_at === "string"
+    ? args.p_cursor_updated_at
+    : null;
+  const cursorId = typeof args.p_cursor_id === "string" ? args.p_cursor_id : null;
+  const limit = typeof args.p_limit === "number" ? args.p_limit : 76;
+  const sorted = [...rows].sort((left, right) => {
+    const timeCmp = timestampSortKey(String(left.updated_at)).localeCompare(
+      timestampSortKey(String(right.updated_at)),
+    );
+    return timeCmp || String(left.id).localeCompare(String(right.id));
+  });
+  const filtered = cursorAt
+    ? sorted.filter((row) => {
+      const rowKey = timestampSortKey(String(row.updated_at));
+      const cursorKey = timestampSortKey(cursorAt);
+      return rowKey > cursorKey ||
+        (rowKey === cursorKey && String(row.id) > String(cursorId ?? ""));
+    })
+    : sorted;
+  return filtered.slice(0, limit);
+}
+
+Deno.test("identical-microsecond personal records produce a distinct nextCursor", async () => {
+  const sharedUpdatedAt = "2026-07-08T14:24:09.648091+00:00";
+  const dataset = Array.from({ length: 200 }, (_, index) => ({
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    user_id: VALID_USER_ID,
+    local_profile_id: VALID_PROFILE_ID,
+    exercise_id: null,
+    exercise_name: `Lift ${index}`,
+    muscle_group: "Chest",
+    record_type: "MAX_WEIGHT",
+    value: 100,
+    weight_kg: 100,
+    reps: 1,
+    workout_phase: "COMBINED",
+    session_id: null,
+    achieved_at: sharedUpdatedAt,
+    updated_at: sharedUpdatedAt,
+    deleted_at: null,
+  }));
+
+  const harness = makeHarness(undefined, {
+    rpcImpl: (name, args) => {
+      if (name !== "get_personal_records_excluding_ids") return undefined;
+      return {
+        data: applyPersonalRecordCursor(dataset, args),
+        error: null,
+      };
+    },
+  });
+
+  const pageSize = 75;
+  const first = await harness.handler(requestFromBody({
+    ...validPullBody(),
+    pageSize,
+  }));
+  const firstBody = await json(first);
+  assertEquals(first.status, 200, JSON.stringify(firstBody));
+  assertEquals(firstBody.hasMore, true);
+  const firstCursor = firstBody.nextCursor;
+  assert(typeof firstCursor === "string" && firstCursor.length > 0);
+  const firstIds = (firstBody.personalRecords as Array<{ id: string }>).map((row) => row.id);
+  assertEquals(firstIds.length, pageSize);
+
+  const second = await harness.handler(requestFromBody({
+    ...validPullBody(),
+    pageSize,
+    cursor: firstCursor,
+  }));
+  const secondBody = await json(second);
+  assertEquals(second.status, 200, JSON.stringify(secondBody));
+  const secondIds = (secondBody.personalRecords as Array<{ id: string }>).map((row) => row.id);
+  assertEquals(secondIds.length, pageSize);
+  assertEquals(
+    firstIds.filter((id) => secondIds.includes(id)),
+    [],
+    "second page must not replay first-page personal records",
+  );
+  assert(
+    secondBody.nextCursor !== firstCursor,
+    "nextCursor must advance when more identical-timestamp PRs remain",
+  );
 });
 
 Deno.test("first-page pull queries exact owner and profile and maps all five canonicals", async () => {

--- a/supabase/functions/mobile-sync-pull/index.ts
+++ b/supabase/functions/mobile-sync-pull/index.ts
@@ -157,7 +157,7 @@ const ENTITY_ORDER: EntityType[] = ['sessions', 'routines', 'cycles', 'badges', 
 
 interface DecodedCursor {
   type: EntityType;
-  updatedAt: number; // epoch ms
+  updatedAt: string; // raw timestamptz / ISO; never Date-normalized
   id: string;
 }
 
@@ -165,9 +165,10 @@ interface DecodedCursor {
  * Encodes pagination state into an opaque cursor string.
  * Format: base64(JSON({type, updatedAt, id}))
  */
-function encodeCursor(type: EntityType, updatedAt: number, id: string): string {
+function encodeCursor(type: EntityType, updatedAt: string, id: string): string {
+  // Keep the raw DB timestamptz string. Date#toISOString() truncates to
+  // milliseconds and makes `updated_at > cursor` match an entire µs cluster.
   const payload = JSON.stringify({ type, updatedAt, id });
-  // Use btoa for base64 encoding (available in Deno)
   return btoa(payload);
 }
 
@@ -183,15 +184,18 @@ function decodeCursor(cursor: string): DecodedCursor | null {
     if (
       typeof parsed.type !== 'string' ||
       !ENTITY_ORDER.includes(parsed.type as EntityType) ||
-      typeof parsed.updatedAt !== 'number' ||
-      !Number.isFinite(parsed.updatedAt) ||
       typeof parsed.id !== 'string'
     ) {
       return null;
     }
-    try {
-      new Date(parsed.updatedAt).toISOString();
-    } catch {
+    // Legacy cursors stored epoch ms. New cursors store the raw timestamptz
+    // string so microsecond precision survives the round-trip.
+    if (typeof parsed.updatedAt === 'number') {
+      if (!Number.isFinite(parsed.updatedAt)) return null;
+      parsed.updatedAt = new Date(parsed.updatedAt).toISOString();
+    } else if (typeof parsed.updatedAt === 'string') {
+      if (!Number.isFinite(Date.parse(parsed.updatedAt))) return null;
+    } else {
       return null;
     }
     // Most paged entity ids are UUIDs. Custom exercise ids are mobile-minted
@@ -619,7 +623,7 @@ async function mobileSyncPullHandler(
         return { cursorUpdatedAt: null, cursorId: null };
       }
       return {
-        cursorUpdatedAt: new Date(cursorData.updatedAt).toISOString(),
+        cursorUpdatedAt: cursorData.updatedAt,
         cursorId: cursorData.id,
       };
     }
@@ -697,10 +701,10 @@ async function mobileSyncPullHandler(
         hasMore = true;
         const lastSession = sessionsRaw[remainingPageSize - 1];
         const updatedAtRaw = lastSession.updated_at ?? lastSession.started_at;
-        const updatedAtMs = updatedAtRaw
-          ? new Date(updatedAtRaw as string).getTime()
-          : dependencies.now();
-        nextCursor = encodeCursor('sessions', updatedAtMs, lastSession.id as string);
+        const updatedAtStr = updatedAtRaw
+          ? String(updatedAtRaw)
+          : new Date(dependencies.now()).toISOString();
+        nextCursor = encodeCursor('sessions', updatedAtStr, lastSession.id as string);
         sessionsRaw.splice(remainingPageSize); // Trim to pageSize
       }
 
@@ -918,8 +922,7 @@ async function mobileSyncPullHandler(
       if (routinesData.length > remainingPageSize) {
         hasMore = true;
         const lastRoutine = routinesData[remainingPageSize - 1];
-        const updatedAtMs = new Date(lastRoutine.updated_at as string).getTime();
-        nextCursor = encodeCursor('routines', updatedAtMs, lastRoutine.id as string);
+        nextCursor = encodeCursor('routines', String(lastRoutine.updated_at), lastRoutine.id as string);
         routinesData.splice(remainingPageSize);
       }
 
@@ -1053,8 +1056,7 @@ async function mobileSyncPullHandler(
       if (cyclesData.length > remainingPageSize) {
         hasMore = true;
         const lastCycle = cyclesData[remainingPageSize - 1];
-        const updatedAtMs = new Date(lastCycle.updated_at as string).getTime();
-        nextCursor = encodeCursor('cycles', updatedAtMs, lastCycle.id as string);
+        nextCursor = encodeCursor('cycles', String(lastCycle.updated_at), lastCycle.id as string);
         cyclesData.splice(remainingPageSize);
       }
 
@@ -1159,8 +1161,7 @@ async function mobileSyncPullHandler(
       if (badgesData.length > remainingPageSize) {
         hasMore = true;
         const lastBadge = badgesData[remainingPageSize - 1];
-        const earnedAtMs = new Date(lastBadge.earned_at as string).getTime();
-        nextCursor = encodeCursor('badges', earnedAtMs, String(lastBadge.id));
+        nextCursor = encodeCursor('badges', String(lastBadge.earned_at), String(lastBadge.id));
         badgesData.splice(remainingPageSize);
       }
 
@@ -1361,8 +1362,7 @@ async function mobileSyncPullHandler(
       if (personalRecordsData.length > remainingPageSize) {
         hasMore = true;
         const lastPR = personalRecordsData[remainingPageSize - 1];
-        const updatedAtMs = new Date(lastPR.updated_at as string).getTime();
-        nextCursor = encodeCursor('personalRecords', updatedAtMs, lastPR.id as string);
+        nextCursor = encodeCursor('personalRecords', String(lastPR.updated_at), lastPR.id as string);
         personalRecordsData.splice(remainingPageSize);
       }
 
@@ -1430,8 +1430,7 @@ async function mobileSyncPullHandler(
       if (customExercisesPage.length > remainingPageSize) {
         hasMore = true;
         const lastCustomExercise = customExercisesPage[remainingPageSize - 1];
-        const updatedAtMs = new Date(lastCustomExercise.updated_at as string).getTime();
-        nextCursor = encodeCursor('customExercises', updatedAtMs, lastCustomExercise.id as string);
+        nextCursor = encodeCursor('customExercises', String(lastCustomExercise.updated_at), lastCustomExercise.id as string);
         customExercisesPage.splice(remainingPageSize);
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #97 / #98. Cloud sync still fails with:

```
Pull detected repeated cursor after 4 pages (cursor=eyJ0eXBlIjoicGVy...). Processed 407 entities.
```

PR #98 added cursor args to `get_personal_records_excluding_ids`, but the edge function still ran timestamps through `Date`, which truncates microseconds. 364 of the reporter's 485 PRs share `2026-07-08 14:24:09.648091+00`. After truncation, Postgres treats the whole cluster as `updated_at > cursor`, so every page restarts at the same row.

## Changes

- Encode the raw DB timestamptz string in the cursor (all entity types).
- Decode accepts legacy epoch-ms cursors and new string cursors; string values are not Date-normalized.
- Regression test: 200 PRs with identical microsecond timestamps must return a distinct `nextCursor` and no overlapping IDs.

## Test plan

- [x] `deno test --no-check --allow-env --allow-net --allow-read mobile-sync-pull/index.test.ts` — 68 passed, 1 ignored
- [ ] Deploy `mobile-sync-pull` and retry reporter sync (pairs with mobile PR that sends `personalRecordIds`)

Relates to #97.
